### PR TITLE
feat: Failure Antibody System MVP (warn-only preflight)

### DIFF
--- a/src/antibodies/__tests__/compiler.test.ts
+++ b/src/antibodies/__tests__/compiler.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Failure Antibody compiler tests
+ */
+
+import { describe, expect, it } from 'vitest';
+import { AntibodyCompiler } from '../compiler.js';
+import type { FailureEvent } from '../types.js';
+
+describe('AntibodyCompiler', () => {
+  it('compiles deterministic rules independent of event order', () => {
+    const events: FailureEvent[] = [
+      {
+        id: 'evt_1',
+        type: 'user_correction',
+        timestamp: '2026-02-20T01:00:00.000Z',
+        tool: 'filesystem',
+        path: '/workspace/app/config.json',
+        correction_code: 'missing_permission',
+        error_code: 'EACCES',
+      },
+      {
+        id: 'evt_2',
+        type: 'tool_failure',
+        timestamp: '2026-02-20T02:00:00.000Z',
+        tool: 'filesystem',
+        error_code: 'ENOENT',
+        hard: true,
+        path: '/workspace/app/missing.txt',
+      },
+    ];
+
+    const compiler = new AntibodyCompiler();
+    const compiledA = compiler.compile(events);
+    const compiledB = compiler.compile([...events].reverse());
+
+    expect(compiledA).toEqual(compiledB);
+    expect(compiledA).toHaveLength(2);
+    expect(compiledA.every((rule) => rule.intervention === 'warn')).toBe(true);
+  });
+
+  it('only compiles hard tool failures', () => {
+    const events: FailureEvent[] = [
+      {
+        id: 'evt_soft',
+        type: 'tool_failure',
+        timestamp: '2026-02-20T03:00:00.000Z',
+        tool: 'network',
+        error_code: 'ECONNRESET',
+        hard: false,
+      },
+      {
+        id: 'evt_hard',
+        type: 'tool_failure',
+        timestamp: '2026-02-20T04:00:00.000Z',
+        tool: 'network',
+        error_code: 'ECONNRESET',
+        hard: true,
+      },
+    ];
+
+    const compiler = new AntibodyCompiler();
+    const compiled = compiler.compile(events);
+
+    expect(compiled).toHaveLength(1);
+    expect(compiled[0].source_event_ids).toEqual(['evt_hard']);
+    expect(compiled[0].safe_action.type).toBe('retry_with_backoff');
+  });
+
+  it('maps user correction codes to deterministic safe actions', () => {
+    const compiler = new AntibodyCompiler();
+    const rule = compiler.compileEvent({
+      id: 'evt_user_1',
+      type: 'user_correction',
+      timestamp: '2026-02-20T05:00:00.000Z',
+      tool: 'filesystem',
+      correction_code: 'wrong_path',
+    });
+
+    expect(rule).not.toBeNull();
+    expect(rule?.safe_action.type).toBe('validate_inputs');
+    expect(rule?.confidence).toBe(0.9);
+  });
+});
+

--- a/src/antibodies/__tests__/engine.test.ts
+++ b/src/antibodies/__tests__/engine.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Failure Antibody preflight engine tests
+ */
+
+import { existsSync } from 'node:fs';
+import { mkdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { AntibodyEngine } from '../engine.js';
+import { AntibodyStore } from '../store.js';
+import type { AntibodyRule } from '../types.js';
+
+describe('AntibodyEngine', () => {
+  let workDir: string;
+  let store: AntibodyStore;
+
+  beforeEach(async () => {
+    workDir = join(
+      tmpdir(),
+      `savestate-antibody-engine-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    await mkdir(workDir, { recursive: true });
+    store = new AntibodyStore(workDir);
+  });
+
+  afterEach(async () => {
+    if (existsSync(workDir)) {
+      await rm(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it('matches rules using cheap matchers (tool/error/path/tag)', async () => {
+    await store.add(
+      createRule('ab_rule_match', {
+        tool: 'filesystem',
+        error_codes: ['EACCES'],
+        path_prefixes: ['/workspace/app'],
+        tags: ['write'],
+      }),
+    );
+
+    const engine = new AntibodyEngine(store);
+    const result = await engine.preflight({
+      tool: 'filesystem',
+      error_code: 'EACCES',
+      path: '/workspace/app/config.json',
+      tags: ['write', 'critical'],
+    });
+
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule_id).toBe('ab_rule_match');
+    expect(result.warnings[0].reason_codes).toEqual(['tool', 'error_code', 'path_prefix', 'tag']);
+    expect(result.semantic_used).toBe(false);
+  });
+
+  it('does not match when required trigger dimensions are missing', async () => {
+    await store.add(
+      createRule('ab_rule_no_match', {
+        tool: 'filesystem',
+        error_codes: ['ENOENT'],
+      }),
+    );
+
+    const engine = new AntibodyEngine(store);
+    const result = await engine.preflight({
+      tool: 'filesystem',
+      error_code: 'EACCES',
+    });
+
+    expect(result.warnings).toHaveLength(0);
+    expect(result.matched_rule_ids).toEqual([]);
+  });
+
+  it('keeps p95 preflight latency under 40ms by default with cheap matchers only', async () => {
+    for (let i = 0; i < 120; i++) {
+      await store.add(
+        createRule(`ab_bulk_${i}`, {
+          tool: i % 2 === 0 ? 'filesystem' : 'network',
+          error_codes: [i % 3 === 0 ? 'EACCES' : 'ENOENT'],
+          path_prefixes: ['/workspace/app'],
+          tags: ['bulk'],
+        }),
+      );
+    }
+
+    const engine = new AntibodyEngine(store);
+    const latencies: number[] = [];
+
+    for (let i = 0; i < 30; i++) {
+      const result = await engine.preflight({
+        tool: 'filesystem',
+        error_code: 'EACCES',
+        path: '/workspace/app/file.txt',
+        tags: ['bulk'],
+      });
+      latencies.push(result.elapsed_ms);
+    }
+
+    const p95 = percentile(latencies, 95);
+    expect(p95).toBeLessThan(40);
+  });
+});
+
+function createRule(
+  id: string,
+  trigger: {
+    tool?: string;
+    error_codes?: string[];
+    path_prefixes?: string[];
+    tags?: string[];
+  },
+): AntibodyRule {
+  return {
+    id,
+    trigger,
+    risk: 'medium',
+    safe_action: { type: 'validate_inputs' },
+    scope: { project: 'local' },
+    confidence: 0.7,
+    intervention: 'warn',
+    created_at: new Date('2026-02-20T00:00:00.000Z').toISOString(),
+    source_event_ids: [],
+    hits: 0,
+    overrides: 0,
+  };
+}
+
+function percentile(values: number[], p: number): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const idx = Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1));
+  return sorted[idx];
+}
+

--- a/src/antibodies/__tests__/store.test.ts
+++ b/src/antibodies/__tests__/store.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Failure Antibody store tests
+ */
+
+import { existsSync } from 'node:fs';
+import { mkdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { AntibodyStore } from '../store.js';
+import type { AntibodyRule } from '../types.js';
+
+describe('AntibodyStore', () => {
+  let workDir: string;
+  let store: AntibodyStore;
+
+  beforeEach(async () => {
+    workDir = join(
+      tmpdir(),
+      `savestate-antibody-store-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    await mkdir(workDir, { recursive: true });
+    store = new AntibodyStore(workDir);
+  });
+
+  afterEach(async () => {
+    if (existsSync(workDir)) {
+      await rm(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it('loads empty store when file does not exist', async () => {
+    const loaded = await store.load();
+    expect(loaded.version).toBe(1);
+    expect(loaded.rules).toEqual([]);
+  });
+
+  it('adds and lists rules', async () => {
+    const rule = createRule('ab_test_1');
+    await store.add(rule);
+
+    const allRules = await store.list();
+    const activeRules = await store.list({ activeOnly: true });
+
+    expect(allRules).toHaveLength(1);
+    expect(activeRules).toHaveLength(1);
+    expect(allRules[0].id).toBe('ab_test_1');
+  });
+
+  it('retires rules and excludes them from active listing', async () => {
+    await store.add(createRule('ab_test_2'));
+    const retired = await store.retire('ab_test_2');
+
+    expect(retired).toBe(true);
+
+    const allRules = await store.list();
+    const activeRules = await store.list({ activeOnly: true });
+
+    expect(allRules).toHaveLength(1);
+    expect(allRules[0].retired_at).toBeDefined();
+    expect(activeRules).toHaveLength(0);
+  });
+
+  it('tracks hit and override counters in stats', async () => {
+    await store.add(createRule('ab_test_3'));
+
+    await store.recordHit('ab_test_3');
+    await store.recordHit('ab_test_3');
+    await store.recordOverride('ab_test_3');
+
+    const stats = await store.stats();
+
+    expect(stats.total_hits).toBe(2);
+    expect(stats.total_overrides).toBe(1);
+    expect(stats.rules).toHaveLength(1);
+    expect(stats.rules[0].hits).toBe(2);
+    expect(stats.rules[0].overrides).toBe(1);
+  });
+});
+
+function createRule(id: string): AntibodyRule {
+  return {
+    id,
+    trigger: {
+      tool: 'filesystem',
+      error_codes: ['EACCES'],
+      path_prefixes: ['/tmp'],
+      tags: ['write'],
+    },
+    risk: 'high',
+    safe_action: { type: 'check_permissions' },
+    scope: { project: 'local' },
+    confidence: 0.88,
+    intervention: 'warn',
+    created_at: new Date('2026-02-20T00:00:00.000Z').toISOString(),
+    source_event_ids: [],
+    hits: 0,
+    overrides: 0,
+  };
+}
+

--- a/src/antibodies/compiler.ts
+++ b/src/antibodies/compiler.ts
@@ -1,0 +1,205 @@
+/**
+ * Deterministic FailureEvent -> AntibodyRule compiler (MVP)
+ */
+
+import { createHash } from 'node:crypto';
+import type {
+  AntibodyRule,
+  FailureEvent,
+  RiskLevel,
+  SafeAction,
+  SafeActionType,
+  ToolFailureEvent,
+  UserCorrectionEvent,
+} from './types.js';
+
+const KNOWN_SAFE_ACTIONS: Record<UserCorrectionEvent['correction_code'], SafeActionType> = {
+  wrong_path: 'validate_inputs',
+  missing_permission: 'check_permissions',
+  unsafe_write: 'run_read_only_probe',
+  wrong_tool: 'confirm_with_user',
+  other: 'confirm_with_user',
+};
+
+const TOOL_FAILURE_ACTIONS: Record<string, SafeActionType> = {
+  EACCES: 'check_permissions',
+  EPERM: 'check_permissions',
+  ENOENT: 'validate_inputs',
+  ETIMEDOUT: 'retry_with_backoff',
+  ECONNRESET: 'retry_with_backoff',
+};
+
+const TOOL_FAILURE_RISK: Record<string, RiskLevel> = {
+  EACCES: 'high',
+  EPERM: 'high',
+  ENOENT: 'medium',
+  ETIMEDOUT: 'medium',
+  ECONNRESET: 'medium',
+};
+
+export class AntibodyCompiler {
+  compile(events: FailureEvent[]): AntibodyRule[] {
+    const byId = new Map<string, AntibodyRule>();
+    const sorted = [...events].sort((a, b) => sortEventKey(a).localeCompare(sortEventKey(b)));
+
+    for (const event of sorted) {
+      const rule = this.compileEvent(event);
+      if (rule) {
+        byId.set(rule.id, rule);
+      }
+    }
+
+    return [...byId.values()].sort((a, b) => a.id.localeCompare(b.id));
+  }
+
+  compileEvent(event: FailureEvent): AntibodyRule | null {
+    if (event.type === 'user_correction') {
+      return compileUserCorrection(event);
+    }
+
+    return compileToolFailure(event);
+  }
+}
+
+function compileUserCorrection(event: UserCorrectionEvent): AntibodyRule {
+  const trigger = {
+    tool: normalizeOptionalText(event.tool),
+    error_codes: event.error_code ? [event.error_code.toUpperCase()] : undefined,
+    path_prefixes: event.path ? [toPathPrefix(event.path)] : undefined,
+    tags: normalizeTags(event.tags),
+  };
+
+  const safeAction: SafeAction = event.safe_action ?? {
+    type: KNOWN_SAFE_ACTIONS[event.correction_code],
+  };
+
+  const rule = {
+    trigger,
+    risk: event.risk ?? 'high',
+    safe_action: safeAction,
+    scope: {
+      project: 'local',
+    },
+    confidence: event.safe_action ? 0.95 : 0.9,
+    intervention: 'warn' as const,
+  };
+
+  return {
+    ...rule,
+    id: deriveRuleId(rule),
+    created_at: event.timestamp,
+    source_event_ids: [event.id],
+    hits: 0,
+    overrides: 0,
+  };
+}
+
+function compileToolFailure(event: ToolFailureEvent): AntibodyRule | null {
+  if (!event.hard) {
+    return null;
+  }
+
+  const normalizedCode = event.error_code.toUpperCase();
+  const safeActionType = TOOL_FAILURE_ACTIONS[normalizedCode] ?? 'run_read_only_probe';
+  const risk = TOOL_FAILURE_RISK[normalizedCode] ?? 'medium';
+
+  const rule = {
+    trigger: {
+      tool: normalizeOptionalText(event.tool),
+      error_codes: [normalizedCode],
+      path_prefixes: event.path ? [toPathPrefix(event.path)] : undefined,
+      tags: normalizeTags(event.tags),
+    },
+    risk,
+    safe_action: { type: safeActionType },
+    scope: {
+      project: 'local',
+    },
+    confidence: safeActionType === 'run_read_only_probe' ? 0.72 : 0.8,
+    intervention: 'warn' as const,
+  };
+
+  return {
+    ...rule,
+    id: deriveRuleId(rule),
+    created_at: event.timestamp,
+    source_event_ids: [event.id],
+    hits: 0,
+    overrides: 0,
+  };
+}
+
+export function deriveRuleId(rule: Pick<
+  AntibodyRule,
+  'trigger' | 'risk' | 'safe_action' | 'scope' | 'confidence' | 'intervention'
+>): string {
+  const stable = {
+    trigger: {
+      tool: normalizeOptionalText(rule.trigger.tool),
+      error_codes: rule.trigger.error_codes?.map((value) => value.toUpperCase()).sort(),
+      path_prefixes: rule.trigger.path_prefixes?.map((value) => toPathPrefix(value)).sort(),
+      tags: normalizeTags(rule.trigger.tags),
+    },
+    risk: rule.risk,
+    safe_action: {
+      type: rule.safe_action.type,
+      params: normalizeParams(rule.safe_action.params),
+    },
+    scope: {
+      project: normalizeOptionalText(rule.scope.project),
+      adapters: rule.scope.adapters?.slice().sort(),
+      tags: normalizeTags(rule.scope.tags),
+    },
+    confidence: Number(rule.confidence.toFixed(4)),
+    intervention: rule.intervention,
+  };
+
+  const digest = createHash('sha256').update(JSON.stringify(stable)).digest('hex');
+  return `ab_${digest.slice(0, 16)}`;
+}
+
+function normalizeOptionalText(input?: string): string | undefined {
+  const value = input?.trim();
+  return value ? value : undefined;
+}
+
+function normalizeTags(tags?: string[]): string[] | undefined {
+  if (!tags || tags.length === 0) {
+    return undefined;
+  }
+
+  return [...new Set(tags.map((tag) => tag.trim().toLowerCase()).filter(Boolean))].sort();
+}
+
+function normalizeParams(
+  params: Record<string, string | number | boolean> | undefined,
+): Record<string, string | number | boolean> | undefined {
+  if (!params) {
+    return undefined;
+  }
+
+  const normalized: Record<string, string | number | boolean> = {};
+  const keys = Object.keys(params).sort();
+  for (const key of keys) {
+    normalized[key] = params[key];
+  }
+  return normalized;
+}
+
+function toPathPrefix(path: string): string {
+  const trimmed = path.trim();
+  const normalized = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+  const parts = normalized.split('/').filter(Boolean);
+
+  if (parts.length === 0) {
+    return '/';
+  }
+
+  const size = Math.min(2, parts.length);
+  return `/${parts.slice(0, size).join('/')}`;
+}
+
+function sortEventKey(event: FailureEvent): string {
+  return `${event.timestamp}|${event.id}`;
+}
+

--- a/src/antibodies/engine.ts
+++ b/src/antibodies/engine.ts
@@ -1,0 +1,137 @@
+/**
+ * Failure Antibody preflight engine (MVP, warn-only)
+ */
+
+import { performance } from 'node:perf_hooks';
+import { AntibodyStore } from './store.js';
+import type { AntibodyRule, PreflightContext, PreflightResult, PreflightWarning } from './types.js';
+
+export interface AntibodyEngineOptions {
+  enableSemanticMatching?: boolean;
+}
+
+export interface PreflightOptions {
+  updateHitCounters?: boolean;
+}
+
+export class AntibodyEngine {
+  constructor(
+    private readonly store: AntibodyStore,
+    private readonly options: AntibodyEngineOptions = {},
+  ) {}
+
+  async preflight(context: PreflightContext, options: PreflightOptions = {}): Promise<PreflightResult> {
+    const started = performance.now();
+    const rules = await this.store.list({ activeOnly: true });
+    const warnings: PreflightWarning[] = [];
+    const matchedRuleIds: string[] = [];
+    const semanticEnabled = Boolean(this.options.enableSemanticMatching);
+
+    for (const rule of rules) {
+      const reasonCodes = this.matchRule(rule, context);
+      if (reasonCodes.length === 0) {
+        continue;
+      }
+
+      warnings.push({
+        rule_id: rule.id,
+        intervention: rule.intervention,
+        risk: rule.risk,
+        safe_action: rule.safe_action,
+        confidence: rule.confidence,
+        reason_codes: reasonCodes,
+      });
+      matchedRuleIds.push(rule.id);
+    }
+
+    if (semanticEnabled && context.semantic_text) {
+      // Stubbed for MVP. Semantic matching is intentionally disabled by default.
+      this.semanticMatchStub(context.semantic_text, rules);
+    }
+
+    if (options.updateHitCounters) {
+      for (const ruleId of matchedRuleIds) {
+        await this.store.recordHit(ruleId);
+      }
+    }
+
+    warnings.sort((a, b) => b.confidence - a.confidence || a.rule_id.localeCompare(b.rule_id));
+    const elapsedMs = performance.now() - started;
+
+    return {
+      warnings,
+      blocked: warnings.some((warning) => warning.intervention === 'block'),
+      elapsed_ms: Number(elapsedMs.toFixed(3)),
+      semantic_used: semanticEnabled && Boolean(context.semantic_text),
+      matched_rule_ids: matchedRuleIds,
+    };
+  }
+
+  private matchRule(
+    rule: AntibodyRule,
+    context: PreflightContext,
+  ): Array<'tool' | 'error_code' | 'path_prefix' | 'tag' | 'semantic'> {
+    const reasonCodes: Array<'tool' | 'error_code' | 'path_prefix' | 'tag' | 'semantic'> = [];
+    const trigger = rule.trigger;
+
+    if (!trigger.tool && !trigger.error_codes?.length && !trigger.path_prefixes?.length && !trigger.tags?.length) {
+      return reasonCodes;
+    }
+
+    // Cheap matcher 1: tool name
+    if (trigger.tool) {
+      if (!context.tool || context.tool !== trigger.tool) {
+        return [];
+      }
+      reasonCodes.push('tool');
+    }
+
+    // Cheap matcher 2: error code
+    if (trigger.error_codes && trigger.error_codes.length > 0) {
+      if (!context.error_code) {
+        return [];
+      }
+
+      const matched = trigger.error_codes.includes(context.error_code.toUpperCase());
+      if (!matched) {
+        return [];
+      }
+      reasonCodes.push('error_code');
+    }
+
+    // Cheap matcher 3: path prefix
+    if (trigger.path_prefixes && trigger.path_prefixes.length > 0) {
+      if (!context.path) {
+        return [];
+      }
+
+      const matched = trigger.path_prefixes.some((prefix) => context.path!.startsWith(prefix));
+      if (!matched) {
+        return [];
+      }
+      reasonCodes.push('path_prefix');
+    }
+
+    // Cheap matcher 4: tags
+    if (trigger.tags && trigger.tags.length > 0) {
+      if (!context.tags || context.tags.length === 0) {
+        return [];
+      }
+
+      const tagSet = new Set(context.tags.map((tag) => tag.toLowerCase()));
+      const matched = trigger.tags.some((tag) => tagSet.has(tag.toLowerCase()));
+      if (!matched) {
+        return [];
+      }
+      reasonCodes.push('tag');
+    }
+
+    return reasonCodes;
+  }
+
+  // Intentionally no semantic scoring for MVP.
+  private semanticMatchStub(_semanticText: string, _rules: AntibodyRule[]): void {
+    return;
+  }
+}
+

--- a/src/antibodies/index.ts
+++ b/src/antibodies/index.ts
@@ -1,0 +1,31 @@
+/**
+ * Failure Antibody System (MVP)
+ */
+
+export type {
+  Intervention,
+  RiskLevel,
+  SafeActionType,
+  SafeAction,
+  FailureEvent,
+  FailureEventBase,
+  UserCorrectionEvent,
+  ToolFailureEvent,
+  AntibodyTrigger,
+  AntibodyScope,
+  AntibodyRule,
+  AntibodyStoreFile,
+  AntibodyStats,
+  PreflightContext,
+  PreflightWarning,
+  PreflightResult,
+} from './types.js';
+
+export { AntibodyStore } from './store.js';
+export type { ListRulesOptions } from './store.js';
+
+export { AntibodyCompiler, deriveRuleId } from './compiler.js';
+
+export { AntibodyEngine } from './engine.js';
+export type { AntibodyEngineOptions, PreflightOptions } from './engine.js';
+

--- a/src/antibodies/store.ts
+++ b/src/antibodies/store.ts
@@ -1,0 +1,161 @@
+/**
+ * Failure Antibody JSON store (.savestate/antibodies.json)
+ */
+
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { localConfigDir } from '../config.js';
+import type { AntibodyRule, AntibodyStats, AntibodyStoreFile } from './types.js';
+
+const ANTIBODIES_FILE = 'antibodies.json';
+
+export interface ListRulesOptions {
+  activeOnly?: boolean;
+}
+
+export class AntibodyStore {
+  constructor(
+    private readonly cwd?: string,
+    private readonly now: () => Date = () => new Date(),
+  ) {}
+
+  path(): string {
+    return join(localConfigDir(this.cwd), ANTIBODIES_FILE);
+  }
+
+  async load(): Promise<AntibodyStoreFile> {
+    const path = this.path();
+    if (!existsSync(path)) {
+      return { version: 1, rules: [] };
+    }
+
+    try {
+      const raw = await readFile(path, 'utf-8');
+      const parsed = JSON.parse(raw) as Partial<AntibodyStoreFile>;
+      return this.normalizeStoreFile(parsed);
+    } catch {
+      return { version: 1, rules: [] };
+    }
+  }
+
+  async save(file: AntibodyStoreFile): Promise<void> {
+    const dir = localConfigDir(this.cwd);
+    await mkdir(dir, { recursive: true });
+    const path = this.path();
+    await writeFile(path, JSON.stringify(file, null, 2) + '\n', 'utf-8');
+  }
+
+  async list(options?: ListRulesOptions): Promise<AntibodyRule[]> {
+    const file = await this.load();
+    const rules = options?.activeOnly
+      ? file.rules.filter((rule) => !rule.retired_at)
+      : file.rules;
+
+    return [...rules].sort((a, b) => a.id.localeCompare(b.id));
+  }
+
+  async add(rule: AntibodyRule): Promise<AntibodyRule> {
+    const file = await this.load();
+    const normalizedRule = this.normalizeRule(rule);
+    const existing = file.rules.find((candidate) => candidate.id === normalizedRule.id);
+
+    if (existing) {
+      return existing;
+    }
+
+    file.rules.push(normalizedRule);
+    await this.save(file);
+    return normalizedRule;
+  }
+
+  async retire(ruleId: string): Promise<boolean> {
+    const file = await this.load();
+    const rule = file.rules.find((candidate) => candidate.id === ruleId);
+
+    if (!rule || rule.retired_at) {
+      return false;
+    }
+
+    rule.retired_at = this.now().toISOString();
+    await this.save(file);
+    return true;
+  }
+
+  async recordHit(ruleId: string): Promise<boolean> {
+    return this.bumpCounter(ruleId, 'hits');
+  }
+
+  async recordOverride(ruleId: string): Promise<boolean> {
+    return this.bumpCounter(ruleId, 'overrides');
+  }
+
+  async stats(): Promise<AntibodyStats> {
+    const file = await this.load();
+    const totalRules = file.rules.length;
+    const activeRules = file.rules.filter((rule) => !rule.retired_at).length;
+    const retiredRules = totalRules - activeRules;
+    const totalHits = file.rules.reduce((sum, rule) => sum + rule.hits, 0);
+    const totalOverrides = file.rules.reduce((sum, rule) => sum + rule.overrides, 0);
+
+    return {
+      total_rules: totalRules,
+      active_rules: activeRules,
+      retired_rules: retiredRules,
+      total_hits: totalHits,
+      total_overrides: totalOverrides,
+      rules: file.rules.map((rule) => ({
+        id: rule.id,
+        risk: rule.risk,
+        intervention: rule.intervention,
+        active: !rule.retired_at,
+        confidence: rule.confidence,
+        hits: rule.hits,
+        overrides: rule.overrides,
+      })),
+    };
+  }
+
+  private normalizeStoreFile(raw: Partial<AntibodyStoreFile>): AntibodyStoreFile {
+    const rules = Array.isArray(raw.rules) ? raw.rules : [];
+    return {
+      version: 1,
+      rules: rules.map((rule) => this.normalizeRule(rule as AntibodyRule)),
+    };
+  }
+
+  private normalizeRule(rule: AntibodyRule): AntibodyRule {
+    return {
+      ...rule,
+      created_at: rule.created_at || this.now().toISOString(),
+      source_event_ids: Array.isArray(rule.source_event_ids) ? rule.source_event_ids : [],
+      hits: Number.isFinite(rule.hits) ? rule.hits : 0,
+      overrides: Number.isFinite(rule.overrides) ? rule.overrides : 0,
+      trigger: {
+        tool: rule.trigger?.tool,
+        error_codes: rule.trigger?.error_codes?.slice(),
+        path_prefixes: rule.trigger?.path_prefixes?.slice(),
+        tags: rule.trigger?.tags?.slice(),
+      },
+      scope: {
+        project: rule.scope?.project,
+        adapters: rule.scope?.adapters?.slice(),
+        tags: rule.scope?.tags?.slice(),
+      },
+    };
+  }
+
+  private async bumpCounter(ruleId: string, key: 'hits' | 'overrides'): Promise<boolean> {
+    const file = await this.load();
+    const rule = file.rules.find((candidate) => candidate.id === ruleId);
+
+    if (!rule) {
+      return false;
+    }
+
+    rule[key] += 1;
+    await this.save(file);
+    return true;
+  }
+}
+

--- a/src/antibodies/types.ts
+++ b/src/antibodies/types.ts
@@ -1,0 +1,119 @@
+/**
+ * Failure Antibody System (MVP) types
+ */
+
+export type Intervention = 'warn' | 'block' | 'confirm';
+
+export type RiskLevel = 'low' | 'medium' | 'high' | 'critical';
+
+export type SafeActionType =
+  | 'retry_with_backoff'
+  | 'check_permissions'
+  | 'validate_inputs'
+  | 'run_read_only_probe'
+  | 'confirm_with_user';
+
+export interface SafeAction {
+  type: SafeActionType;
+  params?: Record<string, string | number | boolean>;
+}
+
+export type FailureEvent = UserCorrectionEvent | ToolFailureEvent;
+
+export interface FailureEventBase {
+  id: string;
+  timestamp: string;
+  tool?: string;
+  path?: string;
+  tags?: string[];
+}
+
+export interface UserCorrectionEvent extends FailureEventBase {
+  type: 'user_correction';
+  correction_code: 'wrong_path' | 'missing_permission' | 'unsafe_write' | 'wrong_tool' | 'other';
+  error_code?: string;
+  risk?: RiskLevel;
+  safe_action?: SafeAction;
+}
+
+export interface ToolFailureEvent extends FailureEventBase {
+  type: 'tool_failure';
+  error_code: string;
+  hard: boolean;
+  exit_code?: number;
+}
+
+export interface AntibodyTrigger {
+  tool?: string;
+  error_codes?: string[];
+  path_prefixes?: string[];
+  tags?: string[];
+}
+
+export interface AntibodyScope {
+  project?: string;
+  adapters?: string[];
+  tags?: string[];
+}
+
+export interface AntibodyRule {
+  id: string;
+  trigger: AntibodyTrigger;
+  risk: RiskLevel;
+  safe_action: SafeAction;
+  scope: AntibodyScope;
+  confidence: number;
+  intervention: Intervention;
+  created_at: string;
+  retired_at?: string;
+  source_event_ids: string[];
+  hits: number;
+  overrides: number;
+}
+
+export interface AntibodyStoreFile {
+  version: 1;
+  rules: AntibodyRule[];
+}
+
+export interface AntibodyStats {
+  total_rules: number;
+  active_rules: number;
+  retired_rules: number;
+  total_hits: number;
+  total_overrides: number;
+  rules: Array<{
+    id: string;
+    risk: RiskLevel;
+    intervention: Intervention;
+    active: boolean;
+    confidence: number;
+    hits: number;
+    overrides: number;
+  }>;
+}
+
+export interface PreflightContext {
+  tool?: string;
+  error_code?: string;
+  path?: string;
+  tags?: string[];
+  semantic_text?: string;
+}
+
+export interface PreflightWarning {
+  rule_id: string;
+  intervention: Intervention;
+  risk: RiskLevel;
+  safe_action: SafeAction;
+  confidence: number;
+  reason_codes: Array<'tool' | 'error_code' | 'path_prefix' | 'tag' | 'semantic'>;
+}
+
+export interface PreflightResult {
+  warnings: PreflightWarning[];
+  blocked: boolean;
+  elapsed_ms: number;
+  semantic_used: boolean;
+  matched_rule_ids: string[];
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@
  *   savestate diff <a> <b>            Compare two snapshots
  *   savestate config                  View/edit configuration
  *   savestate adapters                List available adapters
+ *   savestate antibodies              Manage failure antibodies
  */
 
 import { Command } from 'commander';
@@ -25,6 +26,7 @@ import {
   diffCommand,
   configCommand,
   adaptersCommand,
+  antibodiesCommand,
 } from './commands/index.js';
 import { loginCommand, logoutCommand } from './commands/login.js';
 
@@ -100,6 +102,25 @@ program
   .command('adapters')
   .description('List available platform adapters')
   .action(adaptersCommand);
+
+// ─── savestate antibodies ───────────────────────────────────
+
+program
+  .command('antibodies <subcommand>')
+  .description('Failure antibody system (list, add, preflight, stats)')
+  .option('--id <id>', 'Rule ID (for manual add)')
+  .option('--all', 'Include retired rules in list')
+  .option('--json', 'Output as JSON')
+  .option('--tool <tool>', 'Tool name in trigger/context')
+  .option('--error-code <code>', 'Error code in trigger/context')
+  .option('--path <path>', 'Path in preflight context')
+  .option('--path-prefix <prefix>', 'Path prefix in rule trigger')
+  .option('--tags <tags>', 'Comma-separated tags')
+  .option('--risk <risk>', 'Risk level (low, medium, high, critical)')
+  .option('--safe-action <type>', 'Safe action type for manual rule')
+  .option('--confidence <0..1>', 'Rule confidence (0-1)')
+  .option('--semantic', 'Enable semantic matcher stub')
+  .action(antibodiesCommand);
 
 // ─── savestate search ────────────────────────────────────────
 

--- a/src/commands/antibodies.ts
+++ b/src/commands/antibodies.ts
@@ -1,0 +1,288 @@
+/**
+ * savestate antibodies — Failure antibody commands
+ */
+
+import chalk from 'chalk';
+import { isInitialized } from '../config.js';
+import { AntibodyEngine, AntibodyStore, deriveRuleId } from '../antibodies/index.js';
+import type {
+  AntibodyRule,
+  PreflightContext,
+  RiskLevel,
+  SafeActionType,
+} from '../antibodies/index.js';
+
+interface AntibodiesOptions {
+  id?: string;
+  all?: boolean;
+  json?: boolean;
+  tool?: string;
+  errorCode?: string;
+  path?: string;
+  pathPrefix?: string;
+  tags?: string;
+  risk?: string;
+  safeAction?: string;
+  confidence?: string;
+  semantic?: boolean;
+}
+
+const RISK_LEVELS: RiskLevel[] = ['low', 'medium', 'high', 'critical'];
+const SAFE_ACTION_TYPES: SafeActionType[] = [
+  'retry_with_backoff',
+  'check_permissions',
+  'validate_inputs',
+  'run_read_only_probe',
+  'confirm_with_user',
+];
+
+export async function antibodiesCommand(subcommand: string, options: AntibodiesOptions): Promise<void> {
+  console.log();
+
+  if (!isInitialized()) {
+    console.log(chalk.red('✗ SaveState not initialized. Run `savestate init` first.'));
+    process.exit(1);
+  }
+
+  const store = new AntibodyStore();
+
+  switch (subcommand) {
+    case 'list':
+      await listRules(store, options);
+      return;
+    case 'add':
+      await addRule(store, options);
+      return;
+    case 'preflight':
+      await runPreflight(store, options);
+      return;
+    case 'stats':
+      await showStats(store, options);
+      return;
+    default:
+      showUsage();
+      process.exit(1);
+  }
+}
+
+async function listRules(store: AntibodyStore, options: AntibodiesOptions): Promise<void> {
+  const rules = await store.list({ activeOnly: !options.all });
+
+  if (options.json) {
+    console.log(JSON.stringify(rules, null, 2));
+    return;
+  }
+
+  console.log(chalk.bold('🧬 Failure Antibodies'));
+  console.log(chalk.dim(`   ${store.path()}`));
+  console.log();
+
+  if (rules.length === 0) {
+    console.log(chalk.dim('  No antibody rules found.'));
+    console.log(chalk.dim('  Create one: savestate antibodies add --tool <name> --error-code <code>'));
+    console.log();
+    return;
+  }
+
+  for (const rule of rules) {
+    const state = rule.retired_at ? chalk.dim('retired') : chalk.green('active');
+    const confidence = `${Math.round(rule.confidence * 100)}%`;
+    console.log(
+      `  ${chalk.cyan(rule.id)}  ${rule.risk.padEnd(8)} ${rule.intervention.padEnd(7)} ${confidence.padEnd(4)} ${state}`,
+    );
+    console.log(`    trigger: ${formatTrigger(rule)}`);
+    console.log(`    safe_action: ${rule.safe_action.type}  hits: ${rule.hits}  overrides: ${rule.overrides}`);
+  }
+
+  console.log();
+}
+
+async function addRule(store: AntibodyStore, options: AntibodiesOptions): Promise<void> {
+  const tags = parseTags(options.tags);
+  const risk = parseRisk(options.risk);
+  const safeAction = parseSafeAction(options.safeAction);
+  const confidence = parseConfidence(options.confidence);
+  const pathPrefix = normalizePathPrefix(options.pathPrefix);
+  const errorCode = options.errorCode?.toUpperCase();
+
+  if (!options.tool && !errorCode && !pathPrefix && tags.length === 0) {
+    console.log(chalk.red('✗ Provide at least one trigger: --tool, --error-code, --path-prefix, or --tags'));
+    process.exit(1);
+  }
+
+  const partialRule = {
+    trigger: {
+      tool: options.tool?.trim(),
+      error_codes: errorCode ? [errorCode] : undefined,
+      path_prefixes: pathPrefix ? [pathPrefix] : undefined,
+      tags: tags.length > 0 ? tags : undefined,
+    },
+    risk,
+    safe_action: { type: safeAction },
+    scope: {
+      project: 'local',
+    },
+    confidence,
+    intervention: 'warn' as const,
+  };
+
+  const rule: AntibodyRule = {
+    ...partialRule,
+    id: options.id ?? deriveRuleId(partialRule),
+    created_at: new Date().toISOString(),
+    source_event_ids: [],
+    hits: 0,
+    overrides: 0,
+  };
+
+  const created = await store.add(rule);
+
+  console.log(chalk.green(`✓ Antibody rule saved: ${created.id}`));
+  console.log(chalk.dim(`  safe_action=${created.safe_action.type} confidence=${created.confidence}`));
+  console.log();
+}
+
+async function runPreflight(store: AntibodyStore, options: AntibodiesOptions): Promise<void> {
+  const context: PreflightContext = {
+    tool: options.tool?.trim(),
+    error_code: options.errorCode?.toUpperCase(),
+    path: options.path,
+    tags: parseTags(options.tags),
+  };
+
+  const engine = new AntibodyEngine(store, {
+    enableSemanticMatching: options.semantic,
+  });
+
+  const result = await engine.preflight(context);
+
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  console.log(chalk.bold('🔎 Antibody Preflight'));
+  console.log(chalk.dim(`   elapsed=${result.elapsed_ms}ms semantic=${result.semantic_used ? 'on' : 'off'}`));
+  console.log();
+
+  if (result.warnings.length === 0) {
+    console.log(chalk.green('  No warnings.'));
+    console.log();
+    return;
+  }
+
+  for (const warning of result.warnings) {
+    console.log(
+      `  ${chalk.yellow('warn')} ${chalk.cyan(warning.rule_id)} ${warning.risk} ${warning.safe_action.type} confidence=${warning.confidence.toFixed(2)}`,
+    );
+    console.log(`    reasons: ${warning.reason_codes.join(', ')}`);
+  }
+
+  console.log();
+}
+
+async function showStats(store: AntibodyStore, options: AntibodiesOptions): Promise<void> {
+  const stats = await store.stats();
+
+  if (options.json) {
+    console.log(JSON.stringify(stats, null, 2));
+    return;
+  }
+
+  console.log(chalk.bold('📈 Antibody Stats'));
+  console.log(chalk.dim(`   ${store.path()}`));
+  console.log();
+  console.log(`  total rules:     ${stats.total_rules}`);
+  console.log(`  active rules:    ${stats.active_rules}`);
+  console.log(`  retired rules:   ${stats.retired_rules}`);
+  console.log(`  total hits:      ${stats.total_hits}`);
+  console.log(`  total overrides: ${stats.total_overrides}`);
+  console.log();
+
+  if (stats.rules.length > 0) {
+    const top = [...stats.rules]
+      .sort((a, b) => b.hits - a.hits || a.id.localeCompare(b.id))
+      .slice(0, 10);
+    console.log(chalk.dim('  Top rules by hits:'));
+    for (const rule of top) {
+      console.log(`    ${rule.id}  hits=${rule.hits} overrides=${rule.overrides} active=${rule.active}`);
+    }
+    console.log();
+  }
+}
+
+function parseTags(raw?: string): string[] {
+  if (!raw) return [];
+  return [...new Set(raw.split(',').map((token) => token.trim().toLowerCase()).filter(Boolean))];
+}
+
+function parseRisk(raw?: string): RiskLevel {
+  if (!raw) return 'medium';
+  const normalized = raw.trim().toLowerCase();
+  if (RISK_LEVELS.includes(normalized as RiskLevel)) {
+    return normalized as RiskLevel;
+  }
+
+  console.log(chalk.red(`✗ Invalid risk: ${raw}`));
+  console.log(chalk.dim(`  Allowed: ${RISK_LEVELS.join(', ')}`));
+  process.exit(1);
+}
+
+function parseSafeAction(raw?: string): SafeActionType {
+  if (!raw) return 'validate_inputs';
+  const normalized = raw.trim().toLowerCase() as SafeActionType;
+  if (SAFE_ACTION_TYPES.includes(normalized)) {
+    return normalized;
+  }
+
+  console.log(chalk.red(`✗ Invalid safe action: ${raw}`));
+  console.log(chalk.dim(`  Allowed: ${SAFE_ACTION_TYPES.join(', ')}`));
+  process.exit(1);
+}
+
+function parseConfidence(raw?: string): number {
+  if (!raw) return 0.7;
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value < 0 || value > 1) {
+    console.log(chalk.red('✗ --confidence must be a number between 0 and 1'));
+    process.exit(1);
+  }
+  return Number(value.toFixed(3));
+}
+
+function normalizePathPrefix(raw?: string): string | undefined {
+  if (!raw) return undefined;
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+  return trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+}
+
+function formatTrigger(rule: AntibodyRule): string {
+  const parts: string[] = [];
+  if (rule.trigger.tool) {
+    parts.push(`tool=${rule.trigger.tool}`);
+  }
+  if (rule.trigger.error_codes?.length) {
+    parts.push(`error=${rule.trigger.error_codes.join('|')}`);
+  }
+  if (rule.trigger.path_prefixes?.length) {
+    parts.push(`path=${rule.trigger.path_prefixes.join('|')}`);
+  }
+  if (rule.trigger.tags?.length) {
+    parts.push(`tags=${rule.trigger.tags.join('|')}`);
+  }
+  return parts.join(' ');
+}
+
+function showUsage(): void {
+  console.log(chalk.bold('Failure Antibody commands:'));
+  console.log();
+  console.log('  savestate antibodies list [--all] [--json]');
+  console.log('  savestate antibodies add --tool <name> [--error-code <code>] [--path-prefix <prefix>]');
+  console.log('                             [--tags <a,b>] [--risk <level>] [--safe-action <type>]');
+  console.log('                             [--confidence <0..1>] [--id <rule-id>]');
+  console.log('  savestate antibodies preflight [--tool <name>] [--error-code <code>] [--path <path>]');
+  console.log('                                  [--tags <a,b>] [--semantic] [--json]');
+  console.log('  savestate antibodies stats [--json]');
+  console.log();
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -9,3 +9,4 @@ export { listCommand } from './list.js';
 export { diffCommand } from './diff.js';
 export { configCommand } from './config.js';
 export { adaptersCommand } from './adapters.js';
+export { antibodiesCommand } from './antibodies.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,3 +103,32 @@ export {
   detectAdapter,
   getAdapterInfo,
 } from './adapters/index.js';
+
+// Failure Antibody System (MVP)
+export {
+  AntibodyStore,
+  AntibodyCompiler,
+  deriveRuleId,
+  AntibodyEngine,
+} from './antibodies/index.js';
+export type {
+  Intervention,
+  RiskLevel,
+  SafeActionType,
+  SafeAction,
+  FailureEvent,
+  FailureEventBase,
+  UserCorrectionEvent,
+  ToolFailureEvent,
+  AntibodyTrigger,
+  AntibodyScope,
+  AntibodyRule,
+  AntibodyStoreFile,
+  AntibodyStats,
+  PreflightContext,
+  PreflightWarning,
+  PreflightResult,
+  AntibodyEngineOptions,
+  PreflightOptions,
+  ListRulesOptions,
+} from './antibodies/index.js';


### PR DESCRIPTION
## Summary
Implements an MVP **Failure Antibody System**: deterministic rules compiled from high-signal failures, stored locally, and evaluated via a warn-only preflight.

## Changes
- New module `src/antibodies/`:
  - Types for `FailureEvent` / `AntibodyRule` / `Preflight*`
  - JSON-backed store at `.savestate/antibodies.json` (load/save/list/add/retire/stats + hit/override counters)
  - Deterministic compiler for explicit user corrections + hard tool failures (no free-text generation)
  - Preflight engine with cheap matchers first (`tool`, `error_code`, `path_prefix`, `tags`); semantic matcher is stubbed behind a flag and **off by default**
- New CLI surface:
  - `savestate antibodies list|add|preflight|stats`
- Exported antibody APIs from `src/index.ts`
- Added vitest coverage for store/compiler/engine

## Testing
- [x] `npm test`

## Related Issues
Closes #74
