### PR TITLE
feat(retrieval): add explainability inspector - 'Why this memory?'

### DIFF
--- a/src/checkpoint/index.ts
+++ b/src/checkpoint/index.ts
@@ -15,37 +15,43 @@ export {
   // Namespace
   Namespace,
   namespaceKey,
-  
+
   // Goals & Tasks
   Goal,
   Task,
   Action,
-  
+
   // Checkpoints
   Checkpoint,
   CreateCheckpointInput,
-  
+
   // Memory
   MemoryObject,
   MemorySource,
   MemoryIngestionMetadata,
   ProvenanceEntry,
   CreateMemoryInput,
-  
+
   // Retrieval
   MemoryQuery,
   RankingWeights,
   DEFAULT_RANKING_WEIGHTS,
   MemoryResult,
-  
+
+  // Retrieval Explainability (Issue #115)
+  RetrievalExplanation,
+  ScoreBreakdown,
+  SourceTrace,
+  PolicyPath,
+
   // Restore
   ResumePack,
   RestoreRationale,
   RestoreOptions,
-  
+
   // Audit
   AuditEntry,
-  
+
   // Storage
   CheckpointStorage,
   ListOptions,

--- a/src/checkpoint/storage/memory.ts
+++ b/src/checkpoint/storage/memory.ts
@@ -17,8 +17,13 @@ import {
   Namespace,
   namespaceKey,
   ProvenanceEntry,
+  RetrievalExplanation,
+  ScoreBreakdown,
+  SourceTrace,
+  PolicyPath,
+  DEFAULT_RANKING_WEIGHTS,
 } from '../types.js';
-import { calculateMemoryScore } from '../memory.js';
+import { calculateMemoryScore, calculateRecencyScore } from '../memory.js';
 
 /**
  * Simple cosine similarity for vector comparison.
@@ -110,6 +115,129 @@ function daysBetween(aIso: string, bIso: string): number {
   const a = new Date(aIso).getTime();
   const b = new Date(bIso).getTime();
   return Math.max(0, (b - a) / (24 * 60 * 60 * 1000));
+}
+
+/**
+ * Generate a detailed explanation for why a memory was retrieved.
+ */
+function generateExplanation(
+  memory: MemoryObject,
+  semanticSimilarity: number,
+  finalScore: number,
+  components: MemoryResult['score_components'],
+  query: MemoryQuery
+): RetrievalExplanation {
+  const weights = query.ranking_weights ?? DEFAULT_RANKING_WEIGHTS;
+  const recencyScore = calculateRecencyScore(memory.created_at, memory.last_accessed_at);
+
+  // Build score breakdown
+  const scoreBreakdown: ScoreBreakdown = {
+    semantic_similarity: semanticSimilarity,
+    recency_decay: recencyScore,
+    importance: memory.importance,
+    task_criticality: memory.task_criticality,
+    confidence_boost: memory.ingestion?.confidence_score ?? 1.0,
+  };
+
+  // Build source trace
+  const sourceTrace: SourceTrace = {
+    snapshot_id: memory.checkpoint_refs[0],
+    adapter: memory.source.metadata?.adapter as string | undefined,
+    ingestion_timestamp: memory.ingestion?.ingestion_timestamp ?? memory.created_at,
+    source_type: memory.source.type,
+    source_id: memory.source.identifier,
+  };
+
+  // Build policy path
+  const rulesApplied: string[] = [];
+  const filtersMatched: string[] = [];
+  const boostsApplied: string[] = [];
+
+  // Document which filters were applied
+  if (query.tags && query.tags.length > 0) {
+    filtersMatched.push(`tags: [${query.tags.join(', ')}]`);
+  }
+  if (query.source_types && query.source_types.length > 0) {
+    filtersMatched.push(`source_types: [${query.source_types.join(', ')}]`);
+  }
+  if (query.min_importance !== undefined) {
+    filtersMatched.push(`min_importance >= ${query.min_importance}`);
+  }
+  if (query.min_semantic_similarity !== undefined) {
+    filtersMatched.push(`min_semantic_similarity >= ${query.min_semantic_similarity}`);
+  }
+  if (query.max_age_seconds !== undefined) {
+    filtersMatched.push(`max_age_seconds <= ${query.max_age_seconds}`);
+  }
+
+  // Document ranking rules
+  rulesApplied.push(`task_criticality weight: ${weights.task_criticality}`);
+  rulesApplied.push(`semantic_similarity weight: ${weights.semantic_similarity}`);
+  rulesApplied.push(`importance weight: ${weights.importance}`);
+  rulesApplied.push(`recency_decay weight: ${weights.recency_decay}`);
+
+  // Document boosts
+  if (memory.importance > 0.7) {
+    boostsApplied.push(`high importance (${memory.importance.toFixed(2)})`);
+  }
+  if (memory.task_criticality > 0.7) {
+    boostsApplied.push(`high task criticality (${memory.task_criticality.toFixed(2)})`);
+  }
+  if (semanticSimilarity > 0.8) {
+    boostsApplied.push(`strong semantic match (${semanticSimilarity.toFixed(2)})`);
+  }
+  if (recencyScore > 0.8) {
+    boostsApplied.push(`recent memory (recency: ${recencyScore.toFixed(2)})`);
+  }
+
+  const policyPath: PolicyPath = {
+    rules_applied: rulesApplied,
+    filters_matched: filtersMatched,
+    boosts_applied: boostsApplied,
+  };
+
+  // Generate human-readable summary
+  const summaryParts: string[] = [];
+
+  const topFactor = Object.entries(components)
+    .sort(([, a], [, b]) => b - a)[0];
+
+  if (topFactor) {
+    const factorNames: Record<string, string> = {
+      task_criticality: 'task criticality',
+      semantic_similarity: 'semantic relevance',
+      importance: 'importance',
+      recency: 'recency',
+    };
+    summaryParts.push(`Primary factor: ${factorNames[topFactor[0]] ?? topFactor[0]} (${(topFactor[1] * 100).toFixed(1)}% contribution)`);
+  }
+
+  if (query.query && semanticSimilarity > 0.5) {
+    summaryParts.push(`Matches query "${query.query.slice(0, 30)}${query.query.length > 30 ? '...' : ''}"`);
+  }
+
+  if (memory.tags.length > 0) {
+    summaryParts.push(`Tags: ${memory.tags.slice(0, 3).join(', ')}${memory.tags.length > 3 ? '...' : ''}`);
+  }
+
+  const ageDays = daysBetween(memory.created_at, new Date().toISOString());
+  if (ageDays < 1) {
+    summaryParts.push('Created today');
+  } else if (ageDays < 7) {
+    summaryParts.push(`Created ${Math.floor(ageDays)} day(s) ago`);
+  } else {
+    summaryParts.push(`Created ${Math.floor(ageDays / 7)} week(s) ago`);
+  }
+
+  return {
+    memory_id: memory.memory_id,
+    relevance_score_breakdown: scoreBreakdown,
+    source_trace: sourceTrace,
+    timestamp_weight: recencyScore,
+    policy_path: policyPath,
+    final_score: finalScore,
+    summary: summaryParts.join('. ') + '.',
+  };
 }
 
 export class InMemoryCheckpointStorage implements CheckpointStorage {
@@ -329,6 +457,18 @@ export class InMemoryCheckpointStorage implements CheckpointStorage {
           source: mem.source,
           provenance: mem.provenance,
         };
+
+        // Generate explanation if requested
+        if (query.explain) {
+          result.explanation = generateExplanation(
+            mem,
+            semanticSimilarity,
+            score,
+            components,
+            query
+          );
+        }
+
         return result;
       })
       .filter((r): r is MemoryResult => r !== null);

--- a/src/checkpoint/types.ts
+++ b/src/checkpoint/types.ts
@@ -278,6 +278,14 @@ export interface MemoryQuery {
 
   /** Custom ranking weights (overrides defaults) */
   ranking_weights?: RankingWeights;
+
+  /**
+   * Include detailed explanation of why each memory was retrieved.
+   * When true, each result will include a RetrievalExplanation.
+   *
+   * @see https://github.com/savestatedev/savestate/issues/115
+   */
+  explain?: boolean;
 }
 
 /**
@@ -323,6 +331,86 @@ export interface MemoryResult {
   tags: string[];
   source: MemorySource;
   provenance: ProvenanceEntry[];
+
+  /**
+   * Detailed explanation of why this memory was retrieved.
+   * Only populated when explain=true is set in the query.
+   */
+  explanation?: RetrievalExplanation;
+}
+
+// ─── Retrieval Explainability ────────────────────────────────
+
+/**
+ * Detailed breakdown of relevance score components.
+ * Shows how each factor contributed to the final score.
+ *
+ * @see https://github.com/savestatedev/savestate/issues/115
+ */
+export interface ScoreBreakdown {
+  /** Semantic similarity to query (0-1) */
+  semantic_similarity: number;
+  /** Recency decay factor (0-1, 1 = very recent) */
+  recency_decay: number;
+  /** Base importance score (0-1) */
+  importance: number;
+  /** Task criticality score (0-1) */
+  task_criticality: number;
+  /** Confidence boost from ingestion validation (0-1) */
+  confidence_boost: number;
+}
+
+/**
+ * Trace of where this memory came from.
+ * Provides full provenance for auditability.
+ */
+export interface SourceTrace {
+  /** Snapshot ID where this memory was created (if applicable) */
+  snapshot_id?: string;
+  /** Adapter that ingested this memory */
+  adapter?: string;
+  /** When this memory was ingested */
+  ingestion_timestamp: string;
+  /** Type of source (user_input, tool_output, etc.) */
+  source_type: MemorySource['type'];
+  /** Original source identifier */
+  source_id: string;
+}
+
+/**
+ * Policy decisions that affected retrieval.
+ * Shows which rules were applied during ranking.
+ */
+export interface PolicyPath {
+  /** Rules that were evaluated during retrieval */
+  rules_applied: string[];
+  /** Filters that this memory matched */
+  filters_matched: string[];
+  /** Score boosts that were applied */
+  boosts_applied: string[];
+}
+
+/**
+ * Complete explanation of why a memory was retrieved.
+ * Provides transparency into the retrieval decision.
+ *
+ * @see https://github.com/savestatedev/savestate/issues/115
+ */
+export interface RetrievalExplanation {
+  /** Memory ID this explanation is for */
+  memory_id: string;
+  /** Detailed score breakdown */
+  relevance_score_breakdown: ScoreBreakdown;
+  /** Source provenance trace */
+  source_trace: SourceTrace;
+  /** Weight applied based on timestamp/recency */
+  timestamp_weight: number;
+  /** Policy decisions that affected ranking */
+  policy_path: PolicyPath;
+  /** Final computed score */
+  final_score: number;
+  /** Human-readable summary of why this memory was selected */
+  summary: string;
 }
 
 // ─── Restore ─────────────────────────────────────────────────

--- a/src/commands/memory-cli.ts
+++ b/src/commands/memory-cli.ts
@@ -13,6 +13,7 @@ import {
   unpinMemoryCommand,
   applyPoliciesCommand,
   showTierConfig,
+  explainMemoryCommand,
 } from './memory.js';
 import { loadConfig } from '../config.js';
 import { resolveStorage } from '../storage/index.js';
@@ -175,6 +176,32 @@ export function registerMemoryCommands(program: Command): void {
 
         await showTierConfig(storage, passphrase, {
           snapshotId: options.snapshot,
+        });
+      } catch (err) {
+        handleError(err);
+      }
+    });
+
+  // ─── savestate memory explain ───────────────────────────────
+
+  memory
+    .command('explain <query>')
+    .description('Explain why memories were retrieved for a query')
+    .option('-n, --namespace <ns>', 'Namespace to search (org:app:agent format)')
+    .option('-l, --limit <n>', 'Maximum number of results', '5')
+    .option('-t, --tags <tags>', 'Filter by tags (comma-separated)')
+    .option('--json', 'Output as JSON')
+    .action(async (query, options) => {
+      try {
+        const config = await loadConfig();
+        const storage = await resolveStorage(config);
+        const passphrase = await promptPassphrase();
+
+        await explainMemoryCommand(storage, passphrase, query, {
+          namespace: options.namespace,
+          limit: parseInt(options.limit, 10),
+          tags: options.tags?.split(',').map((t: string) => t.trim()),
+          format: options.json ? 'json' : 'pretty',
         });
       } catch (err) {
         handleError(err);

--- a/src/index.ts
+++ b/src/index.ts
@@ -205,3 +205,54 @@ export type {
   PrivacyConfig,
   PrivacyPipelineResult,
 } from './privacy/index.js';
+
+// Checkpoint System - Memory with Provenance
+export {
+  // Core services
+  KnowledgeLane,
+  CheckpointLedger,
+  RestoreService,
+  InMemoryCheckpointStorage,
+  // Utilities
+  calculateRecencyScore,
+  calculateMemoryScore,
+  computeCheckpointHash,
+  verifyCheckpointIntegrity,
+  verifyChainIntegrity,
+  namespaceKey,
+  DEFAULT_RANKING_WEIGHTS,
+} from './checkpoint/index.js';
+export type {
+  // Namespace
+  Namespace,
+  // Checkpoints
+  Checkpoint,
+  CreateCheckpointInput,
+  // Goals & Tasks
+  Goal,
+  Task,
+  Action,
+  // Memory
+  MemoryObject,
+  MemorySource,
+  MemoryIngestionMetadata,
+  ProvenanceEntry,
+  CreateMemoryInput,
+  // Retrieval
+  MemoryQuery,
+  RankingWeights,
+  MemoryResult,
+  // Retrieval Explainability (Issue #115)
+  RetrievalExplanation,
+  ScoreBreakdown,
+  SourceTrace,
+  PolicyPath,
+  // Restore
+  ResumePack,
+  RestoreRationale,
+  RestoreOptions,
+  // Audit & Storage
+  AuditEntry,
+  CheckpointStorage,
+  ListOptions,
+} from './checkpoint/index.js';


### PR DESCRIPTION
## Summary
Implements Retrieval Explainability for #115 - addresses 'black box retrieval' by showing why specific memories were selected.

## Changes

### Explainability Types
- `RetrievalExplanation`: Main type with memory_id, score breakdown, source trace, policy path, summary
- `ScoreBreakdown`: Semantic similarity, recency decay, importance, task criticality, confidence boost
- `SourceTrace`: Snapshot ID, adapter, ingestion timestamp, source type
- `PolicyPath`: Rules applied, filters matched, boosts applied

### Extended Retrieval
- Added `explain?: boolean` parameter to `MemoryQuery`
- When `explain=true`, generates full `RetrievalExplanation` for each result
- Added `KnowledgeLane.explainRetrieval()` convenience method

### CLI Command
```bash
savestate memory explain <query> --namespace <ns> --limit <n> --tags <tags> [--json]
```
- Pretty-prints score components, source trace, and policy path
- Supports JSON output for programmatic use

### Public API
- Exports `KnowledgeLane` with `explainRetrieval()` method
- Exports all explainability types

## Testing
- 10 new tests for explanation generation
- All 719 tests passing

## Acceptance Criteria
- [x] RetrievalExplanation type with all breakdown fields
- [x] searchMemories supports explain=true option
- [x] CLI command shows human-readable explanation
- [x] Tests for explanation generation

## Related Issues
Closes #115