### PR TITLE
feat(migrate): Comprehensive test suite for Migration Wizard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,11 +24,72 @@
       },
       "devDependencies": {
         "@types/node": "^22.15.0",
+        "@vitest/coverage-v8": "^4.0.18",
         "typescript": "^5.8.3",
         "vitest": "^4.0.18"
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -1336,6 +1397,37 @@
         "ts-morph": "12.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.18.tgz",
+      "integrity": "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.0.18",
+        "ast-v8-to-istanbul": "^0.3.10",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.1",
+        "obug": "^2.1.1",
+        "std-env": "^3.10.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.0.18",
+        "vitest": "4.0.18"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.0.18",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
@@ -1605,6 +1697,39 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.11.tgz",
+      "integrity": "sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
       }
     },
     "node_modules/async-listen": {
@@ -2481,6 +2606,16 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -2513,6 +2648,13 @@
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -2653,6 +2795,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jose": {
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
@@ -2661,6 +2842,13 @@
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-schema-to-ts": {
       "version": "1.6.4",
@@ -2729,6 +2917,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/make-error": {
@@ -3779,6 +3995,19 @@
         "@types/node": {
           "optional": true
         }
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/tar": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.15.0",
+    "@vitest/coverage-v8": "^4.0.18",
     "typescript": "^5.8.3",
     "vitest": "^4.0.18"
   }

--- a/src/migrate/__tests__/capabilities.test.ts
+++ b/src/migrate/__tests__/capabilities.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Platform Capabilities Tests
+ *
+ * Tests for platform capability definitions and migration support checks.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  getPlatformCapabilities,
+  isMigrationSupported,
+  getSupportedMigrations,
+  PLATFORM_CAPABILITIES,
+} from '../capabilities.js';
+
+describe('Platform Capabilities', () => {
+  describe('getPlatformCapabilities', () => {
+    it('should return capabilities for ChatGPT', () => {
+      const caps = getPlatformCapabilities('chatgpt');
+      expect(caps.id).toBe('chatgpt');
+      expect(caps.name).toBe('ChatGPT');
+      expect(caps.instructionLimit).toBe(1500);
+      expect(caps.hasMemory).toBe(true);
+      expect(caps.memoryLimit).toBe(100);
+      expect(caps.hasCustomBots).toBe(true);
+    });
+
+    it('should return capabilities for Claude', () => {
+      const caps = getPlatformCapabilities('claude');
+      expect(caps.id).toBe('claude');
+      expect(caps.name).toBe('Claude');
+      expect(caps.instructionLimit).toBe(8000);
+      expect(caps.hasMemory).toBe(false);
+      expect(caps.hasProjects).toBe(true);
+    });
+
+    it('should return capabilities for Gemini', () => {
+      const caps = getPlatformCapabilities('gemini');
+      expect(caps.id).toBe('gemini');
+      expect(caps.name).toBe('Gemini');
+      expect(caps.instructionLimit).toBe(4000);
+      expect(caps.hasMemory).toBe(true);
+    });
+
+    it('should return capabilities for Copilot', () => {
+      const caps = getPlatformCapabilities('copilot');
+      expect(caps.id).toBe('copilot');
+      expect(caps.name).toBe('Microsoft Copilot');
+      expect(caps.instructionLimit).toBe(2000);
+    });
+  });
+
+  describe('isMigrationSupported', () => {
+    it('should return true for ChatGPT to Claude', () => {
+      expect(isMigrationSupported('chatgpt', 'claude')).toBe(true);
+    });
+
+    it('should return true for Claude to ChatGPT', () => {
+      expect(isMigrationSupported('claude', 'chatgpt')).toBe(true);
+    });
+
+    it('should return false for unsupported paths', () => {
+      expect(isMigrationSupported('gemini', 'claude')).toBe(false);
+      expect(isMigrationSupported('chatgpt', 'gemini')).toBe(false);
+      expect(isMigrationSupported('copilot', 'chatgpt')).toBe(false);
+    });
+
+    it('should return false for same platform migration', () => {
+      expect(isMigrationSupported('chatgpt', 'chatgpt')).toBe(false);
+      expect(isMigrationSupported('claude', 'claude')).toBe(false);
+    });
+  });
+
+  describe('getSupportedMigrations', () => {
+    it('should return all supported migration paths', () => {
+      const paths = getSupportedMigrations();
+      expect(paths).toHaveLength(2);
+      expect(paths).toContainEqual({ source: 'chatgpt', target: 'claude' });
+      expect(paths).toContainEqual({ source: 'claude', target: 'chatgpt' });
+    });
+  });
+
+  describe('PLATFORM_CAPABILITIES', () => {
+    it('should have all platforms defined', () => {
+      expect(PLATFORM_CAPABILITIES).toHaveProperty('chatgpt');
+      expect(PLATFORM_CAPABILITIES).toHaveProperty('claude');
+      expect(PLATFORM_CAPABILITIES).toHaveProperty('gemini');
+      expect(PLATFORM_CAPABILITIES).toHaveProperty('copilot');
+    });
+
+    it('should have valid file size limits', () => {
+      for (const platform of Object.keys(PLATFORM_CAPABILITIES) as Array<keyof typeof PLATFORM_CAPABILITIES>) {
+        const caps = PLATFORM_CAPABILITIES[platform];
+        if (caps.hasFiles) {
+          expect(caps.fileSizeLimit).toBeDefined();
+          expect(caps.fileSizeLimit).toBeGreaterThan(0);
+        }
+      }
+    });
+
+    it('should have valid instruction limits', () => {
+      for (const platform of Object.keys(PLATFORM_CAPABILITIES) as Array<keyof typeof PLATFORM_CAPABILITIES>) {
+        const caps = PLATFORM_CAPABILITIES[platform];
+        expect(caps.instructionLimit).toBeGreaterThan(0);
+      }
+    });
+  });
+});

--- a/src/migrate/__tests__/edge-cases.test.ts
+++ b/src/migrate/__tests__/edge-cases.test.ts
@@ -1,0 +1,887 @@
+/**
+ * Edge Case Tests for Migration Wizard
+ *
+ * Tests boundary conditions and unusual scenarios.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync } from 'node:fs';
+import { rm, mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { MigrationOrchestrator } from '../orchestrator.js';
+import { registerMockPlugins } from '../testing/index.js';
+import { ChatGPTToClaudeTransformer } from '../transformers/chatgpt-to-claude.js';
+import { ClaudeToChatGPTTransformer } from '../transformers/claude-to-chatgpt.js';
+import { registerTransformer } from '../transformers/registry.js';
+import type { MigrationBundle, MemoryEntry, FileEntry } from '../types.js';
+
+describe('Edge Case Tests', () => {
+  let testWorkDir: string;
+
+  beforeEach(async () => {
+    testWorkDir = join(
+      tmpdir(),
+      `savestate-edge-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    await mkdir(testWorkDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    if (existsSync(testWorkDir)) {
+      await rm(testWorkDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('Empty Source Account', () => {
+    it('should handle account with no data to migrate', async () => {
+      const emptyBundle: MigrationBundle = {
+        version: '1.0',
+        id: 'bundle_empty',
+        source: {
+          platform: 'chatgpt',
+          extractedAt: new Date().toISOString(),
+          extractorVersion: '1.0.0',
+        },
+        contents: {},
+        metadata: {
+          totalItems: 0,
+          itemCounts: {
+            instructions: 0,
+            memories: 0,
+            conversations: 0,
+            files: 0,
+            customBots: 0,
+          },
+          warnings: [],
+          errors: [],
+        },
+      };
+
+      registerMockPlugins({
+        extractors: { chatgpt: { customBundle: emptyBundle } },
+      });
+      registerTransformer('chatgpt', 'claude', () => new ChatGPTToClaudeTransformer());
+
+      const orchestrator = new MigrationOrchestrator('chatgpt', 'claude', {
+        workDir: join(testWorkDir, 'migration-empty'),
+      });
+
+      const result = await orchestrator.run();
+
+      expect(result.success).toBe(true);
+      expect(result.loaded.instructions).toBe(false);
+      expect(result.loaded.memories).toBe(0);
+      expect(result.loaded.files).toBe(0);
+    });
+
+    it('should handle account with only empty containers', async () => {
+      const emptyContainersBundle: MigrationBundle = {
+        version: '1.0',
+        id: 'bundle_empty_containers',
+        source: {
+          platform: 'chatgpt',
+          extractedAt: new Date().toISOString(),
+          extractorVersion: '1.0.0',
+        },
+        contents: {
+          memories: { entries: [], count: 0 },
+          files: { files: [], count: 0, totalSize: 0 },
+          customBots: { bots: [], count: 0 },
+          conversations: {
+            path: 'conversations/',
+            count: 0,
+            messageCount: 0,
+            summaries: [],
+          },
+        },
+        metadata: {
+          totalItems: 0,
+          itemCounts: {
+            instructions: 0,
+            memories: 0,
+            conversations: 0,
+            files: 0,
+            customBots: 0,
+          },
+          warnings: [],
+          errors: [],
+        },
+      };
+
+      registerMockPlugins({
+        extractors: { chatgpt: { customBundle: emptyContainersBundle } },
+      });
+
+      const orchestrator = new MigrationOrchestrator('chatgpt', 'claude', {
+        workDir: join(testWorkDir, 'migration-empty-containers'),
+      });
+
+      const result = await orchestrator.run();
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('Very Large Accounts', () => {
+    it('should handle 1000+ conversations', async () => {
+      const conversations = Array.from({ length: 1000 }, (_, i) => ({
+        id: `conv_${i}`,
+        title: `Conversation ${i}`,
+        messageCount: Math.floor(Math.random() * 50) + 5,
+        createdAt: new Date(Date.now() - i * 86400000).toISOString(),
+        updatedAt: new Date(Date.now() - i * 43200000).toISOString(),
+        keyPoints: i % 10 === 0 ? [`Key point from conversation ${i}`] : undefined,
+      }));
+
+      const largeBundle: MigrationBundle = {
+        version: '1.0',
+        id: 'bundle_large_conversations',
+        source: {
+          platform: 'chatgpt',
+          extractedAt: new Date().toISOString(),
+          extractorVersion: '1.0.0',
+        },
+        contents: {
+          conversations: {
+            path: 'conversations/',
+            count: 1000,
+            messageCount: conversations.reduce((sum, c) => sum + c.messageCount, 0),
+            summaries: conversations,
+          },
+        },
+        metadata: {
+          totalItems: 1000,
+          itemCounts: {
+            instructions: 0,
+            memories: 0,
+            conversations: 1000,
+            files: 0,
+            customBots: 0,
+          },
+          warnings: [],
+          errors: [],
+        },
+      };
+
+      registerMockPlugins({
+        extractors: { chatgpt: { customBundle: largeBundle } },
+      });
+      registerTransformer('chatgpt', 'claude', () => new ChatGPTToClaudeTransformer());
+
+      const orchestrator = new MigrationOrchestrator('chatgpt', 'claude', {
+        workDir: join(testWorkDir, 'migration-large-convs'),
+      });
+
+      const result = await orchestrator.run();
+
+      expect(result.success).toBe(true);
+      const bundle = orchestrator.getBundle();
+      expect(bundle?.contents.conversations?.count).toBe(1000);
+    });
+
+    it('should handle 500+ memories', async () => {
+      const memories: MemoryEntry[] = Array.from({ length: 500 }, (_, i) => ({
+        id: `mem_${i}`,
+        content: `Memory entry ${i}: User learned about ${['TypeScript', 'React', 'Node.js', 'Python', 'Go'][i % 5]}`,
+        createdAt: new Date(Date.now() - i * 3600000).toISOString(),
+        category: ['preferences', 'facts', 'context', 'decisions'][i % 4],
+      }));
+
+      const largeMemoriesBundle: MigrationBundle = {
+        version: '1.0',
+        id: 'bundle_large_memories',
+        source: {
+          platform: 'chatgpt',
+          extractedAt: new Date().toISOString(),
+          extractorVersion: '1.0.0',
+        },
+        contents: {
+          memories: { entries: memories, count: 500 },
+        },
+        metadata: {
+          totalItems: 500,
+          itemCounts: {
+            instructions: 0,
+            memories: 500,
+            conversations: 0,
+            files: 0,
+            customBots: 0,
+          },
+          warnings: [],
+          errors: [],
+        },
+      };
+
+      registerMockPlugins({
+        extractors: { chatgpt: { customBundle: largeMemoriesBundle } },
+      });
+      registerTransformer('chatgpt', 'claude', () => new ChatGPTToClaudeTransformer());
+
+      const orchestrator = new MigrationOrchestrator('chatgpt', 'claude', {
+        workDir: join(testWorkDir, 'migration-large-memories'),
+      });
+
+      const result = await orchestrator.run();
+
+      expect(result.success).toBe(true);
+      // Should have a warning about large number of memories
+      const bundle = orchestrator.getBundle();
+      expect(bundle?.metadata.warnings.some((w) => w.includes('memories') || w.includes('500'))).toBe(true);
+    });
+  });
+
+  describe('Files Exceeding Size Limits', () => {
+    it('should skip files exceeding Claude size limit', async () => {
+      const filesBundle: MigrationBundle = {
+        version: '1.0',
+        id: 'bundle_large_files',
+        source: {
+          platform: 'chatgpt',
+          extractedAt: new Date().toISOString(),
+          extractorVersion: '1.0.0',
+        },
+        contents: {
+          files: {
+            files: [
+              {
+                id: 'file_small',
+                filename: 'small.txt',
+                mimeType: 'text/plain',
+                size: 1024, // 1KB
+                path: 'files/small.txt',
+              },
+              {
+                id: 'file_huge',
+                filename: 'huge-database.sql',
+                mimeType: 'application/sql',
+                size: 150 * 1024 * 1024, // 150MB - exceeds limit
+                path: 'files/huge-database.sql',
+              },
+              {
+                id: 'file_medium',
+                filename: 'medium.pdf',
+                mimeType: 'application/pdf',
+                size: 5 * 1024 * 1024, // 5MB - within limit
+                path: 'files/medium.pdf',
+              },
+            ],
+            count: 3,
+            totalSize: 155 * 1024 * 1024,
+          },
+        },
+        metadata: {
+          totalItems: 3,
+          itemCounts: {
+            instructions: 0,
+            memories: 0,
+            conversations: 0,
+            files: 3,
+            customBots: 0,
+          },
+          warnings: [],
+          errors: [],
+        },
+      };
+
+      registerMockPlugins({
+        extractors: { chatgpt: { customBundle: filesBundle } },
+      });
+      registerTransformer('chatgpt', 'claude', () => new ChatGPTToClaudeTransformer());
+
+      const orchestrator = new MigrationOrchestrator('chatgpt', 'claude', {
+        workDir: join(testWorkDir, 'migration-large-files'),
+      });
+
+      const result = await orchestrator.run();
+
+      expect(result.success).toBe(true);
+      // 2 files should be loaded (small + medium), 1 skipped
+      expect(result.loaded.files).toBe(2);
+
+      const bundle = orchestrator.getBundle();
+      expect(bundle?.contents.files?.count).toBe(2);
+      expect(bundle?.metadata.warnings.some((w) => w.includes('huge-database.sql'))).toBe(true);
+    });
+  });
+
+  describe('Unicode and Emoji in Content', () => {
+    it('should preserve Unicode characters in instructions', async () => {
+      const unicodeBundle: MigrationBundle = {
+        version: '1.0',
+        id: 'bundle_unicode',
+        source: {
+          platform: 'chatgpt',
+          extractedAt: new Date().toISOString(),
+          extractorVersion: '1.0.0',
+        },
+        contents: {
+          instructions: {
+            content: `## 关于我 (About Me) 🎯
+
+I speak multiple languages:
+- 日本語 (Japanese)
+- 中文 (Chinese)
+- العربية (Arabic)
+- עברית (Hebrew)
+- हिंदी (Hindi)
+
+Emoji support: 🚀 💻 🎨 🔧 ⚡️ 🎸
+
+Mathematical symbols: ∑ ∫ ∂ ∞ √ π
+
+Special characters: © ® ™ € £ ¥`,
+            length: 300,
+          },
+          memories: {
+            entries: [
+              {
+                id: 'mem_unicode',
+                content: 'ユーザーは日本に住んでいます 🇯🇵',
+                createdAt: new Date().toISOString(),
+              },
+              {
+                id: 'mem_emoji',
+                content: 'Favorite foods: 🍕🍣🌮🍜',
+                createdAt: new Date().toISOString(),
+              },
+              {
+                id: 'mem_math',
+                content: 'User is studying calculus: ∫₀^∞ e^(-x²)dx = √π/2',
+                createdAt: new Date().toISOString(),
+              },
+            ],
+            count: 3,
+          },
+        },
+        metadata: {
+          totalItems: 4,
+          itemCounts: {
+            instructions: 1,
+            memories: 3,
+            conversations: 0,
+            files: 0,
+            customBots: 0,
+          },
+          warnings: [],
+          errors: [],
+        },
+      };
+
+      registerMockPlugins({
+        extractors: { chatgpt: { customBundle: unicodeBundle } },
+      });
+      registerTransformer('chatgpt', 'claude', () => new ChatGPTToClaudeTransformer());
+
+      const orchestrator = new MigrationOrchestrator('chatgpt', 'claude', {
+        workDir: join(testWorkDir, 'migration-unicode'),
+      });
+
+      const result = await orchestrator.run();
+
+      expect(result.success).toBe(true);
+
+      const bundle = orchestrator.getBundle();
+      expect(bundle?.contents.instructions?.content).toContain('日本語');
+      expect(bundle?.contents.instructions?.content).toContain('🚀');
+      expect(bundle?.contents.instructions?.content).toContain('∑');
+    });
+
+    it('should handle filenames with Unicode characters', async () => {
+      const unicodeFilesBundle: MigrationBundle = {
+        version: '1.0',
+        id: 'bundle_unicode_files',
+        source: {
+          platform: 'chatgpt',
+          extractedAt: new Date().toISOString(),
+          extractorVersion: '1.0.0',
+        },
+        contents: {
+          files: {
+            files: [
+              {
+                id: 'file_jp',
+                filename: 'ドキュメント.pdf',
+                mimeType: 'application/pdf',
+                size: 1024,
+                path: 'files/ドキュメント.pdf',
+              },
+              {
+                id: 'file_emoji',
+                filename: '🚀 launch-plan.md',
+                mimeType: 'text/markdown',
+                size: 512,
+                path: 'files/🚀 launch-plan.md',
+              },
+            ],
+            count: 2,
+            totalSize: 1536,
+          },
+        },
+        metadata: {
+          totalItems: 2,
+          itemCounts: {
+            instructions: 0,
+            memories: 0,
+            conversations: 0,
+            files: 2,
+            customBots: 0,
+          },
+          warnings: [],
+          errors: [],
+        },
+      };
+
+      registerMockPlugins({
+        extractors: { chatgpt: { customBundle: unicodeFilesBundle } },
+      });
+
+      const orchestrator = new MigrationOrchestrator('chatgpt', 'claude', {
+        workDir: join(testWorkDir, 'migration-unicode-files'),
+      });
+
+      const result = await orchestrator.run();
+
+      expect(result.success).toBe(true);
+      expect(result.loaded.files).toBe(2);
+    });
+  });
+
+  describe('Long Custom Instructions Requiring Truncation', () => {
+    it('should truncate instructions exceeding target limit', async () => {
+      // Claude has ~8000 char limit, create instructions that exceed it
+      const veryLongContent = Array.from({ length: 200 }, (_, i) =>
+        `Section ${i}: This is a detailed instruction about how to handle situation ${i}. `
+      ).join('\n\n');
+
+      const longInstructionsBundle: MigrationBundle = {
+        version: '1.0',
+        id: 'bundle_long_instructions',
+        source: {
+          platform: 'chatgpt',
+          extractedAt: new Date().toISOString(),
+          extractorVersion: '1.0.0',
+        },
+        contents: {
+          instructions: {
+            content: veryLongContent,
+            length: veryLongContent.length,
+          },
+        },
+        metadata: {
+          totalItems: 1,
+          itemCounts: {
+            instructions: 1,
+            memories: 0,
+            conversations: 0,
+            files: 0,
+            customBots: 0,
+          },
+          warnings: [],
+          errors: [],
+        },
+      };
+
+      registerMockPlugins({
+        extractors: { chatgpt: { customBundle: longInstructionsBundle } },
+      });
+      registerTransformer('chatgpt', 'claude', () => new ChatGPTToClaudeTransformer());
+
+      const orchestrator = new MigrationOrchestrator('chatgpt', 'claude', {
+        workDir: join(testWorkDir, 'migration-long-instructions'),
+      });
+
+      const result = await orchestrator.run();
+
+      expect(result.success).toBe(true);
+
+      const bundle = orchestrator.getBundle();
+      // Instructions should be truncated to fit within limit
+      expect(bundle?.contents.instructions?.length).toBeLessThanOrEqual(20000); // Claude's limit
+      // Should have a warning about truncation
+      expect(bundle?.metadata.warnings.some((w) =>
+        w.toLowerCase().includes('truncat') || w.toLowerCase().includes('summar')
+      )).toBe(true);
+    });
+
+    it('should use summarize strategy when configured', async () => {
+      const longContent = 'x'.repeat(25000); // Exceeds limit
+
+      const bundle: MigrationBundle = {
+        version: '1.0',
+        id: 'bundle_summarize',
+        source: {
+          platform: 'chatgpt',
+          extractedAt: new Date().toISOString(),
+          extractorVersion: '1.0.0',
+        },
+        contents: {
+          instructions: { content: longContent, length: longContent.length },
+        },
+        metadata: {
+          totalItems: 1,
+          itemCounts: {
+            instructions: 1,
+            memories: 0,
+            conversations: 0,
+            files: 0,
+            customBots: 0,
+          },
+          warnings: [],
+          errors: [],
+        },
+      };
+
+      registerMockPlugins({
+        extractors: { chatgpt: { customBundle: bundle } },
+      });
+      registerTransformer('chatgpt', 'claude', () => new ChatGPTToClaudeTransformer());
+
+      const orchestrator = new MigrationOrchestrator('chatgpt', 'claude', {
+        workDir: join(testWorkDir, 'migration-summarize'),
+      });
+
+      const result = await orchestrator.run();
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('Network Interruption Simulation', () => {
+    it('should handle network failure during extraction', async () => {
+      registerMockPlugins({
+        extractors: {
+          chatgpt: {
+            shouldFail: true,
+            failureMessage: 'Network error: Connection timed out',
+          },
+        },
+      });
+
+      const orchestrator = new MigrationOrchestrator('chatgpt', 'claude', {
+        workDir: join(testWorkDir, 'migration-network-extract'),
+      });
+
+      await expect(orchestrator.run()).rejects.toThrow('Connection timed out');
+
+      const state = orchestrator.getState();
+      expect(state.phase).toBe('failed');
+      expect(state.error).toContain('Connection timed out');
+    });
+
+    it('should handle network failure during load phase', async () => {
+      registerMockPlugins({
+        loaders: {
+          claude: {
+            shouldFail: true,
+            failureMessage: 'API Error: 503 Service Unavailable',
+          },
+        },
+      });
+
+      const orchestrator = new MigrationOrchestrator('chatgpt', 'claude', {
+        workDir: join(testWorkDir, 'migration-network-load'),
+      });
+
+      await expect(orchestrator.run()).rejects.toThrow('503 Service Unavailable');
+
+      const state = orchestrator.getState();
+      expect(state.phase).toBe('failed');
+    });
+
+    it('should handle partial load failure', async () => {
+      registerMockPlugins({
+        loaders: {
+          claude: {
+            partialFailure: {
+              memories: true,
+              files: true,
+            },
+          },
+        },
+      });
+
+      const orchestrator = new MigrationOrchestrator('chatgpt', 'claude', {
+        workDir: join(testWorkDir, 'migration-partial-failure'),
+      });
+
+      const result = await orchestrator.run();
+
+      // Should still succeed but with warnings
+      expect(result.success).toBe(true);
+      expect(result.warnings.length).toBeGreaterThan(0);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Auth Token Expiration Simulation', () => {
+    it('should handle auth failure during extraction', async () => {
+      registerMockPlugins({
+        extractors: {
+          chatgpt: {
+            canExtractResult: false,
+          },
+        },
+      });
+
+      const orchestrator = new MigrationOrchestrator('chatgpt', 'claude', {
+        workDir: join(testWorkDir, 'migration-auth-extract'),
+      });
+
+      await expect(orchestrator.run()).rejects.toThrow(/Cannot extract/);
+    });
+
+    it('should handle auth failure during load', async () => {
+      registerMockPlugins({
+        loaders: {
+          claude: {
+            canLoadResult: false,
+          },
+        },
+      });
+
+      const orchestrator = new MigrationOrchestrator('chatgpt', 'claude', {
+        workDir: join(testWorkDir, 'migration-auth-load'),
+      });
+
+      await expect(orchestrator.run()).rejects.toThrow(/Cannot load/);
+    });
+
+    it('should handle mid-migration auth expiration', async () => {
+      registerMockPlugins({
+        loaders: {
+          claude: {
+            shouldFail: true,
+            failureMessage: 'Authentication failed: Token expired',
+          },
+        },
+      });
+
+      const orchestrator = new MigrationOrchestrator('chatgpt', 'claude', {
+        workDir: join(testWorkDir, 'migration-token-expired'),
+      });
+
+      await expect(orchestrator.run()).rejects.toThrow('Token expired');
+    });
+  });
+
+  describe('Special Characters in Identifiers', () => {
+    it('should handle conversation IDs with special characters', async () => {
+      const specialIdBundle: MigrationBundle = {
+        version: '1.0',
+        id: 'bundle_special_ids',
+        source: {
+          platform: 'chatgpt',
+          extractedAt: new Date().toISOString(),
+          extractorVersion: '1.0.0',
+        },
+        contents: {
+          conversations: {
+            path: 'conversations/',
+            count: 3,
+            messageCount: 30,
+            summaries: [
+              {
+                id: 'conv-123-456-789',
+                title: 'Normal ID',
+                messageCount: 10,
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+              },
+              {
+                id: 'conv/with/slashes',
+                title: 'Slashed ID',
+                messageCount: 10,
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+              },
+              {
+                id: 'conv with spaces & special<>chars',
+                title: 'Special Chars ID',
+                messageCount: 10,
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+              },
+            ],
+          },
+        },
+        metadata: {
+          totalItems: 3,
+          itemCounts: {
+            instructions: 0,
+            memories: 0,
+            conversations: 3,
+            files: 0,
+            customBots: 0,
+          },
+          warnings: [],
+          errors: [],
+        },
+      };
+
+      registerMockPlugins({
+        extractors: { chatgpt: { customBundle: specialIdBundle } },
+      });
+
+      const orchestrator = new MigrationOrchestrator('chatgpt', 'claude', {
+        workDir: join(testWorkDir, 'migration-special-ids'),
+      });
+
+      const result = await orchestrator.run();
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('Malformed Data Handling', () => {
+    it('should handle instructions with null content', async () => {
+      const malformedBundle: MigrationBundle = {
+        version: '1.0',
+        id: 'bundle_malformed',
+        source: {
+          platform: 'chatgpt',
+          extractedAt: new Date().toISOString(),
+          extractorVersion: '1.0.0',
+        },
+        contents: {
+          instructions: {
+            content: '', // Empty content
+            length: 0,
+          },
+        },
+        metadata: {
+          totalItems: 0,
+          itemCounts: {
+            instructions: 0,
+            memories: 0,
+            conversations: 0,
+            files: 0,
+            customBots: 0,
+          },
+          warnings: [],
+          errors: [],
+        },
+      };
+
+      registerMockPlugins({
+        extractors: { chatgpt: { customBundle: malformedBundle } },
+      });
+
+      const orchestrator = new MigrationOrchestrator('chatgpt', 'claude', {
+        workDir: join(testWorkDir, 'migration-malformed'),
+      });
+
+      const result = await orchestrator.run();
+      expect(result.success).toBe(true);
+    });
+
+    it('should handle memories with missing required fields', async () => {
+      const incompleteMemoriesBundle: MigrationBundle = {
+        version: '1.0',
+        id: 'bundle_incomplete_memories',
+        source: {
+          platform: 'chatgpt',
+          extractedAt: new Date().toISOString(),
+          extractorVersion: '1.0.0',
+        },
+        contents: {
+          memories: {
+            entries: [
+              {
+                id: 'mem_complete',
+                content: 'Complete memory entry',
+                createdAt: new Date().toISOString(),
+              },
+              {
+                id: 'mem_no_content',
+                content: '', // Empty content
+                createdAt: new Date().toISOString(),
+              },
+            ],
+            count: 2,
+          },
+        },
+        metadata: {
+          totalItems: 2,
+          itemCounts: {
+            instructions: 0,
+            memories: 2,
+            conversations: 0,
+            files: 0,
+            customBots: 0,
+          },
+          warnings: [],
+          errors: [],
+        },
+      };
+
+      registerMockPlugins({
+        extractors: { chatgpt: { customBundle: incompleteMemoriesBundle } },
+      });
+
+      const orchestrator = new MigrationOrchestrator('chatgpt', 'claude', {
+        workDir: join(testWorkDir, 'migration-incomplete-memories'),
+      });
+
+      const result = await orchestrator.run();
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('Timestamp Edge Cases', () => {
+    it('should handle various date formats', async () => {
+      const dateBundle: MigrationBundle = {
+        version: '1.0',
+        id: 'bundle_dates',
+        source: {
+          platform: 'chatgpt',
+          extractedAt: new Date().toISOString(),
+          extractorVersion: '1.0.0',
+        },
+        contents: {
+          memories: {
+            entries: [
+              {
+                id: 'mem_iso',
+                content: 'ISO date memory',
+                createdAt: '2024-01-15T10:30:00.000Z',
+              },
+              {
+                id: 'mem_old',
+                content: 'Very old memory',
+                createdAt: '2020-01-01T00:00:00.000Z',
+              },
+              {
+                id: 'mem_future',
+                content: 'Future dated memory', // Edge case
+                createdAt: '2030-12-31T23:59:59.999Z',
+              },
+            ],
+            count: 3,
+          },
+        },
+        metadata: {
+          totalItems: 3,
+          itemCounts: {
+            instructions: 0,
+            memories: 3,
+            conversations: 0,
+            files: 0,
+            customBots: 0,
+          },
+          warnings: [],
+          errors: [],
+        },
+      };
+
+      registerMockPlugins({
+        extractors: { chatgpt: { customBundle: dateBundle } },
+      });
+
+      const orchestrator = new MigrationOrchestrator('chatgpt', 'claude', {
+        workDir: join(testWorkDir, 'migration-dates'),
+      });
+
+      const result = await orchestrator.run();
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/src/migrate/__tests__/error-recovery.test.ts
+++ b/src/migrate/__tests__/error-recovery.test.ts
@@ -1,0 +1,585 @@
+/**
+ * Error Recovery Tests for Migration Wizard
+ *
+ * Tests checkpoint/resume capability from various failure points.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync } from 'node:fs';
+import { rm, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { MigrationOrchestrator, type MigrationEvent } from '../orchestrator.js';
+import { registerMockPlugins } from '../testing/index.js';
+import { ChatGPTToClaudeTransformer } from '../transformers/chatgpt-to-claude.js';
+import { registerTransformer } from '../transformers/registry.js';
+import type { MigrationBundle, MigrationState } from '../types.js';
+
+describe('Error Recovery Tests', () => {
+  let testWorkDir: string;
+
+  beforeEach(async () => {
+    testWorkDir = join(
+      tmpdir(),
+      `savestate-recovery-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    await mkdir(testWorkDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    if (existsSync(testWorkDir)) {
+      await rm(testWorkDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('Resume from Extract Phase Failure', () => {
+    it('should resume after extraction failure and complete migration', async () => {
+      const workDir = join(testWorkDir, 'migration-resume-extract');
+
+      // First attempt: fail during extraction
+      registerMockPlugins({
+        extractors: {
+          chatgpt: {
+            shouldFail: true,
+            failureMessage: 'Network timeout during extraction',
+          },
+        },
+      });
+
+      const orchestrator1 = new MigrationOrchestrator('chatgpt', 'claude', { workDir });
+      const migrationId = orchestrator1.getState().id;
+
+      await expect(orchestrator1.run()).rejects.toThrow('Network timeout');
+
+      let state = orchestrator1.getState();
+      expect(state.phase).toBe('failed');
+      expect(state.checkpoints.length).toBe(0); // No checkpoint before extraction completes
+
+      // Second attempt: fix the issue and retry
+      registerMockPlugins({
+        extractors: {
+          chatgpt: { shouldFail: false },
+        },
+      });
+
+      const orchestrator2 = await MigrationOrchestrator.resume(migrationId, workDir);
+      const result = await orchestrator2.continue();
+
+      expect(result.success).toBe(true);
+      expect(orchestrator2.getState().phase).toBe('complete');
+    });
+
+    it('should preserve migration ID across resume attempts', async () => {
+      const workDir = join(testWorkDir, 'migration-preserve-id');
+
+      registerMockPlugins({
+        extractors: {
+          chatgpt: { shouldFail: true, failureMessage: 'First attempt failed' },
+        },
+      });
+
+      const orchestrator1 = new MigrationOrchestrator('chatgpt', 'claude', { workDir });
+      const originalId = orchestrator1.getState().id;
+
+      try {
+        await orchestrator1.run();
+      } catch {
+        // Expected failure
+      }
+
+      // Resume should have the same ID
+      registerMockPlugins();
+      const orchestrator2 = await MigrationOrchestrator.resume(originalId, workDir);
+      expect(orchestrator2.getState().id).toBe(originalId);
+    });
+  });
+
+  describe('Resume from Transform Phase Failure', () => {
+    it('should resume from transform checkpoint after failure', async () => {
+      const workDir = join(testWorkDir, 'migration-resume-transform');
+
+      // First attempt: succeed extraction, fail during transformation
+      registerMockPlugins({
+        transformers: {
+          'chatgpt->claude': {
+            shouldFail: true,
+            failureMessage: 'Transform validation failed',
+          },
+        },
+      });
+      registerTransformer('chatgpt', 'claude', () => new ChatGPTToClaudeTransformer());
+
+      const orchestrator1 = new MigrationOrchestrator('chatgpt', 'claude', { workDir });
+      const migrationId = orchestrator1.getState().id;
+
+      // Just extract first
+      await orchestrator1.extract();
+      expect(orchestrator1.getState().checkpoints.length).toBe(1);
+
+      // Now try the full run with failing transformer
+      const { transformers } = registerMockPlugins({
+        transformers: {
+          'chatgpt->claude': {
+            shouldFail: true,
+            failureMessage: 'Transform failed',
+          },
+        },
+      });
+
+      const orchestrator2 = await MigrationOrchestrator.resume(migrationId, workDir);
+
+      await expect(orchestrator2.continue()).rejects.toThrow('Transform failed');
+
+      let state = orchestrator2.getState();
+      expect(state.phase).toBe('failed');
+
+      // Third attempt: fix transformer and resume
+      registerMockPlugins();
+
+      const orchestrator3 = await MigrationOrchestrator.resume(migrationId, workDir);
+      const result = await orchestrator3.continue();
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should not re-extract when resuming from transform checkpoint', async () => {
+      const workDir = join(testWorkDir, 'migration-skip-extract');
+      let extractCount = 0;
+
+      // Track extraction calls
+      const mockBundle: MigrationBundle = {
+        version: '1.0',
+        id: 'tracked_bundle',
+        source: {
+          platform: 'chatgpt',
+          extractedAt: new Date().toISOString(),
+          extractorVersion: '1.0.0',
+        },
+        contents: {
+          instructions: { content: 'Test instructions', length: 20 },
+        },
+        metadata: {
+          totalItems: 1,
+          itemCounts: {
+            instructions: 1,
+            memories: 0,
+            conversations: 0,
+            files: 0,
+            customBots: 0,
+          },
+          warnings: [],
+          errors: [],
+        },
+      };
+
+      registerMockPlugins({
+        extractors: { chatgpt: { customBundle: mockBundle } },
+      });
+
+      // First: complete extraction
+      const orchestrator1 = new MigrationOrchestrator('chatgpt', 'claude', { workDir });
+      const migrationId = orchestrator1.getState().id;
+      await orchestrator1.extract();
+
+      // Verify checkpoint exists
+      expect(orchestrator1.getState().checkpoints.length).toBe(1);
+      expect(orchestrator1.getState().checkpoints[0].phase).toBe('extracting');
+
+      // Resume - extraction should be skipped
+      const orchestrator2 = await MigrationOrchestrator.resume(migrationId, workDir);
+
+      // The bundle should already be loaded
+      expect(orchestrator2.getBundle()).not.toBeNull();
+    });
+  });
+
+  describe('Resume from Load Phase Failure', () => {
+    it('should resume from load checkpoint after failure', async () => {
+      const workDir = join(testWorkDir, 'migration-resume-load');
+
+      // First attempt: succeed extraction and transform, fail during load
+      registerMockPlugins({
+        loaders: {
+          claude: {
+            shouldFail: true,
+            failureMessage: 'API rate limit exceeded',
+          },
+        },
+      });
+
+      const orchestrator1 = new MigrationOrchestrator('chatgpt', 'claude', { workDir });
+      const migrationId = orchestrator1.getState().id;
+
+      await expect(orchestrator1.run()).rejects.toThrow('rate limit');
+
+      let state = orchestrator1.getState();
+      expect(state.phase).toBe('failed');
+      // Should have extract and transform checkpoints
+      expect(state.checkpoints.length).toBe(2);
+
+      // Second attempt: fix loader and resume
+      registerMockPlugins();
+
+      const orchestrator2 = await MigrationOrchestrator.resume(migrationId, workDir);
+      const result = await orchestrator2.continue();
+
+      expect(result.success).toBe(true);
+      expect(orchestrator2.getState().phase).toBe('complete');
+    });
+
+    it('should not re-transform when resuming from load checkpoint', async () => {
+      const workDir = join(testWorkDir, 'migration-skip-transform');
+
+      // Run until load phase, then fail
+      registerMockPlugins({
+        loaders: {
+          claude: {
+            shouldFail: true,
+            failureMessage: 'Load failed',
+          },
+        },
+      });
+
+      const orchestrator1 = new MigrationOrchestrator('chatgpt', 'claude', { workDir });
+      const migrationId = orchestrator1.getState().id;
+
+      try {
+        await orchestrator1.run();
+      } catch {
+        // Expected
+      }
+
+      const checkpoints = orchestrator1.getState().checkpoints;
+      expect(checkpoints.some((c) => c.phase === 'transforming')).toBe(true);
+
+      // Resume - transform should be skipped
+      registerMockPlugins();
+
+      const orchestrator2 = await MigrationOrchestrator.resume(migrationId, workDir);
+      const bundle = orchestrator2.getBundle();
+
+      // Bundle should already have target info from previous transform
+      expect(bundle?.target?.platform).toBe('claude');
+
+      const result = await orchestrator2.continue();
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('Checkpoint Integrity', () => {
+    it('should detect corrupted checkpoint files', async () => {
+      const workDir = join(testWorkDir, 'migration-corrupted');
+
+      // Create a successful extraction checkpoint
+      registerMockPlugins();
+
+      const orchestrator1 = new MigrationOrchestrator('chatgpt', 'claude', { workDir });
+      const migrationId = orchestrator1.getState().id;
+      await orchestrator1.extract();
+
+      const checkpoints = orchestrator1.getState().checkpoints;
+      expect(checkpoints.length).toBe(1);
+
+      // Corrupt the checkpoint file
+      const checkpointPath = checkpoints[0].dataPath;
+      await writeFile(checkpointPath, 'corrupted data that is not valid JSON');
+
+      // Resume should detect corruption
+      const orchestrator2 = await MigrationOrchestrator.resume(migrationId, workDir);
+
+      // Attempting to continue from corrupted checkpoint should fail
+      await expect(orchestrator2.continue()).rejects.toThrow();
+    });
+
+    it('should verify checksum before loading checkpoint', async () => {
+      const workDir = join(testWorkDir, 'migration-checksum');
+
+      registerMockPlugins();
+
+      const orchestrator1 = new MigrationOrchestrator('chatgpt', 'claude', { workDir });
+      const migrationId = orchestrator1.getState().id;
+      await orchestrator1.extract();
+
+      const checkpoints = orchestrator1.getState().checkpoints;
+      const originalChecksum = checkpoints[0].checksum;
+
+      // Modify checkpoint content slightly
+      const checkpointPath = checkpoints[0].dataPath;
+      const content = await readFile(checkpointPath, 'utf-8');
+      const modified = content.replace('"version"', '"VERSION"');
+      await writeFile(checkpointPath, modified);
+
+      // Resume should detect checksum mismatch
+      const orchestrator2 = await MigrationOrchestrator.resume(migrationId, workDir);
+      await expect(orchestrator2.continue()).rejects.toThrow(/checksum|corrupted/i);
+    });
+  });
+
+  describe('State Persistence', () => {
+    it('should persist error state to disk', async () => {
+      const workDir = join(testWorkDir, 'migration-persist-error');
+
+      registerMockPlugins({
+        extractors: {
+          chatgpt: {
+            shouldFail: true,
+            failureMessage: 'Persistent error message',
+          },
+        },
+      });
+
+      const orchestrator = new MigrationOrchestrator('chatgpt', 'claude', { workDir });
+
+      try {
+        await orchestrator.run();
+      } catch {
+        // Expected
+      }
+
+      // Check state file on disk
+      const statePath = join(workDir, 'state.json');
+      expect(existsSync(statePath)).toBe(true);
+
+      const savedState = JSON.parse(await readFile(statePath, 'utf-8')) as MigrationState;
+      expect(savedState.phase).toBe('failed');
+      expect(savedState.error).toContain('Persistent error message');
+    });
+
+    it('should restore state correctly after process restart simulation', async () => {
+      const workDir = join(testWorkDir, 'migration-restart');
+
+      registerMockPlugins();
+
+      // Start migration and complete extraction
+      const orchestrator1 = new MigrationOrchestrator('chatgpt', 'claude', { workDir });
+      const migrationId = orchestrator1.getState().id;
+      await orchestrator1.extract();
+
+      const originalState = orchestrator1.getState();
+
+      // Simulate process restart by loading from disk
+      const orchestrator2 = await MigrationOrchestrator.resume(migrationId, workDir);
+      const restoredState = orchestrator2.getState();
+
+      // Key state should be preserved
+      expect(restoredState.id).toBe(originalState.id);
+      expect(restoredState.source).toBe(originalState.source);
+      expect(restoredState.target).toBe(originalState.target);
+      expect(restoredState.checkpoints.length).toBe(originalState.checkpoints.length);
+    });
+  });
+
+  describe('Multiple Failure Recovery', () => {
+    it('should handle multiple consecutive failures', async () => {
+      const workDir = join(testWorkDir, 'migration-multi-fail');
+
+      // Failure 1: Extraction
+      registerMockPlugins({
+        extractors: { chatgpt: { shouldFail: true, failureMessage: 'Failure 1' } },
+      });
+
+      const orchestrator1 = new MigrationOrchestrator('chatgpt', 'claude', { workDir });
+      const migrationId = orchestrator1.getState().id;
+
+      try {
+        await orchestrator1.run();
+      } catch {
+        // Expected
+      }
+
+      // Failure 2: Transform
+      registerMockPlugins({
+        transformers: { 'chatgpt->claude': { shouldFail: true, failureMessage: 'Failure 2' } },
+      });
+
+      const orchestrator2 = await MigrationOrchestrator.resume(migrationId, workDir);
+
+      try {
+        await orchestrator2.continue();
+      } catch {
+        // Expected
+      }
+
+      // Failure 3: Load
+      registerMockPlugins({
+        loaders: { claude: { shouldFail: true, failureMessage: 'Failure 3' } },
+      });
+
+      const orchestrator3 = await MigrationOrchestrator.resume(migrationId, workDir);
+
+      try {
+        await orchestrator3.continue();
+      } catch {
+        // Expected
+      }
+
+      // Finally succeed
+      registerMockPlugins();
+
+      const orchestrator4 = await MigrationOrchestrator.resume(migrationId, workDir);
+      const result = await orchestrator4.continue();
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should accumulate warnings across recovery attempts', async () => {
+      const workDir = join(testWorkDir, 'migration-warnings');
+
+      // First attempt with partial issues
+      registerMockPlugins({
+        loaders: {
+          claude: {
+            partialFailure: { memories: true },
+          },
+        },
+      });
+
+      const orchestrator1 = new MigrationOrchestrator('chatgpt', 'claude', { workDir });
+      const result = await orchestrator1.run();
+
+      expect(result.success).toBe(true);
+      expect(result.warnings.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Rollback After Recovery', () => {
+    it('should support rollback after resumed migration completes', async () => {
+      const workDir = join(testWorkDir, 'migration-rollback-resume');
+
+      // Fail during load first
+      registerMockPlugins({
+        loaders: { claude: { shouldFail: true, failureMessage: 'First load attempt' } },
+      });
+
+      const orchestrator1 = new MigrationOrchestrator('chatgpt', 'claude', { workDir });
+      const migrationId = orchestrator1.getState().id;
+
+      try {
+        await orchestrator1.run();
+      } catch {
+        // Expected
+      }
+
+      // Resume and complete
+      registerMockPlugins();
+
+      const orchestrator2 = await MigrationOrchestrator.resume(migrationId, workDir);
+      const result = await orchestrator2.continue();
+
+      expect(result.success).toBe(true);
+      expect(orchestrator2.canRollback()).toBe(true);
+
+      // Rollback should work
+      const rollbackResult = await orchestrator2.rollback();
+      expect(rollbackResult.success).toBe(true);
+    });
+
+    it('should not have rollback available for failed migrations', async () => {
+      const workDir = join(testWorkDir, 'migration-no-rollback');
+
+      registerMockPlugins({
+        loaders: { claude: { shouldFail: true, failureMessage: 'Permanent failure' } },
+      });
+
+      const orchestrator = new MigrationOrchestrator('chatgpt', 'claude', { workDir });
+
+      try {
+        await orchestrator.run();
+      } catch {
+        // Expected
+      }
+
+      expect(orchestrator.canRollback()).toBe(false);
+    });
+  });
+
+  describe('Progress Tracking During Recovery', () => {
+    it('should emit progress events during resumed migration', async () => {
+      const workDir = join(testWorkDir, 'migration-progress-resume');
+
+      // Complete extraction with delays to generate progress events
+      registerMockPlugins({
+        extractors: { chatgpt: { delayMs: 50 } },
+        transformers: { 'chatgpt->claude': { delayMs: 100 } },
+        loaders: { claude: { delayMs: 100 } },
+      });
+
+      const orchestrator1 = new MigrationOrchestrator('chatgpt', 'claude', { workDir });
+      const migrationId = orchestrator1.getState().id;
+      await orchestrator1.extract();
+
+      // Resume with delays and track progress
+      registerMockPlugins({
+        transformers: { 'chatgpt->claude': { delayMs: 100 } },
+        loaders: { claude: { delayMs: 100 } },
+      });
+
+      const orchestrator2 = await MigrationOrchestrator.resume(migrationId, workDir);
+
+      const events: MigrationEvent[] = [];
+      orchestrator2.on((e) => events.push(e));
+
+      await orchestrator2.continue();
+
+      // Should have progress events for transform and load phases
+      const progressEvents = events.filter((e) => e.type === 'progress');
+      expect(progressEvents.length).toBeGreaterThan(0);
+
+      // Should have completion event
+      const completeEvent = events.find((e) => e.type === 'complete');
+      expect(completeEvent).toBeDefined();
+    });
+  });
+
+  describe('Edge Cases in Recovery', () => {
+    it('should handle resume of non-existent migration', async () => {
+      await expect(
+        MigrationOrchestrator.resume('mig_nonexistent', testWorkDir),
+      ).rejects.toThrow(/not found/);
+    });
+
+    it('should handle resume when state file is missing', async () => {
+      const workDir = join(testWorkDir, 'migration-missing-state');
+      await mkdir(workDir, { recursive: true });
+
+      // Create directory structure but no state file
+      await expect(
+        MigrationOrchestrator.resume('mig_test', workDir),
+      ).rejects.toThrow(/not found/);
+    });
+
+    it('should handle resume when bundle file is missing', async () => {
+      const workDir = join(testWorkDir, 'mig_missing_bundle');
+      await mkdir(workDir, { recursive: true });
+
+      // Create state file pointing to non-existent bundle
+      const state: MigrationState = {
+        id: 'mig_missing_bundle',
+        phase: 'extracting',
+        source: 'chatgpt',
+        target: 'claude',
+        startedAt: new Date().toISOString(),
+        phaseStartedAt: new Date().toISOString(),
+        checkpoints: [
+          {
+            phase: 'extracting',
+            timestamp: new Date().toISOString(),
+            dataPath: join(workDir, 'missing_checkpoint.json'),
+            checksum: 'abc123',
+          },
+        ],
+        progress: 33,
+        bundlePath: join(workDir, 'nonexistent_bundle.json'),
+        options: {},
+      };
+
+      await writeFile(join(workDir, 'state.json'), JSON.stringify(state));
+
+      const orchestrator = await MigrationOrchestrator.resume('mig_missing_bundle', workDir);
+
+      // Bundle should be null since file doesn't exist
+      expect(orchestrator.getBundle()).toBeNull();
+    });
+  });
+});

--- a/src/migrate/__tests__/integration.test.ts
+++ b/src/migrate/__tests__/integration.test.ts
@@ -1,0 +1,599 @@
+/**
+ * Integration Tests for Migration Wizard
+ *
+ * Tests complete migration paths between platforms with realistic data.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { existsSync } from 'node:fs';
+import { rm, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { MigrationOrchestrator, type MigrationEvent } from '../orchestrator.js';
+import { registerMockPlugins, MockExtractor, MockLoader } from '../testing/index.js';
+import { ChatGPTToClaudeTransformer } from '../transformers/chatgpt-to-claude.js';
+import { ClaudeToChatGPTTransformer } from '../transformers/claude-to-chatgpt.js';
+import { registerTransformer } from '../transformers/registry.js';
+import type {
+  MigrationBundle,
+  MemoryEntry,
+  ConversationSummary,
+  CustomBotEntry,
+  FileEntry,
+} from '../types.js';
+
+describe('Integration Tests', () => {
+  let testWorkDir: string;
+
+  beforeEach(async () => {
+    testWorkDir = join(
+      tmpdir(),
+      `savestate-integration-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    await mkdir(testWorkDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    if (existsSync(testWorkDir)) {
+      await rm(testWorkDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('ChatGPT → Claude Full Migration', () => {
+    it('should migrate typical user data from ChatGPT to Claude', async () => {
+      // Create realistic ChatGPT data
+      const typicalUserBundle: MigrationBundle = {
+        version: '1.0',
+        id: 'bundle_chatgpt_typical',
+        source: {
+          platform: 'chatgpt',
+          extractedAt: new Date().toISOString(),
+          accountId: 'user_12345',
+          extractorVersion: '1.0.0',
+        },
+        contents: {
+          instructions: {
+            content: `## About Me
+I am a software developer working on web applications. I prefer TypeScript and React.
+I live in San Francisco and work remotely.
+
+## How ChatGPT Should Respond
+Be concise but thorough. Use code examples when helpful.
+Always explain the reasoning behind suggestions.
+Format code with proper indentation.`,
+            length: 300,
+            sections: [
+              { title: 'About Me', content: 'Software developer...', priority: 'high' },
+              { title: 'Response Style', content: 'Be concise...', priority: 'medium' },
+            ],
+          },
+          memories: {
+            entries: [
+              {
+                id: 'mem_1',
+                content: 'User prefers TypeScript over JavaScript',
+                createdAt: '2024-01-15T10:00:00Z',
+                category: 'preferences',
+              },
+              {
+                id: 'mem_2',
+                content: 'User is building a Next.js e-commerce platform',
+                createdAt: '2024-01-20T14:30:00Z',
+                category: 'projects',
+              },
+              {
+                id: 'mem_3',
+                content: 'User timezone is PST (UTC-8)',
+                createdAt: '2024-02-01T09:00:00Z',
+                category: 'context',
+              },
+            ],
+            count: 3,
+          },
+          conversations: {
+            path: 'conversations/',
+            count: 15,
+            messageCount: 150,
+            summaries: [
+              {
+                id: 'conv_1',
+                title: 'React State Management',
+                messageCount: 25,
+                createdAt: '2024-01-10T10:00:00Z',
+                updatedAt: '2024-01-10T12:00:00Z',
+                keyPoints: ['Decided to use Zustand for state management'],
+              },
+              {
+                id: 'conv_2',
+                title: 'Database Design',
+                messageCount: 40,
+                createdAt: '2024-01-12T09:00:00Z',
+                updatedAt: '2024-01-12T16:00:00Z',
+                keyPoints: ['Using Prisma with PostgreSQL'],
+              },
+            ],
+          },
+          files: {
+            files: [
+              {
+                id: 'file_1',
+                filename: 'schema.prisma',
+                mimeType: 'text/plain',
+                size: 4096,
+                path: 'files/schema.prisma',
+              },
+              {
+                id: 'file_2',
+                filename: 'api-docs.pdf',
+                mimeType: 'application/pdf',
+                size: 524288,
+                path: 'files/api-docs.pdf',
+              },
+            ],
+            count: 2,
+            totalSize: 528384,
+          },
+          customBots: {
+            bots: [
+              {
+                id: 'gpt_1',
+                name: 'Code Reviewer',
+                description: 'Reviews code for best practices',
+                instructions: 'You are a senior code reviewer...',
+                capabilities: ['code_interpreter'],
+                createdAt: '2024-01-05T10:00:00Z',
+              },
+            ],
+            count: 1,
+          },
+        },
+        metadata: {
+          totalItems: 22,
+          itemCounts: {
+            instructions: 1,
+            memories: 3,
+            conversations: 15,
+            files: 2,
+            customBots: 1,
+          },
+          warnings: [],
+          errors: [],
+        },
+      };
+
+      // Register mock extractor with this bundle
+      const { loaders } = registerMockPlugins({
+        extractors: {
+          chatgpt: { customBundle: typicalUserBundle },
+        },
+      });
+
+      // Also register the real ChatGPT→Claude transformer
+      registerTransformer('chatgpt', 'claude', () => new ChatGPTToClaudeTransformer());
+
+      const orchestrator = new MigrationOrchestrator('chatgpt', 'claude', {
+        workDir: join(testWorkDir, 'migration-chatgpt-claude'),
+      });
+
+      const events: MigrationEvent[] = [];
+      orchestrator.on((e) => events.push(e));
+
+      const result = await orchestrator.run();
+
+      // Verify success
+      expect(result.success).toBe(true);
+      expect(result.loaded.instructions).toBe(true);
+      expect(result.loaded.memories).toBeGreaterThan(0);
+      expect(result.loaded.files).toBe(2);
+
+      // Verify state
+      const state = orchestrator.getState();
+      expect(state.phase).toBe('complete');
+      expect(state.checkpoints.length).toBe(3);
+
+      // Verify the bundle was transformed correctly
+      const bundle = orchestrator.getBundle();
+      expect(bundle?.target?.platform).toBe('claude');
+      expect(bundle?.contents.instructions).toBeDefined();
+
+      // Verify phase events
+      const phaseStarts = events.filter((e) => e.type === 'phase:start');
+      expect(phaseStarts.length).toBe(3);
+    });
+
+    it('should preserve custom bot configurations during migration', async () => {
+      const bundleWithMultipleGPTs: MigrationBundle = {
+        version: '1.0',
+        id: 'bundle_gpts',
+        source: {
+          platform: 'chatgpt',
+          extractedAt: new Date().toISOString(),
+          extractorVersion: '1.0.0',
+        },
+        contents: {
+          customBots: {
+            bots: [
+              {
+                id: 'gpt_writer',
+                name: 'Creative Writer',
+                description: 'Helps with creative writing',
+                instructions:
+                  'You are a creative writing assistant. Help with stories, poems, and creative content.',
+                capabilities: ['browsing'],
+                createdAt: '2024-01-01T10:00:00Z',
+              },
+              {
+                id: 'gpt_data',
+                name: 'Data Analyst',
+                description: 'Analyzes data and creates visualizations',
+                instructions:
+                  'You are a data analyst. Process data, create charts, and provide insights.',
+                capabilities: ['code_interpreter'],
+                createdAt: '2024-01-02T10:00:00Z',
+              },
+            ],
+            count: 2,
+          },
+        },
+        metadata: {
+          totalItems: 2,
+          itemCounts: {
+            instructions: 0,
+            memories: 0,
+            conversations: 0,
+            files: 0,
+            customBots: 2,
+          },
+          warnings: [],
+          errors: [],
+        },
+      };
+
+      registerMockPlugins({
+        extractors: { chatgpt: { customBundle: bundleWithMultipleGPTs } },
+      });
+      registerTransformer('chatgpt', 'claude', () => new ChatGPTToClaudeTransformer());
+
+      const orchestrator = new MigrationOrchestrator('chatgpt', 'claude', {
+        workDir: join(testWorkDir, 'migration-gpts'),
+      });
+
+      const result = await orchestrator.run();
+
+      expect(result.success).toBe(true);
+      expect(result.loaded.customBots).toBe(2);
+
+      const bundle = orchestrator.getBundle();
+      expect(bundle?.contents.customBots?.count).toBe(2);
+    });
+  });
+
+  describe('Claude → ChatGPT Full Migration', () => {
+    it('should migrate typical user data from Claude to ChatGPT', async () => {
+      const claudeBundle: MigrationBundle = {
+        version: '1.0',
+        id: 'bundle_claude_typical',
+        source: {
+          platform: 'claude',
+          extractedAt: new Date().toISOString(),
+          accountId: 'org_abc123',
+          extractorVersion: '1.0.0',
+        },
+        contents: {
+          instructions: {
+            content: `You are assisting a product manager at a tech startup.
+
+Key context:
+- The user manages a team of 5 engineers
+- Main product is a B2B SaaS platform
+- Currently in Series A funding stage
+
+Response guidelines:
+- Be direct and action-oriented
+- Use bullet points for clarity
+- Consider business impact in suggestions`,
+            length: 350,
+          },
+          memories: {
+            entries: [
+              {
+                id: 'claude_mem_1',
+                content: 'User manages product roadmap quarterly',
+                createdAt: '2024-02-01T10:00:00Z',
+              },
+              {
+                id: 'claude_mem_2',
+                content: 'Team uses Jira for project tracking',
+                createdAt: '2024-02-05T14:00:00Z',
+              },
+            ],
+            count: 2,
+          },
+          files: {
+            files: [
+              {
+                id: 'claude_file_1',
+                filename: 'roadmap-q1.md',
+                mimeType: 'text/markdown',
+                size: 8192,
+                path: 'files/roadmap-q1.md',
+              },
+            ],
+            count: 1,
+            totalSize: 8192,
+          },
+        },
+        metadata: {
+          totalItems: 4,
+          itemCounts: {
+            instructions: 1,
+            memories: 2,
+            conversations: 0,
+            files: 1,
+            customBots: 0,
+          },
+          warnings: [],
+          errors: [],
+        },
+      };
+
+      registerMockPlugins({
+        extractors: { claude: { customBundle: claudeBundle } },
+      });
+      registerTransformer('claude', 'chatgpt', () => new ClaudeToChatGPTTransformer());
+
+      const orchestrator = new MigrationOrchestrator('claude', 'chatgpt', {
+        workDir: join(testWorkDir, 'migration-claude-chatgpt'),
+      });
+
+      const result = await orchestrator.run();
+
+      expect(result.success).toBe(true);
+      expect(result.loaded.instructions).toBe(true);
+      expect(result.loaded.memories).toBe(2);
+      expect(result.loaded.files).toBe(1);
+
+      const bundle = orchestrator.getBundle();
+      expect(bundle?.target?.platform).toBe('chatgpt');
+    });
+
+    it('should handle Claude projects mapped to ChatGPT', async () => {
+      const claudeWithProjects: MigrationBundle = {
+        version: '1.0',
+        id: 'bundle_claude_projects',
+        source: {
+          platform: 'claude',
+          extractedAt: new Date().toISOString(),
+          extractorVersion: '1.0.0',
+        },
+        contents: {
+          customBots: {
+            bots: [
+              {
+                id: 'proj_research',
+                name: 'Research Assistant',
+                description: 'Helps with academic research',
+                instructions: 'Focus on peer-reviewed sources and citations',
+                createdAt: '2024-01-15T10:00:00Z',
+              },
+            ],
+            count: 1,
+          },
+        },
+        metadata: {
+          totalItems: 1,
+          itemCounts: {
+            instructions: 0,
+            memories: 0,
+            conversations: 0,
+            files: 0,
+            customBots: 1,
+          },
+          warnings: [],
+          errors: [],
+        },
+      };
+
+      registerMockPlugins({
+        extractors: { claude: { customBundle: claudeWithProjects } },
+      });
+      registerTransformer('claude', 'chatgpt', () => new ClaudeToChatGPTTransformer());
+
+      const orchestrator = new MigrationOrchestrator('claude', 'chatgpt', {
+        workDir: join(testWorkDir, 'migration-projects'),
+      });
+
+      const result = await orchestrator.run();
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('Dry Run Mode', () => {
+    it('should show accurate compatibility report in dry run', async () => {
+      const bundleWithMixedCompatibility: MigrationBundle = {
+        version: '1.0',
+        id: 'bundle_mixed',
+        source: {
+          platform: 'chatgpt',
+          extractedAt: new Date().toISOString(),
+          extractorVersion: '1.0.0',
+        },
+        contents: {
+          instructions: {
+            content: 'A'.repeat(10000), // Long instructions that will need adaptation
+            length: 10000,
+          },
+          memories: {
+            entries: Array.from({ length: 25 }, (_, i) => ({
+              id: `mem_${i}`,
+              content: `Memory entry ${i}`,
+              createdAt: new Date().toISOString(),
+            })),
+            count: 25,
+          },
+          files: {
+            files: [
+              {
+                id: 'large_file',
+                filename: 'huge-dataset.csv',
+                mimeType: 'text/csv',
+                size: 100 * 1024 * 1024, // 100MB - exceeds Claude's limit
+                path: 'files/huge-dataset.csv',
+              },
+              {
+                id: 'normal_file',
+                filename: 'readme.md',
+                mimeType: 'text/markdown',
+                size: 1024,
+                path: 'files/readme.md',
+              },
+            ],
+            count: 2,
+            totalSize: 100 * 1024 * 1024 + 1024,
+          },
+        },
+        metadata: {
+          totalItems: 28,
+          itemCounts: {
+            instructions: 1,
+            memories: 25,
+            conversations: 0,
+            files: 2,
+            customBots: 0,
+          },
+          warnings: [],
+          errors: [],
+        },
+      };
+
+      registerMockPlugins({
+        extractors: { chatgpt: { customBundle: bundleWithMixedCompatibility } },
+      });
+      registerTransformer('chatgpt', 'claude', () => new ChatGPTToClaudeTransformer());
+
+      const orchestrator = new MigrationOrchestrator('chatgpt', 'claude', {
+        workDir: join(testWorkDir, 'migration-dry-run'),
+        dryRun: true,
+      });
+
+      // First get the compatibility report
+      const report = await orchestrator.analyze();
+
+      expect(report.source).toBe('chatgpt');
+      expect(report.target).toBe('claude');
+      expect(report.summary.total).toBeGreaterThan(0);
+      expect(report.items.some((i) => i.status === 'adapted')).toBe(true);
+      expect(report.items.some((i) => i.status === 'incompatible')).toBe(true);
+      expect(report.recommendations.length).toBeGreaterThan(0);
+
+      // Now run the dry migration
+      const result = await orchestrator.run();
+
+      expect(result.success).toBe(true);
+      expect(result.warnings).toContain('Dry run - no changes made');
+    });
+
+    it('should not create any resources in dry run mode', async () => {
+      registerMockPlugins();
+
+      const orchestrator = new MigrationOrchestrator('chatgpt', 'claude', {
+        workDir: join(testWorkDir, 'migration-dry-run-resources'),
+        dryRun: true,
+      });
+
+      const result = await orchestrator.run();
+
+      expect(result.success).toBe(true);
+      expect(result.created).toBeUndefined();
+    });
+  });
+
+  describe('Bidirectional Migration', () => {
+    it('should support round-trip migration ChatGPT → Claude → ChatGPT', async () => {
+      const originalBundle: MigrationBundle = {
+        version: '1.0',
+        id: 'bundle_roundtrip',
+        source: {
+          platform: 'chatgpt',
+          extractedAt: new Date().toISOString(),
+          extractorVersion: '1.0.0',
+        },
+        contents: {
+          instructions: {
+            content: 'I am a helpful assistant for a software engineer.',
+            length: 50,
+          },
+          memories: {
+            entries: [
+              {
+                id: 'mem_rt',
+                content: 'User prefers detailed explanations',
+                createdAt: new Date().toISOString(),
+              },
+            ],
+            count: 1,
+          },
+        },
+        metadata: {
+          totalItems: 2,
+          itemCounts: {
+            instructions: 1,
+            memories: 1,
+            conversations: 0,
+            files: 0,
+            customBots: 0,
+          },
+          warnings: [],
+          errors: [],
+        },
+      };
+
+      // First migration: ChatGPT → Claude
+      registerMockPlugins({
+        extractors: { chatgpt: { customBundle: originalBundle } },
+      });
+      registerTransformer('chatgpt', 'claude', () => new ChatGPTToClaudeTransformer());
+      registerTransformer('claude', 'chatgpt', () => new ClaudeToChatGPTTransformer());
+
+      const orchestrator1 = new MigrationOrchestrator('chatgpt', 'claude', {
+        workDir: join(testWorkDir, 'migration-roundtrip-1'),
+      });
+
+      const result1 = await orchestrator1.run();
+      expect(result1.success).toBe(true);
+
+      const claudeBundle = orchestrator1.getBundle()!;
+      expect(claudeBundle.target?.platform).toBe('claude');
+
+      // Second migration: Claude → ChatGPT (using the transformed bundle)
+      registerMockPlugins({
+        extractors: {
+          claude: {
+            customBundle: {
+              ...claudeBundle,
+              source: {
+                platform: 'claude',
+                extractedAt: new Date().toISOString(),
+                extractorVersion: '1.0.0',
+              },
+            },
+          },
+        },
+      });
+
+      const orchestrator2 = new MigrationOrchestrator('claude', 'chatgpt', {
+        workDir: join(testWorkDir, 'migration-roundtrip-2'),
+      });
+
+      const result2 = await orchestrator2.run();
+      expect(result2.success).toBe(true);
+
+      const finalBundle = orchestrator2.getBundle()!;
+      expect(finalBundle.target?.platform).toBe('chatgpt');
+
+      // Core data should be preserved
+      expect(finalBundle.contents.instructions).toBeDefined();
+    });
+  });
+});

--- a/src/migrate/__tests__/performance.test.ts
+++ b/src/migrate/__tests__/performance.test.ts
@@ -1,0 +1,558 @@
+/**
+ * Performance Tests for Migration Wizard
+ *
+ * Tests memory usage, progress responsiveness, and large dataset handling.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync } from 'node:fs';
+import { rm, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { MigrationOrchestrator, type MigrationEvent } from '../orchestrator.js';
+import { registerMockPlugins } from '../testing/index.js';
+import { ChatGPTToClaudeTransformer } from '../transformers/chatgpt-to-claude.js';
+import { registerTransformer } from '../transformers/registry.js';
+import type { MigrationBundle, MemoryEntry, ConversationSummary, FileEntry } from '../types.js';
+
+describe('Performance Tests', () => {
+  let testWorkDir: string;
+
+  beforeEach(async () => {
+    testWorkDir = join(
+      tmpdir(),
+      `savestate-perf-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    await mkdir(testWorkDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    if (existsSync(testWorkDir)) {
+      await rm(testWorkDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('Memory Usage Bounds', () => {
+    it('should handle large conversation dataset without memory explosion', async () => {
+      // Create a bundle with 2000 conversations
+      const conversations: ConversationSummary[] = Array.from({ length: 2000 }, (_, i) => ({
+        id: `conv_${i}`,
+        title: `Conversation ${i}: ${generateRandomTitle()}`,
+        messageCount: Math.floor(Math.random() * 100) + 10,
+        createdAt: new Date(Date.now() - i * 86400000).toISOString(),
+        updatedAt: new Date(Date.now() - i * 43200000).toISOString(),
+        keyPoints: i % 5 === 0
+          ? [`Key point ${i}-1`, `Key point ${i}-2`, `Key point ${i}-3`]
+          : undefined,
+      }));
+
+      const largeBundle: MigrationBundle = {
+        version: '1.0',
+        id: 'bundle_large_memory_test',
+        source: {
+          platform: 'chatgpt',
+          extractedAt: new Date().toISOString(),
+          extractorVersion: '1.0.0',
+        },
+        contents: {
+          conversations: {
+            path: 'conversations/',
+            count: 2000,
+            messageCount: conversations.reduce((sum, c) => sum + c.messageCount, 0),
+            summaries: conversations,
+          },
+        },
+        metadata: {
+          totalItems: 2000,
+          itemCounts: {
+            instructions: 0,
+            memories: 0,
+            conversations: 2000,
+            files: 0,
+            customBots: 0,
+          },
+          warnings: [],
+          errors: [],
+        },
+      };
+
+      registerMockPlugins({
+        extractors: { chatgpt: { customBundle: largeBundle } },
+      });
+      registerTransformer('chatgpt', 'claude', () => new ChatGPTToClaudeTransformer());
+
+      // Get initial memory usage
+      const initialMemory = process.memoryUsage().heapUsed;
+
+      const orchestrator = new MigrationOrchestrator('chatgpt', 'claude', {
+        workDir: join(testWorkDir, 'migration-large-memory'),
+      });
+
+      const result = await orchestrator.run();
+
+      // Get final memory usage
+      const finalMemory = process.memoryUsage().heapUsed;
+      const memoryIncrease = finalMemory - initialMemory;
+
+      expect(result.success).toBe(true);
+
+      // Memory increase should be reasonable (< 200MB for 2000 conversations)
+      // This is a rough bound - actual implementation should be much lower
+      expect(memoryIncrease).toBeLessThan(200 * 1024 * 1024);
+    });
+
+    it('should handle large memory dataset efficiently', async () => {
+      // Create 1000 memory entries with varying content sizes
+      const memories: MemoryEntry[] = Array.from({ length: 1000 }, (_, i) => ({
+        id: `mem_${i}`,
+        content: generateVariableContent(100 + (i % 500)),
+        createdAt: new Date(Date.now() - i * 3600000).toISOString(),
+        category: ['preferences', 'facts', 'context', 'decisions', 'insights'][i % 5],
+        source: 'chatgpt',
+      }));
+
+      const bundle: MigrationBundle = {
+        version: '1.0',
+        id: 'bundle_large_memories',
+        source: {
+          platform: 'chatgpt',
+          extractedAt: new Date().toISOString(),
+          extractorVersion: '1.0.0',
+        },
+        contents: {
+          memories: { entries: memories, count: 1000 },
+        },
+        metadata: {
+          totalItems: 1000,
+          itemCounts: {
+            instructions: 0,
+            memories: 1000,
+            conversations: 0,
+            files: 0,
+            customBots: 0,
+          },
+          warnings: [],
+          errors: [],
+        },
+      };
+
+      registerMockPlugins({
+        extractors: { chatgpt: { customBundle: bundle } },
+      });
+      registerTransformer('chatgpt', 'claude', () => new ChatGPTToClaudeTransformer());
+
+      const initialMemory = process.memoryUsage().heapUsed;
+
+      const orchestrator = new MigrationOrchestrator('chatgpt', 'claude', {
+        workDir: join(testWorkDir, 'migration-large-memories'),
+      });
+
+      const result = await orchestrator.run();
+      const finalMemory = process.memoryUsage().heapUsed;
+
+      expect(result.success).toBe(true);
+
+      // Memory increase should be bounded
+      const memoryIncreaseMB = (finalMemory - initialMemory) / (1024 * 1024);
+      expect(memoryIncreaseMB).toBeLessThan(100);
+    });
+  });
+
+  describe('Progress Update Responsiveness', () => {
+    it('should emit progress updates at regular intervals', async () => {
+      // Use mocks with delays to simulate real processing
+      registerMockPlugins({
+        extractors: { chatgpt: { delayMs: 500 } },
+        transformers: { 'chatgpt->claude': { delayMs: 500 } },
+        loaders: { claude: { delayMs: 500 } },
+      });
+
+      const progressEvents: MigrationEvent[] = [];
+      const progressTimestamps: number[] = [];
+
+      const orchestrator = new MigrationOrchestrator('chatgpt', 'claude', {
+        workDir: join(testWorkDir, 'migration-progress-timing'),
+      });
+
+      orchestrator.on((event) => {
+        if (event.type === 'progress') {
+          progressEvents.push(event);
+          progressTimestamps.push(Date.now());
+        }
+      });
+
+      const startTime = Date.now();
+      await orchestrator.run();
+      const endTime = Date.now();
+
+      // Should have multiple progress events
+      expect(progressEvents.length).toBeGreaterThan(10);
+
+      // Check intervals between progress updates
+      if (progressTimestamps.length > 1) {
+        const intervals: number[] = [];
+        for (let i = 1; i < progressTimestamps.length; i++) {
+          intervals.push(progressTimestamps[i] - progressTimestamps[i - 1]);
+        }
+
+        // Average interval should be reasonable (< 500ms for responsive UI)
+        const avgInterval = intervals.reduce((a, b) => a + b, 0) / intervals.length;
+        expect(avgInterval).toBeLessThan(500);
+      }
+    });
+
+    it('should provide progress updates throughout all phases', async () => {
+      registerMockPlugins({
+        extractors: { chatgpt: { delayMs: 300 } },
+        transformers: { 'chatgpt->claude': { delayMs: 300 } },
+        loaders: { claude: { delayMs: 300 } },
+      });
+
+      const phaseProgress: Map<string, number[]> = new Map();
+
+      const orchestrator = new MigrationOrchestrator('chatgpt', 'claude', {
+        workDir: join(testWorkDir, 'migration-phase-progress'),
+      });
+
+      let currentPhase = 'pending';
+
+      orchestrator.on((event) => {
+        if (event.type === 'phase:start' && event.phase) {
+          currentPhase = event.phase;
+          phaseProgress.set(currentPhase, []);
+        }
+        if (event.type === 'progress' && event.progress !== undefined) {
+          const progress = phaseProgress.get(currentPhase) || [];
+          progress.push(event.progress);
+          phaseProgress.set(currentPhase, progress);
+        }
+      });
+
+      await orchestrator.run();
+
+      // Each phase should have progress updates
+      expect(phaseProgress.has('extracting')).toBe(true);
+      expect(phaseProgress.has('transforming')).toBe(true);
+      expect(phaseProgress.has('loading')).toBe(true);
+
+      // Progress should increase within each phase
+      for (const [phase, progressValues] of phaseProgress) {
+        if (progressValues.length > 1) {
+          for (let i = 1; i < progressValues.length; i++) {
+            expect(progressValues[i]).toBeGreaterThanOrEqual(progressValues[i - 1]);
+          }
+        }
+      }
+    });
+
+    it('should not block on progress callbacks', async () => {
+      registerMockPlugins({
+        extractors: { chatgpt: { delayMs: 100 } },
+        transformers: { 'chatgpt->claude': { delayMs: 100 } },
+        loaders: { claude: { delayMs: 100 } },
+      });
+
+      let slowCallbackCount = 0;
+
+      const orchestrator = new MigrationOrchestrator('chatgpt', 'claude', {
+        workDir: join(testWorkDir, 'migration-slow-callback'),
+      });
+
+      orchestrator.on(async (event) => {
+        if (event.type === 'progress') {
+          // Simulate slow callback (shouldn't block migration)
+          await new Promise((r) => setTimeout(r, 50));
+          slowCallbackCount++;
+        }
+      });
+
+      const startTime = Date.now();
+      const result = await orchestrator.run();
+      const duration = Date.now() - startTime;
+
+      expect(result.success).toBe(true);
+      expect(slowCallbackCount).toBeGreaterThan(0);
+
+      // Total duration should not be significantly increased by slow callbacks
+      // If callbacks blocked, duration would be >> 300ms + (50ms * slowCallbackCount)
+      // With non-blocking, it should be closer to 300ms + small overhead
+      expect(duration).toBeLessThan(2000);
+    });
+  });
+
+  describe('Large File Handling', () => {
+    it('should handle many small files efficiently', async () => {
+      // Create 100 small files
+      const files: FileEntry[] = Array.from({ length: 100 }, (_, i) => ({
+        id: `file_${i}`,
+        filename: `document_${i}.${['txt', 'md', 'json', 'yaml'][i % 4]}`,
+        mimeType: ['text/plain', 'text/markdown', 'application/json', 'text/yaml'][i % 4],
+        size: Math.floor(Math.random() * 50000) + 1000,
+        path: `files/document_${i}.txt`,
+      }));
+
+      const bundle: MigrationBundle = {
+        version: '1.0',
+        id: 'bundle_many_files',
+        source: {
+          platform: 'chatgpt',
+          extractedAt: new Date().toISOString(),
+          extractorVersion: '1.0.0',
+        },
+        contents: {
+          files: {
+            files,
+            count: 100,
+            totalSize: files.reduce((sum, f) => sum + f.size, 0),
+          },
+        },
+        metadata: {
+          totalItems: 100,
+          itemCounts: {
+            instructions: 0,
+            memories: 0,
+            conversations: 0,
+            files: 100,
+            customBots: 0,
+          },
+          warnings: [],
+          errors: [],
+        },
+      };
+
+      registerMockPlugins({
+        extractors: { chatgpt: { customBundle: bundle } },
+      });
+      registerTransformer('chatgpt', 'claude', () => new ChatGPTToClaudeTransformer());
+
+      const startTime = Date.now();
+
+      const orchestrator = new MigrationOrchestrator('chatgpt', 'claude', {
+        workDir: join(testWorkDir, 'migration-many-files'),
+      });
+
+      const result = await orchestrator.run();
+      const duration = Date.now() - startTime;
+
+      expect(result.success).toBe(true);
+      expect(result.loaded.files).toBe(100);
+
+      // Should complete in reasonable time (< 5 seconds for mock processing)
+      expect(duration).toBeLessThan(5000);
+    });
+  });
+
+  describe('Concurrent Migrations', () => {
+    it('should support multiple concurrent migrations', async () => {
+      registerMockPlugins({
+        extractors: { chatgpt: { delayMs: 100 } },
+        transformers: { 'chatgpt->claude': { delayMs: 100 } },
+        loaders: { claude: { delayMs: 100 } },
+      });
+
+      // Start multiple migrations concurrently
+      const migrations = await Promise.all([
+        (async () => {
+          const o = new MigrationOrchestrator('chatgpt', 'claude', {
+            workDir: join(testWorkDir, 'migration-concurrent-1'),
+          });
+          return o.run();
+        })(),
+        (async () => {
+          const o = new MigrationOrchestrator('chatgpt', 'claude', {
+            workDir: join(testWorkDir, 'migration-concurrent-2'),
+          });
+          return o.run();
+        })(),
+        (async () => {
+          const o = new MigrationOrchestrator('chatgpt', 'claude', {
+            workDir: join(testWorkDir, 'migration-concurrent-3'),
+          });
+          return o.run();
+        })(),
+      ]);
+
+      // All should succeed
+      expect(migrations.every((r) => r.success)).toBe(true);
+    });
+
+    it('should maintain isolation between concurrent migrations', async () => {
+      const customBundle1: MigrationBundle = {
+        version: '1.0',
+        id: 'bundle_1',
+        source: {
+          platform: 'chatgpt',
+          extractedAt: new Date().toISOString(),
+          accountId: 'user_1',
+          extractorVersion: '1.0.0',
+        },
+        contents: {
+          instructions: { content: 'Instructions for user 1', length: 25 },
+        },
+        metadata: {
+          totalItems: 1,
+          itemCounts: {
+            instructions: 1,
+            memories: 0,
+            conversations: 0,
+            files: 0,
+            customBots: 0,
+          },
+          warnings: [],
+          errors: [],
+        },
+      };
+
+      const customBundle2: MigrationBundle = {
+        version: '1.0',
+        id: 'bundle_2',
+        source: {
+          platform: 'chatgpt',
+          extractedAt: new Date().toISOString(),
+          accountId: 'user_2',
+          extractorVersion: '1.0.0',
+        },
+        contents: {
+          instructions: { content: 'Instructions for user 2', length: 25 },
+        },
+        metadata: {
+          totalItems: 1,
+          itemCounts: {
+            instructions: 1,
+            memories: 0,
+            conversations: 0,
+            files: 0,
+            customBots: 0,
+          },
+          warnings: [],
+          errors: [],
+        },
+      };
+
+      // Start migrations with different bundles
+      const orchestrator1 = new MigrationOrchestrator('chatgpt', 'claude', {
+        workDir: join(testWorkDir, 'migration-isolated-1'),
+      });
+      registerMockPlugins({
+        extractors: { chatgpt: { customBundle: customBundle1 } },
+      });
+      const result1 = await orchestrator1.run();
+
+      const orchestrator2 = new MigrationOrchestrator('chatgpt', 'claude', {
+        workDir: join(testWorkDir, 'migration-isolated-2'),
+      });
+      registerMockPlugins({
+        extractors: { chatgpt: { customBundle: customBundle2 } },
+      });
+      const result2 = await orchestrator2.run();
+
+      expect(result1.success).toBe(true);
+      expect(result2.success).toBe(true);
+
+      // Bundles should remain distinct
+      const bundle1 = orchestrator1.getBundle();
+      const bundle2 = orchestrator2.getBundle();
+
+      expect(bundle1?.id).not.toBe(bundle2?.id);
+    });
+  });
+
+  describe('Transformation Performance', () => {
+    it('should transform instructions efficiently even when long', async () => {
+      // Create very long instructions (100KB)
+      const longInstructions = Array.from({ length: 1000 }, (_, i) =>
+        `Instruction block ${i}: This is a detailed instruction about topic ${i}. `.repeat(3),
+      ).join('\n\n');
+
+      const bundle: MigrationBundle = {
+        version: '1.0',
+        id: 'bundle_long_transform',
+        source: {
+          platform: 'chatgpt',
+          extractedAt: new Date().toISOString(),
+          extractorVersion: '1.0.0',
+        },
+        contents: {
+          instructions: {
+            content: longInstructions,
+            length: longInstructions.length,
+          },
+        },
+        metadata: {
+          totalItems: 1,
+          itemCounts: {
+            instructions: 1,
+            memories: 0,
+            conversations: 0,
+            files: 0,
+            customBots: 0,
+          },
+          warnings: [],
+          errors: [],
+        },
+      };
+
+      registerMockPlugins({
+        extractors: { chatgpt: { customBundle: bundle } },
+      });
+      registerTransformer('chatgpt', 'claude', () => new ChatGPTToClaudeTransformer());
+
+      const startTime = Date.now();
+
+      const orchestrator = new MigrationOrchestrator('chatgpt', 'claude', {
+        workDir: join(testWorkDir, 'migration-transform-perf'),
+      });
+
+      const result = await orchestrator.run();
+      const transformTime = Date.now() - startTime;
+
+      expect(result.success).toBe(true);
+
+      // Transformation of 100KB should complete quickly (< 2 seconds)
+      expect(transformTime).toBeLessThan(2000);
+    });
+  });
+});
+
+// ─── Helper Functions ──────────────────────────────────────────
+
+function generateRandomTitle(): string {
+  const topics = [
+    'Code Review',
+    'Bug Fix',
+    'Feature Discussion',
+    'Architecture',
+    'Testing Strategy',
+    'Performance Optimization',
+    'Security Review',
+    'API Design',
+    'Database Schema',
+    'Deployment Planning',
+  ];
+  const actions = [
+    'Discussion',
+    'Analysis',
+    'Planning',
+    'Review',
+    'Implementation',
+    'Debugging',
+    'Refactoring',
+  ];
+  return `${topics[Math.floor(Math.random() * topics.length)]} ${actions[Math.floor(Math.random() * actions.length)]}`;
+}
+
+function generateVariableContent(length: number): string {
+  const words = [
+    'user', 'prefers', 'typescript', 'react', 'node', 'python', 'docker',
+    'kubernetes', 'aws', 'gcp', 'azure', 'mongodb', 'postgresql', 'redis',
+    'graphql', 'rest', 'api', 'frontend', 'backend', 'fullstack', 'devops',
+    'ci', 'cd', 'testing', 'unit', 'integration', 'e2e', 'performance',
+  ];
+
+  let content = '';
+  while (content.length < length) {
+    content += words[Math.floor(Math.random() * words.length)] + ' ';
+  }
+  return content.substring(0, length);
+}

--- a/src/migrate/__tests__/registry.test.ts
+++ b/src/migrate/__tests__/registry.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Registry Tests
+ *
+ * Tests for extractor, transformer, and loader registries.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  getExtractor,
+  registerExtractor,
+  listExtractors,
+  hasExtractor,
+} from '../extractors/registry.js';
+import {
+  getTransformer,
+  registerTransformer,
+  listTransformers,
+  hasTransformer,
+} from '../transformers/registry.js';
+import {
+  getLoader,
+  registerLoader,
+  listLoaders,
+  hasLoader,
+} from '../loaders/registry.js';
+import { registerMockPlugins } from '../testing/index.js';
+
+describe('Extractor Registry', () => {
+  beforeEach(() => {
+    // Register mock plugins to ensure consistent state
+    registerMockPlugins();
+  });
+
+  it('should get registered extractor', () => {
+    const extractor = getExtractor('chatgpt');
+    expect(extractor).not.toBeNull();
+    expect(extractor?.platform).toBe('chatgpt');
+  });
+
+  it('should list all extractors', () => {
+    const extractors = listExtractors();
+    expect(extractors).toContain('chatgpt');
+    expect(extractors).toContain('claude');
+  });
+
+  it('should check if extractor exists', () => {
+    expect(hasExtractor('chatgpt')).toBe(true);
+    expect(hasExtractor('claude')).toBe(true);
+    expect(hasExtractor('gemini')).toBe(true); // Mock registered
+  });
+
+  it('should return null for non-registered platform without mocks', () => {
+    // This tests the underlying behavior - mock plugins register all platforms
+    // but the original registry only has chatgpt and claude
+    const extractor = getExtractor('copilot');
+    // With mocks, all platforms are registered
+    expect(extractor).not.toBeNull();
+  });
+});
+
+describe('Transformer Registry', () => {
+  beforeEach(() => {
+    registerMockPlugins();
+  });
+
+  it('should get registered transformer', () => {
+    const transformer = getTransformer('chatgpt', 'claude');
+    expect(transformer).not.toBeNull();
+    expect(transformer?.source).toBe('chatgpt');
+    expect(transformer?.target).toBe('claude');
+  });
+
+  it('should list all transformers', () => {
+    const transformers = listTransformers();
+    expect(transformers.some((t) => t.source === 'chatgpt' && t.target === 'claude')).toBe(true);
+    expect(transformers.some((t) => t.source === 'claude' && t.target === 'chatgpt')).toBe(true);
+  });
+
+  it('should check if transformer exists', () => {
+    expect(hasTransformer('chatgpt', 'claude')).toBe(true);
+    expect(hasTransformer('claude', 'chatgpt')).toBe(true);
+  });
+
+  it('should return null for non-registered path', () => {
+    // Mock plugins register common paths but not all combinations
+    const transformer = getTransformer('copilot', 'gemini');
+    expect(transformer).toBeNull();
+  });
+});
+
+describe('Loader Registry', () => {
+  beforeEach(() => {
+    registerMockPlugins();
+  });
+
+  it('should get registered loader', () => {
+    const loader = getLoader('claude');
+    expect(loader).not.toBeNull();
+    expect(loader?.platform).toBe('claude');
+  });
+
+  it('should list all loaders', () => {
+    const loaders = listLoaders();
+    expect(loaders).toContain('chatgpt');
+    expect(loaders).toContain('claude');
+  });
+
+  it('should check if loader exists', () => {
+    expect(hasLoader('chatgpt')).toBe(true);
+    expect(hasLoader('claude')).toBe(true);
+  });
+});
+
+describe('Registry Integration', () => {
+  it('should allow registering custom implementations', () => {
+    const customPlatform = 'gemini' as const;
+
+    // Register custom extractor
+    let extractCalled = false;
+    registerExtractor(customPlatform, () => ({
+      platform: customPlatform,
+      version: 'custom',
+      canExtract: async () => true,
+      extract: async () => {
+        extractCalled = true;
+        return {
+          version: '1.0' as const,
+          id: 'custom',
+          source: {
+            platform: customPlatform,
+            extractedAt: new Date().toISOString(),
+            extractorVersion: 'custom',
+          },
+          contents: {},
+          metadata: {
+            totalItems: 0,
+            itemCounts: {
+              instructions: 0,
+              memories: 0,
+              conversations: 0,
+              files: 0,
+              customBots: 0,
+            },
+            warnings: [],
+            errors: [],
+          },
+        };
+      },
+      getProgress: () => 100,
+    }));
+
+    const extractor = getExtractor(customPlatform);
+    expect(extractor?.version).toBe('custom');
+  });
+
+  it('should allow registering custom transformers', () => {
+    registerTransformer('gemini', 'copilot', () => ({
+      source: 'gemini',
+      target: 'copilot',
+      version: 'custom-transformer',
+      analyze: async (bundle) => ({
+        source: 'gemini',
+        target: 'copilot',
+        generatedAt: new Date().toISOString(),
+        summary: { perfect: 1, adapted: 0, incompatible: 0, total: 1 },
+        items: [],
+        recommendations: [],
+        feasibility: 'easy',
+      }),
+      transform: async (bundle) => ({
+        ...bundle,
+        target: {
+          platform: 'copilot',
+          transformedAt: new Date().toISOString(),
+          transformerVersion: 'custom-transformer',
+        },
+      }),
+    }));
+
+    expect(hasTransformer('gemini', 'copilot')).toBe(true);
+    const transformer = getTransformer('gemini', 'copilot');
+    expect(transformer?.version).toBe('custom-transformer');
+  });
+
+  it('should allow registering custom loaders', () => {
+    registerLoader('gemini', () => ({
+      platform: 'gemini',
+      version: 'custom-loader',
+      canLoad: async () => true,
+      load: async () => ({
+        success: true,
+        loaded: { instructions: true, memories: 0, files: 0, customBots: 0 },
+        warnings: [],
+        errors: [],
+      }),
+      getProgress: () => 100,
+    }));
+
+    expect(hasLoader('gemini')).toBe(true);
+    const loader = getLoader('gemini');
+    expect(loader?.version).toBe('custom-loader');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,12 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
       include: ['src/migrate/**/*.ts'],
-      exclude: ['src/migrate/__tests__/**', 'src/migrate/testing/**'],
+      exclude: [
+        'src/migrate/__tests__/**',
+        'src/migrate/testing/**',
+        'src/migrate/index.ts', // Re-exports only
+        'src/migrate/types.ts', // Type definitions only
+      ],
     },
     testTimeout: 30000,
   },


### PR DESCRIPTION
## Summary

Implements Issue #31: Testing & Edge Cases

Adds comprehensive testing for the Migration Wizard with 79 new tests, bringing the total from 293 to 372.

## Test Categories

### 1. Integration Tests (7 tests)
- Full ChatGPT → Claude migration with typical user data
- Full Claude → ChatGPT migration with typical user data  
- Custom bot/GPT configuration preservation
- Dry run with accurate compatibility report
- Bidirectional round-trip migration

### 2. Edge Case Tests (19 tests)
- Empty source account (no data to migrate)
- Very large accounts (1000+ conversations, 500+ memories)
- Files exceeding platform size limits
- Unicode/emoji in content and filenames
- Very long custom instructions requiring truncation
- Network interruption simulation
- Auth token expiration simulation
- Special characters in identifiers
- Malformed data handling
- Timestamp edge cases

### 3. Error Recovery Tests (18 tests)
- Resume from Extract phase failure
- Resume from Transform phase failure
- Resume from Load phase failure
- Checkpoint integrity verification (checksum validation)
- State persistence to disk
- Multiple consecutive failure recovery
- Rollback after resumed migration

### 4. Performance Tests (9 tests)
- Memory usage stays bounded for large datasets (2000 conversations)
- Progress updates are responsive (< 500ms intervals)
- Large file handling efficiency
- Concurrent migration isolation
- Transformation performance

### 5. Additional Coverage Tests (26 tests)
- Platform capabilities (capabilities.test.ts)
- Registry functions (registry.test.ts)

## Coverage Report

| Component | Line Coverage |
|-----------|---------------|
| Orchestrator | 92.89% |
| Transformers | 90%+ |
| Loaders | 83%+ |
| Capabilities | 100% |

The extractors have lower coverage (60-67%) due to complex API/file I/O that requires extensive mocking.

## Changes

- Added 6 new test files with 79 tests
- Added `@vitest/coverage-v8` dev dependency
- Updated `vitest.config.ts` to exclude type-only files from coverage

Closes #31