### PR TITLE
feat(state-events): add schema-aware, metadata-tagged state capture

### DIFF
--- a/src/adapters/interface.ts
+++ b/src/adapters/interface.ts
@@ -5,4 +5,19 @@
  * Adapters are the bridge between SaveState and the outside world.
  */
 
-export type { Adapter, PlatformMeta, Snapshot } from '../types.js';
+export type { Adapter, PlatformMeta, Snapshot, SnapshotStateEvents } from '../types.js';
+
+// Re-export state event utilities for adapter implementations (Issue #91)
+export {
+  getGlobalStore,
+  queryStateEvents,
+  getStateEventsByType,
+  getStateEventsByKey,
+  getLatestStateValue,
+  getDecisions,
+  getPreferences,
+  getErrors,
+  getApiResponses,
+} from '../state-events/helpers.js';
+
+export type { StateEvent, StateEventType, StateEventFilter } from '../state-events/types.js';

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -60,6 +60,8 @@ program
   .option('-a, --adapter <adapter>', 'Adapter to use (default: auto-detect)')
   .option('-s, --schedule <interval>', 'Set up auto-snapshot schedule (e.g., 6h, 1d)')
   .option('--full', 'Force a full snapshot (skip incremental)')
+  .option('--tag <entry...>', 'Record structured state entry (type:key=value)')
+  .option('--meta <entry...>', 'Additional metadata for state entries (key=value)')
   .action(snapshotCommand);
 
 // ─── savestate restore ───────────────────────────────────────

--- a/src/state-events/__tests__/state-events.test.ts
+++ b/src/state-events/__tests__/state-events.test.ts
@@ -1,0 +1,468 @@
+/**
+ * State Events Tests
+ *
+ * Issue #91: Schema-aware, metadata-tagged state capture
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  StateEventStore,
+  STATE_EVENTS_FILE,
+} from '../store.js';
+import {
+  parseTagString,
+  parseMetaString,
+  STATE_EVENTS_VERSION,
+  type StateEvent,
+  type StateEventType,
+} from '../types.js';
+import {
+  getGlobalStore,
+  setGlobalStore,
+  clearGlobalStore,
+  recordStateEvent,
+  queryStateEvents,
+  getStateEventsByType,
+  getStateEventsByKey,
+  getLatestStateValue,
+  getDecisions,
+  getPreferences,
+  getErrors,
+  getApiResponses,
+  recordDecision,
+  recordPreference,
+  recordError,
+  recordApiResponse,
+  exportStateEvents,
+} from '../helpers.js';
+
+describe('StateEventStore', () => {
+  let store: StateEventStore;
+
+  beforeEach(() => {
+    store = new StateEventStore();
+  });
+
+  describe('add', () => {
+    it('should add a state event and return it with generated id and timestamp', () => {
+      const event = store.add({
+        type: 'decision',
+        key: 'api_provider',
+        value: 'openai',
+        tags: ['architecture'],
+        metadata: { confidence: 'high' },
+      });
+
+      expect(event.id).toBeDefined();
+      expect(event.type).toBe('decision');
+      expect(event.key).toBe('api_provider');
+      expect(event.value).toBe('openai');
+      expect(event.tags).toEqual(['architecture']);
+      expect(event.metadata).toEqual({ confidence: 'high' });
+      expect(event.timestamp).toBeDefined();
+    });
+
+    it('should use empty arrays/objects for optional fields', () => {
+      const event = store.add({
+        type: 'preference',
+        key: 'theme',
+        value: 'dark',
+      });
+
+      expect(event.tags).toEqual([]);
+      expect(event.metadata).toEqual({});
+    });
+  });
+
+  describe('get', () => {
+    it('should retrieve an event by ID', () => {
+      const event = store.add({
+        type: 'error',
+        key: 'auth_failure',
+        value: { code: 401 },
+      });
+
+      const retrieved = store.get(event.id);
+      expect(retrieved).toEqual(event);
+    });
+
+    it('should return null for non-existent ID', () => {
+      expect(store.get('non-existent-id')).toBeNull();
+    });
+  });
+
+  describe('query', () => {
+    beforeEach(() => {
+      store.add({ type: 'decision', key: 'api', value: 'openai', tags: ['arch'] });
+      store.add({ type: 'decision', key: 'database', value: 'postgres', tags: ['arch', 'data'] });
+      store.add({ type: 'preference', key: 'theme', value: 'dark' });
+      store.add({ type: 'error', key: 'timeout', value: { ms: 5000 } });
+    });
+
+    it('should return all events when no filter provided', () => {
+      const results = store.query();
+      expect(results).toHaveLength(4);
+    });
+
+    it('should filter by type', () => {
+      const decisions = store.query({ type: 'decision' });
+      expect(decisions).toHaveLength(2);
+      expect(decisions.every(e => e.type === 'decision')).toBe(true);
+    });
+
+    it('should filter by exact key', () => {
+      const results = store.query({ key: 'theme' });
+      expect(results).toHaveLength(1);
+      expect(results[0].key).toBe('theme');
+    });
+
+    it('should filter by key prefix', () => {
+      store.add({ type: 'custom', key: 'user.name', value: 'Alice' });
+      store.add({ type: 'custom', key: 'user.email', value: 'alice@test.com' });
+
+      const results = store.query({ keyPrefix: 'user.' });
+      expect(results).toHaveLength(2);
+    });
+
+    it('should filter by tags (ALL must match)', () => {
+      const results = store.query({ tags: ['arch', 'data'] });
+      expect(results).toHaveLength(1);
+      expect(results[0].key).toBe('database');
+    });
+
+    it('should filter by tags (ANY must match)', () => {
+      const results = store.query({ tagsAny: ['arch'] });
+      expect(results).toHaveLength(2);
+    });
+
+    it('should respect limit', () => {
+      const results = store.query({ limit: 2 });
+      expect(results).toHaveLength(2);
+    });
+
+    it('should respect offset', () => {
+      const all = store.query();
+      const offset = store.query({ offset: 2 });
+      expect(offset).toHaveLength(all.length - 2);
+    });
+  });
+
+  describe('getByType', () => {
+    it('should return all events of a specific type', () => {
+      store.add({ type: 'decision', key: 'a', value: 1 });
+      store.add({ type: 'preference', key: 'b', value: 2 });
+      store.add({ type: 'decision', key: 'c', value: 3 });
+
+      const decisions = store.getByType('decision');
+      expect(decisions).toHaveLength(2);
+    });
+  });
+
+  describe('getByKey', () => {
+    it('should return all events with a specific key', () => {
+      store.add({ type: 'decision', key: 'theme', value: 'light' });
+      store.add({ type: 'preference', key: 'theme', value: 'dark' });
+
+      const themeEvents = store.getByKey('theme');
+      expect(themeEvents).toHaveLength(2);
+    });
+  });
+
+  describe('getLatestByKey', () => {
+    it('should return the most recent event for a key', async () => {
+      store.add({ type: 'preference', key: 'theme', value: 'light' });
+      // Small delay to ensure different timestamps
+      await new Promise(resolve => setTimeout(resolve, 10));
+      store.add({ type: 'preference', key: 'theme', value: 'dark' });
+
+      const latest = store.getLatestByKey('theme');
+      expect(latest?.value).toBe('dark');
+    });
+
+    it('should return null for non-existent key', () => {
+      expect(store.getLatestByKey('non-existent')).toBeNull();
+    });
+  });
+
+  describe('JSONL serialization', () => {
+    it('should serialize to JSONL format', () => {
+      store.add({ type: 'decision', key: 'a', value: 1 });
+      store.add({ type: 'preference', key: 'b', value: 'test' });
+
+      const jsonl = store.toJSONL();
+      const lines = jsonl.trim().split('\n');
+
+      expect(lines).toHaveLength(2);
+      expect(() => JSON.parse(lines[0])).not.toThrow();
+      expect(() => JSON.parse(lines[1])).not.toThrow();
+    });
+
+    it('should load from JSONL format', () => {
+      const event1: StateEvent = {
+        id: 'test-1',
+        type: 'decision',
+        timestamp: '2024-01-01T00:00:00Z',
+        key: 'api',
+        value: 'openai',
+        tags: [],
+        metadata: {},
+      };
+      const event2: StateEvent = {
+        id: 'test-2',
+        type: 'preference',
+        timestamp: '2024-01-01T00:00:01Z',
+        key: 'theme',
+        value: 'dark',
+        tags: [],
+        metadata: {},
+      };
+
+      const jsonl = `${JSON.stringify(event1)}\n${JSON.stringify(event2)}\n`;
+      store.fromJSONL(jsonl);
+
+      expect(store.count()).toBe(2);
+      expect(store.get('test-1')).toEqual(event1);
+      expect(store.get('test-2')).toEqual(event2);
+    });
+
+    it('should survive round-trip serialization', () => {
+      store.add({ type: 'decision', key: 'api', value: 'openai', tags: ['arch'] });
+      store.add({ type: 'preference', key: 'theme', value: 'dark' });
+
+      const jsonl = store.toJSONL();
+      const newStore = StateEventStore.fromJSONL(jsonl);
+
+      expect(newStore.count()).toBe(2);
+      expect(newStore.getByType('decision')).toHaveLength(1);
+      expect(newStore.getByType('preference')).toHaveLength(1);
+    });
+
+    it('should skip invalid JSONL lines', () => {
+      const jsonl = `{"id":"1","type":"decision","timestamp":"2024","key":"a","value":1,"tags":[],"metadata":{}}
+not valid json
+{"id":"2","type":"preference","timestamp":"2024","key":"b","value":2,"tags":[],"metadata":{}}`;
+
+      store.fromJSONL(jsonl);
+      expect(store.count()).toBe(2);
+    });
+  });
+
+  describe('merge', () => {
+    it('should merge events from another store', () => {
+      store.add({ type: 'decision', key: 'a', value: 1 });
+
+      const other = new StateEventStore();
+      other.add({ type: 'preference', key: 'b', value: 2 });
+
+      store.merge(other);
+      expect(store.count()).toBe(2);
+    });
+  });
+});
+
+describe('CLI parsing', () => {
+  describe('parseTagString', () => {
+    it('should parse valid tag strings', () => {
+      const result = parseTagString('decision:api_provider=openai');
+      expect(result).toEqual({
+        type: 'decision',
+        key: 'api_provider',
+        value: 'openai',
+        tags: [],
+        metadata: {},
+      });
+    });
+
+    it('should parse preference tags', () => {
+      const result = parseTagString('preference:theme=dark');
+      expect(result?.type).toBe('preference');
+      expect(result?.key).toBe('theme');
+      expect(result?.value).toBe('dark');
+    });
+
+    it('should parse error tags', () => {
+      const result = parseTagString('error:auth_failure=401');
+      expect(result?.type).toBe('error');
+    });
+
+    it('should parse api_response tags', () => {
+      const result = parseTagString('api_response:weather=sunny');
+      expect(result?.type).toBe('api_response');
+    });
+
+    it('should parse custom tags', () => {
+      const result = parseTagString('custom:my_key=my_value');
+      expect(result?.type).toBe('custom');
+    });
+
+    it('should return null for missing colon', () => {
+      expect(parseTagString('decision')).toBeNull();
+    });
+
+    it('should return null for missing equals', () => {
+      expect(parseTagString('decision:api_provider')).toBeNull();
+    });
+
+    it('should return null for invalid type', () => {
+      expect(parseTagString('invalid:key=value')).toBeNull();
+    });
+
+    it('should handle values with equals signs', () => {
+      const result = parseTagString('custom:equation=a=b+c');
+      expect(result?.value).toBe('a=b+c');
+    });
+  });
+
+  describe('parseMetaString', () => {
+    it('should parse valid meta strings', () => {
+      const result = parseMetaString('confidence=high');
+      expect(result).toEqual({ key: 'confidence', value: 'high' });
+    });
+
+    it('should return null for missing equals', () => {
+      expect(parseMetaString('confidence')).toBeNull();
+    });
+
+    it('should handle values with equals signs', () => {
+      const result = parseMetaString('formula=x=y+z');
+      expect(result?.value).toBe('x=y+z');
+    });
+  });
+});
+
+describe('Helper functions', () => {
+  beforeEach(() => {
+    clearGlobalStore();
+  });
+
+  describe('global store management', () => {
+    it('should create global store on demand', () => {
+      const store = getGlobalStore();
+      expect(store).toBeInstanceOf(StateEventStore);
+    });
+
+    it('should clear global store', () => {
+      recordStateEvent('decision', 'test', 'value');
+      expect(exportStateEvents()).toHaveLength(1);
+
+      clearGlobalStore();
+      expect(getGlobalStore().count()).toBe(0);
+    });
+
+    it('should set custom global store', () => {
+      const custom = new StateEventStore();
+      custom.add({ type: 'decision', key: 'pre-existing', value: 'test' });
+
+      setGlobalStore(custom);
+      expect(getGlobalStore().count()).toBe(1);
+    });
+  });
+
+  describe('recordStateEvent', () => {
+    it('should record an event to global store', () => {
+      const event = recordStateEvent('decision', 'api', 'openai', ['arch']);
+      expect(event.type).toBe('decision');
+      expect(event.key).toBe('api');
+      expect(event.value).toBe('openai');
+      expect(event.tags).toEqual(['arch']);
+    });
+  });
+
+  describe('queryStateEvents', () => {
+    it('should query global store', () => {
+      recordStateEvent('decision', 'a', 1);
+      recordStateEvent('preference', 'b', 2);
+
+      const decisions = queryStateEvents({ type: 'decision' });
+      expect(decisions).toHaveLength(1);
+    });
+  });
+
+  describe('type-specific getters', () => {
+    beforeEach(() => {
+      recordStateEvent('decision', 'd1', 'v1');
+      recordStateEvent('preference', 'p1', 'v2');
+      recordStateEvent('error', 'e1', 'v3');
+      recordStateEvent('api_response', 'a1', 'v4');
+    });
+
+    it('should get decisions', () => {
+      expect(getDecisions()).toHaveLength(1);
+      expect(getDecisions()[0].type).toBe('decision');
+    });
+
+    it('should get preferences', () => {
+      expect(getPreferences()).toHaveLength(1);
+      expect(getPreferences()[0].type).toBe('preference');
+    });
+
+    it('should get errors', () => {
+      expect(getErrors()).toHaveLength(1);
+      expect(getErrors()[0].type).toBe('error');
+    });
+
+    it('should get API responses', () => {
+      expect(getApiResponses()).toHaveLength(1);
+      expect(getApiResponses()[0].type).toBe('api_response');
+    });
+  });
+
+  describe('getLatestStateValue', () => {
+    it('should get latest value for a key', async () => {
+      recordStateEvent('preference', 'theme', 'light');
+      // Add small delay to ensure different timestamps
+      await new Promise(resolve => setTimeout(resolve, 5));
+      recordStateEvent('preference', 'theme', 'dark');
+
+      expect(getLatestStateValue('theme')).toBe('dark');
+    });
+
+    it('should return undefined for non-existent key', () => {
+      expect(getLatestStateValue('non-existent')).toBeUndefined();
+    });
+  });
+
+  describe('convenience recorders', () => {
+    it('should record decision with metadata', () => {
+      const event = recordDecision('database', 'postgres', 'Best performance', ['mysql', 'sqlite']);
+      expect(event.type).toBe('decision');
+      expect(event.metadata.reason).toBe('Best performance');
+      expect(event.metadata.alternatives).toEqual(['mysql', 'sqlite']);
+    });
+
+    it('should record preference with source', () => {
+      const event = recordPreference('theme', 'dark', 'user-settings');
+      expect(event.type).toBe('preference');
+      expect(event.metadata.source).toBe('user-settings');
+    });
+
+    it('should record error with context', () => {
+      const error = new Error('Connection failed');
+      const event = recordError('db_connection', error, { attempt: 3 });
+
+      expect(event.type).toBe('error');
+      expect(event.value).toMatchObject({
+        name: 'Error',
+        message: 'Connection failed',
+      });
+      expect(event.metadata.attempt).toBe(3);
+    });
+
+    it('should record API response with context', () => {
+      const event = recordApiResponse('weather', { temp: 72 }, { endpoint: '/api/weather' });
+      expect(event.type).toBe('api_response');
+      expect(event.value).toEqual({ temp: 72 });
+      expect(event.metadata.endpoint).toBe('/api/weather');
+    });
+  });
+});
+
+describe('Constants', () => {
+  it('should export STATE_EVENTS_FILE', () => {
+    expect(STATE_EVENTS_FILE).toBe('state-events.jsonl');
+  });
+
+  it('should export STATE_EVENTS_VERSION', () => {
+    expect(STATE_EVENTS_VERSION).toBe('1.0.0');
+  });
+});

--- a/src/state-events/helpers.ts
+++ b/src/state-events/helpers.ts
@@ -1,0 +1,295 @@
+/**
+ * State Events SDK/API Helpers
+ *
+ * Convenience functions for adapters and integrations.
+ * Issue #91: Schema-aware, metadata-tagged state capture.
+ */
+
+import type {
+  StateEvent,
+  StateEventType,
+  StateEventFilter,
+  StateEventInput,
+} from './types.js';
+import { StateEventStore } from './store.js';
+
+/**
+ * Global state event store instance.
+ * Used for recording events during a snapshot session.
+ */
+let globalStore: StateEventStore | null = null;
+
+/**
+ * Get the global state event store, creating one if needed.
+ */
+export function getGlobalStore(): StateEventStore {
+  if (!globalStore) {
+    globalStore = new StateEventStore();
+  }
+  return globalStore;
+}
+
+/**
+ * Set the global state event store.
+ * Used during restore to provide access to loaded events.
+ */
+export function setGlobalStore(store: StateEventStore): void {
+  globalStore = store;
+}
+
+/**
+ * Clear the global state event store.
+ */
+export function clearGlobalStore(): void {
+  globalStore = null;
+}
+
+/**
+ * Record a new state event.
+ *
+ * @param type - Event type category
+ * @param key - The key/name for this state entry
+ * @param value - The value associated with this key
+ * @param tags - Optional tags for categorization
+ * @param metadata - Optional additional metadata
+ * @returns The created state event
+ *
+ * @example
+ * ```ts
+ * // Record a decision
+ * recordStateEvent('decision', 'api_provider', 'openai', ['architecture']);
+ *
+ * // Record a preference with metadata
+ * recordStateEvent('preference', 'theme', 'dark', [], { confidence: 'high' });
+ *
+ * // Record an error
+ * recordStateEvent('error', 'auth_failure', { code: 401, message: 'Unauthorized' });
+ * ```
+ */
+export function recordStateEvent(
+  type: StateEventType,
+  key: string,
+  value: unknown,
+  tags?: string[],
+  metadata?: Record<string, unknown>,
+): StateEvent {
+  const store = getGlobalStore();
+  return store.add({
+    type,
+    key,
+    value,
+    tags,
+    metadata,
+  });
+}
+
+/**
+ * Query state events with filters.
+ *
+ * @param filters - Optional filters to apply
+ * @returns Array of matching state events
+ *
+ * @example
+ * ```ts
+ * // Get all decisions
+ * const decisions = queryStateEvents({ type: 'decision' });
+ *
+ * // Get recent preferences
+ * const prefs = queryStateEvents({
+ *   type: 'preference',
+ *   after: '2024-01-01T00:00:00Z',
+ * });
+ *
+ * // Get events by tag
+ * const important = queryStateEvents({ tags: ['important'] });
+ * ```
+ */
+export function queryStateEvents(filters?: StateEventFilter): StateEvent[] {
+  const store = getGlobalStore();
+  return store.query(filters);
+}
+
+/**
+ * Get all state events of a specific type.
+ *
+ * @param type - The event type to filter by
+ * @returns Array of state events of that type
+ */
+export function getStateEventsByType(type: StateEventType): StateEvent[] {
+  const store = getGlobalStore();
+  return store.getByType(type);
+}
+
+/**
+ * Get all state events with a specific key.
+ *
+ * @param key - The key to filter by
+ * @returns Array of state events with that key
+ */
+export function getStateEventsByKey(key: string): StateEvent[] {
+  const store = getGlobalStore();
+  return store.getByKey(key);
+}
+
+/**
+ * Get the most recent value for a state key.
+ *
+ * @param key - The key to look up
+ * @returns The value if found, undefined otherwise
+ */
+export function getLatestStateValue<T = unknown>(key: string): T | undefined {
+  const store = getGlobalStore();
+  const event = store.getLatestByKey(key);
+  return event ? (event.value as T) : undefined;
+}
+
+/**
+ * Get all decisions recorded in the current session.
+ */
+export function getDecisions(): StateEvent[] {
+  return getStateEventsByType('decision');
+}
+
+/**
+ * Get all preferences recorded in the current session.
+ */
+export function getPreferences(): StateEvent[] {
+  return getStateEventsByType('preference');
+}
+
+/**
+ * Get all errors recorded in the current session.
+ */
+export function getErrors(): StateEvent[] {
+  return getStateEventsByType('error');
+}
+
+/**
+ * Get all API responses recorded in the current session.
+ */
+export function getApiResponses(): StateEvent[] {
+  return getStateEventsByType('api_response');
+}
+
+/**
+ * Check if a specific decision has been made.
+ *
+ * @param key - The decision key to check
+ * @returns true if the decision exists
+ */
+export function hasDecision(key: string): boolean {
+  const events = queryStateEvents({ type: 'decision', key });
+  return events.length > 0;
+}
+
+/**
+ * Get a specific preference value.
+ *
+ * @param key - The preference key
+ * @param defaultValue - Default value if not found
+ * @returns The preference value or default
+ */
+export function getPreference<T = unknown>(key: string, defaultValue?: T): T | undefined {
+  const events = queryStateEvents({ type: 'preference', key, limit: 1 });
+  return events.length > 0 ? (events[0].value as T) : defaultValue;
+}
+
+/**
+ * Record a decision with standard metadata.
+ *
+ * @param key - Decision identifier
+ * @param value - The decision value
+ * @param reason - Why this decision was made
+ * @param alternatives - Other options considered
+ */
+export function recordDecision(
+  key: string,
+  value: unknown,
+  reason?: string,
+  alternatives?: string[],
+): StateEvent {
+  return recordStateEvent('decision', key, value, [], {
+    reason,
+    alternatives,
+    decided_at: new Date().toISOString(),
+  });
+}
+
+/**
+ * Record a user preference.
+ *
+ * @param key - Preference identifier
+ * @param value - The preference value
+ * @param source - Where this preference came from
+ */
+export function recordPreference(
+  key: string,
+  value: unknown,
+  source?: string,
+): StateEvent {
+  return recordStateEvent('preference', key, value, [], {
+    source: source ?? 'user',
+    recorded_at: new Date().toISOString(),
+  });
+}
+
+/**
+ * Record an error for future reference.
+ *
+ * @param key - Error identifier
+ * @param error - Error details
+ * @param context - Additional context
+ */
+export function recordError(
+  key: string,
+  error: unknown,
+  context?: Record<string, unknown>,
+): StateEvent {
+  const errorValue = error instanceof Error
+    ? { name: error.name, message: error.message, stack: error.stack }
+    : error;
+
+  return recordStateEvent('error', key, errorValue, [], {
+    ...context,
+    recorded_at: new Date().toISOString(),
+  });
+}
+
+/**
+ * Record an API response for caching/reference.
+ *
+ * @param key - API identifier (e.g., endpoint name)
+ * @param response - The response data
+ * @param requestContext - Optional request context
+ */
+export function recordApiResponse(
+  key: string,
+  response: unknown,
+  requestContext?: Record<string, unknown>,
+): StateEvent {
+  return recordStateEvent('api_response', key, response, [], {
+    ...requestContext,
+    recorded_at: new Date().toISOString(),
+  });
+}
+
+/**
+ * Bulk import state events from an array.
+ *
+ * @param events - Array of state event inputs to import
+ * @returns Array of created state events
+ */
+export function importStateEvents(events: StateEventInput[]): StateEvent[] {
+  const store = getGlobalStore();
+  return events.map(e => store.add(e));
+}
+
+/**
+ * Export all state events as an array.
+ *
+ * @returns Array of all state events
+ */
+export function exportStateEvents(): StateEvent[] {
+  const store = getGlobalStore();
+  return store.getAll();
+}

--- a/src/state-events/index.ts
+++ b/src/state-events/index.ts
@@ -1,0 +1,65 @@
+/**
+ * State Events Module
+ *
+ * Schema-aware, metadata-tagged state capture for AI agents.
+ * Issue #91: Structured, queryable state beyond raw file-based snapshots.
+ *
+ * @example
+ * ```ts
+ * import {
+ *   recordStateEvent,
+ *   recordDecision,
+ *   recordPreference,
+ *   queryStateEvents,
+ *   getDecisions,
+ * } from '@savestate/state-events';
+ *
+ * // Record state during a session
+ * recordDecision('api_provider', 'openai', 'Best model performance');
+ * recordPreference('output_format', 'markdown');
+ *
+ * // Query state events
+ * const decisions = getDecisions();
+ * const recent = queryStateEvents({ after: '2024-01-01' });
+ * ```
+ */
+
+// Types
+export {
+  type StateEvent,
+  type StateEventType,
+  type StateEventInput,
+  type StateEventFilter,
+  type StateEventStore as IStateEventStore,
+  type SnapshotStateEvents,
+  parseTagString,
+  parseMetaString,
+  STATE_EVENTS_VERSION,
+} from './types.js';
+
+// Store
+export { StateEventStore, STATE_EVENTS_FILE } from './store.js';
+
+// Helpers
+export {
+  getGlobalStore,
+  setGlobalStore,
+  clearGlobalStore,
+  recordStateEvent,
+  queryStateEvents,
+  getStateEventsByType,
+  getStateEventsByKey,
+  getLatestStateValue,
+  getDecisions,
+  getPreferences,
+  getErrors,
+  getApiResponses,
+  hasDecision,
+  getPreference,
+  recordDecision,
+  recordPreference,
+  recordError,
+  recordApiResponse,
+  importStateEvents,
+  exportStateEvents,
+} from './helpers.js';

--- a/src/state-events/store.ts
+++ b/src/state-events/store.ts
@@ -1,0 +1,200 @@
+/**
+ * State Event Store
+ *
+ * Lightweight sidecar storage for state events.
+ * Persists as JSONL inside snapshots (state-events.jsonl).
+ * Issue #91: Schema-aware, metadata-tagged state capture.
+ */
+
+import { randomUUID } from 'node:crypto';
+import type {
+  StateEvent,
+  StateEventInput,
+  StateEventFilter,
+  StateEventStore as IStateEventStore,
+  StateEventType,
+} from './types.js';
+
+/**
+ * In-memory state event store with JSONL serialization.
+ */
+export class StateEventStore implements IStateEventStore {
+  private events: Map<string, StateEvent> = new Map();
+
+  /**
+   * Add a new state event.
+   */
+  add(input: StateEventInput): StateEvent {
+    const event: StateEvent = {
+      id: randomUUID(),
+      type: input.type,
+      timestamp: new Date().toISOString(),
+      key: input.key,
+      value: input.value,
+      tags: input.tags ?? [],
+      metadata: input.metadata ?? {},
+    };
+
+    this.events.set(event.id, event);
+    return event;
+  }
+
+  /**
+   * Get a state event by ID.
+   */
+  get(id: string): StateEvent | null {
+    return this.events.get(id) ?? null;
+  }
+
+  /**
+   * Query state events with filters.
+   */
+  query(filter?: StateEventFilter): StateEvent[] {
+    let results = Array.from(this.events.values());
+
+    if (!filter) {
+      return results;
+    }
+
+    // Filter by type
+    if (filter.type) {
+      results = results.filter(e => e.type === filter.type);
+    }
+
+    // Filter by exact key
+    if (filter.key) {
+      results = results.filter(e => e.key === filter.key);
+    }
+
+    // Filter by key prefix
+    if (filter.keyPrefix) {
+      results = results.filter(e => e.key.startsWith(filter.keyPrefix!));
+    }
+
+    // Filter by tags (ALL must match)
+    if (filter.tags && filter.tags.length > 0) {
+      results = results.filter(e =>
+        filter.tags!.every(tag => e.tags.includes(tag))
+      );
+    }
+
+    // Filter by tags (ANY must match)
+    if (filter.tagsAny && filter.tagsAny.length > 0) {
+      results = results.filter(e =>
+        filter.tagsAny!.some(tag => e.tags.includes(tag))
+      );
+    }
+
+    // Filter by timestamp range
+    if (filter.after) {
+      results = results.filter(e => e.timestamp >= filter.after!);
+    }
+    if (filter.before) {
+      results = results.filter(e => e.timestamp <= filter.before!);
+    }
+
+    // Sort by timestamp (newest first)
+    results.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+
+    // Apply offset
+    if (filter.offset && filter.offset > 0) {
+      results = results.slice(filter.offset);
+    }
+
+    // Apply limit
+    if (filter.limit && filter.limit > 0) {
+      results = results.slice(0, filter.limit);
+    }
+
+    return results;
+  }
+
+  /**
+   * Get all events of a specific type.
+   */
+  getByType(type: StateEventType): StateEvent[] {
+    return this.query({ type });
+  }
+
+  /**
+   * Get all events with a specific key.
+   */
+  getByKey(key: string): StateEvent[] {
+    return this.query({ key });
+  }
+
+  /**
+   * Get the most recent event for a key.
+   */
+  getLatestByKey(key: string): StateEvent | null {
+    const events = this.query({ key, limit: 1 });
+    return events.length > 0 ? events[0] : null;
+  }
+
+  /**
+   * Get all events.
+   */
+  getAll(): StateEvent[] {
+    return this.query();
+  }
+
+  /**
+   * Get count of events.
+   */
+  count(): number {
+    return this.events.size;
+  }
+
+  /**
+   * Clear all events.
+   */
+  clear(): void {
+    this.events.clear();
+  }
+
+  /**
+   * Serialize to JSONL string (one JSON object per line).
+   */
+  toJSONL(): string {
+    const events = Array.from(this.events.values());
+    // Sort by timestamp for deterministic output
+    events.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+    return events.map(e => JSON.stringify(e)).join('\n') + (events.length > 0 ? '\n' : '');
+  }
+
+  /**
+   * Load from JSONL string.
+   */
+  fromJSONL(jsonl: string): void {
+    const lines = jsonl.trim().split('\n').filter(line => line.trim());
+    for (const line of lines) {
+      try {
+        const event = JSON.parse(line) as StateEvent;
+        this.events.set(event.id, event);
+      } catch {
+        // Skip invalid lines
+      }
+    }
+  }
+
+  /**
+   * Create a store from JSONL string.
+   */
+  static fromJSONL(jsonl: string): StateEventStore {
+    const store = new StateEventStore();
+    store.fromJSONL(jsonl);
+    return store;
+  }
+
+  /**
+   * Merge events from another store (for restore scenarios).
+   */
+  merge(other: StateEventStore): void {
+    for (const event of other.getAll()) {
+      this.events.set(event.id, event);
+    }
+  }
+}
+
+/** File path for state events inside the archive */
+export const STATE_EVENTS_FILE = 'state-events.jsonl';

--- a/src/state-events/types.ts
+++ b/src/state-events/types.ts
@@ -1,0 +1,175 @@
+/**
+ * State Events Types
+ *
+ * Schema-aware, metadata-tagged state capture for AI agents.
+ * Issue #91: Structured, queryable state beyond raw file-based snapshots.
+ */
+
+/**
+ * State event types for categorizing captured state.
+ */
+export type StateEventType =
+  | 'decision'      // Architectural or implementation decisions
+  | 'preference'    // User or agent preferences
+  | 'error'         // Captured errors and their context
+  | 'api_response'  // Key API responses to remember
+  | 'custom';       // User-defined event types
+
+/**
+ * A single state event capturing a key-value pair with metadata.
+ */
+export interface StateEvent {
+  /** Unique identifier for this event */
+  id: string;
+  /** Event type category */
+  type: StateEventType;
+  /** ISO 8601 timestamp when the event was recorded */
+  timestamp: string;
+  /** The key/name for this state entry */
+  key: string;
+  /** The value associated with this key (can be any JSON-serializable value) */
+  value: unknown;
+  /** Tags for categorization and filtering */
+  tags: string[];
+  /** Additional metadata */
+  metadata: Record<string, unknown>;
+}
+
+/**
+ * Options for creating a new state event.
+ */
+export interface StateEventInput {
+  /** Event type category */
+  type: StateEventType;
+  /** The key/name for this state entry */
+  key: string;
+  /** The value associated with this key */
+  value: unknown;
+  /** Optional tags for categorization */
+  tags?: string[];
+  /** Optional additional metadata */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Filters for querying state events.
+ */
+export interface StateEventFilter {
+  /** Filter by event type */
+  type?: StateEventType;
+  /** Filter by key (exact match) */
+  key?: string;
+  /** Filter by key prefix */
+  keyPrefix?: string;
+  /** Filter events that have ALL of these tags */
+  tags?: string[];
+  /** Filter events that have ANY of these tags */
+  tagsAny?: string[];
+  /** Filter events after this timestamp (inclusive) */
+  after?: string;
+  /** Filter events before this timestamp (inclusive) */
+  before?: string;
+  /** Maximum number of events to return */
+  limit?: number;
+  /** Offset for pagination */
+  offset?: number;
+}
+
+/**
+ * Collection of state events with query capabilities.
+ */
+export interface StateEventStore {
+  /** Add a new state event */
+  add(event: StateEventInput): StateEvent;
+
+  /** Get a state event by ID */
+  get(id: string): StateEvent | null;
+
+  /** Query state events with filters */
+  query(filter?: StateEventFilter): StateEvent[];
+
+  /** Get all events of a specific type */
+  getByType(type: StateEventType): StateEvent[];
+
+  /** Get all events with a specific key */
+  getByKey(key: string): StateEvent[];
+
+  /** Get the most recent event for a key */
+  getLatestByKey(key: string): StateEvent | null;
+
+  /** Get all events */
+  getAll(): StateEvent[];
+
+  /** Get count of events */
+  count(): number;
+
+  /** Clear all events */
+  clear(): void;
+
+  /** Serialize to JSONL string */
+  toJSONL(): string;
+
+  /** Load from JSONL string */
+  fromJSONL(jsonl: string): void;
+}
+
+/**
+ * State events section in a snapshot.
+ */
+export interface SnapshotStateEvents {
+  /** Schema version for state events */
+  version: string;
+  /** Count of state events */
+  count: number;
+  /** State events (inline for small counts, or path to JSONL file) */
+  events?: StateEvent[];
+  /** Path to JSONL file for large event sets */
+  eventsPath?: string;
+}
+
+/**
+ * Parse a CLI tag string into a StateEventInput.
+ * Format: "type:key=value" (e.g., "decision:api_provider=openai")
+ */
+export function parseTagString(tagString: string): StateEventInput | null {
+  const colonIndex = tagString.indexOf(':');
+  if (colonIndex === -1) return null;
+
+  const type = tagString.slice(0, colonIndex) as StateEventType;
+  const rest = tagString.slice(colonIndex + 1);
+
+  const equalsIndex = rest.indexOf('=');
+  if (equalsIndex === -1) return null;
+
+  const key = rest.slice(0, equalsIndex);
+  const value = rest.slice(equalsIndex + 1);
+
+  // Validate type
+  const validTypes: StateEventType[] = ['decision', 'preference', 'error', 'api_response', 'custom'];
+  if (!validTypes.includes(type)) return null;
+
+  return {
+    type,
+    key,
+    value,
+    tags: [],
+    metadata: {},
+  };
+}
+
+/**
+ * Parse a CLI metadata string into a key-value pair.
+ * Format: "key=value"
+ */
+export function parseMetaString(metaString: string): { key: string; value: string } | null {
+  const equalsIndex = metaString.indexOf('=');
+  if (equalsIndex === -1) return null;
+
+  return {
+    key: metaString.slice(0, equalsIndex),
+    value: metaString.slice(equalsIndex + 1),
+  };
+}
+
+/** Current state events schema version */
+export const STATE_EVENTS_VERSION = '1.0.0';

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,10 @@
  */
 
 import type { SnapshotTrace } from './trace/types.js';
+import type { SnapshotStateEvents as StateEventsType } from './state-events/types.js';
+
+/** Re-export SnapshotStateEvents for external use */
+export type SnapshotStateEvents = StateEventsType;
 
 // ─── Manifest ────────────────────────────────────────────────
 
@@ -272,6 +276,8 @@ export interface Snapshot {
   chain: SnapshotChain;
   restoreHints: RestoreHints;
   trace?: SnapshotTrace;
+  /** Structured state events (Issue #91) */
+  stateEvents?: SnapshotStateEvents;
 }
 
 // ─── Adapter Interface ───────────────────────────────────────
@@ -297,6 +303,12 @@ export interface Adapter {
 
   /** Get platform-specific identity information */
   identify(): Promise<PlatformMeta>;
+
+  /**
+   * Get state events from the last restored snapshot (Issue #91).
+   * Available after restore() is called with a snapshot containing state events.
+   */
+  getStateEvents?(): SnapshotStateEvents | undefined;
 }
 
 // ─── Storage Backend Interface ───────────────────────────────


### PR DESCRIPTION
## Summary
Implements schema-aware, metadata-tagged state capture for structured agent state (decisions, prefs, errors, API responses).

## Changes

### State Event Types (`src/state-events/types.ts`)
- `StateEvent` interface: id, type, timestamp, key, value, tags[], metadata{}
- `StateEventType`: decision | preference | error | api_response | custom
- CLI parsing helpers: `parseTagString()`, `parseMetaString()`

### State Event Store (`src/state-events/store.ts`)
- In-memory store with CRUD operations
- Query filtering by type, key, tags, timestamps
- JSONL serialization for snapshot persistence
- Survives encrypt/decrypt + restore cycle

### SDK/API Helpers (`src/state-events/helpers.ts`)
```typescript
recordStateEvent(type, key, value, tags?, metadata?)
queryStateEvents(filters)
getStateEventsByType(type)
getStateEventsByKey(key)
// Convenience methods
recordDecision(), recordPreference(), recordError(), recordApiResponse()
```

### CLI Integration
```bash
savestate snapshot --tag "decision:api_provider=openai" --meta "confidence=high"
```

### Snapshot Format
- State events stored as `state-events/state-events.jsonl` inside archive
- Added `stateEvents` field to `Snapshot` interface
- Events survive pack/unpack/encrypt/decrypt

### Adapter Hook
- State events loaded into global store on restore
- Adapters access via exported helpers
- Optional `getStateEvents()` method on Adapter interface

## Testing
- 50 new tests for state events
- All 869 tests passing

## Acceptance Criteria
- [x] Can snapshot with >=1 structured state entry (type, timestamp, key/value, tags)
- [x] Entries survive encrypt/decrypt + restore
- [x] At restore, adapter can read entries without parsing raw conversation logs

## Related Issues
Closes #91