### PR TITLE
Fix critical tar advisory and reject unsafe archive paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "commander": "^13.1.0",
         "ora": "^8.2.0",
         "stripe": "^20.2.0",
-        "tar": "^7.4.3",
+        "tar": "^7.5.22",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -4428,9 +4428,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
-      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "commander": "^13.1.0",
     "ora": "^8.2.0",
     "stripe": "^20.2.0",
-    "tar": "^7.4.3",
+    "tar": "^7.5.22",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/src/__tests__/format-archive.test.ts
+++ b/src/__tests__/format-archive.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { gzipSync } from 'node:zlib';
+import { Header } from 'tar';
+import { packToArchive, unpackFromArchive } from '../format.js';
+
+function encodeEntry(path: string, data: Buffer, type: 'File' | 'SymbolicLink' | 'Link' = 'File', linkpath?: string): Buffer {
+  const headerBuf = Buffer.alloc(512);
+  const header = new Header();
+  header.path = path;
+  header.size = type === 'File' ? data.length : 0;
+  header.type = type;
+  header.mode = 0o644;
+  header.mtime = new Date(0);
+  header.uid = 0;
+  header.gid = 0;
+  header.uname = 'savestate';
+  header.gname = 'savestate';
+  if (linkpath) {
+    header.linkpath = linkpath;
+  }
+  header.encode(headerBuf, 0);
+
+  const blocks: Buffer[] = [headerBuf];
+  if (type === 'File') {
+    blocks.push(data);
+    const remainder = data.length % 512;
+    if (remainder > 0) {
+      blocks.push(Buffer.alloc(512 - remainder));
+    }
+  }
+  return Buffer.concat(blocks);
+}
+
+function gzipTar(entries: Buffer[]): Buffer {
+  return gzipSync(Buffer.concat([...entries, Buffer.alloc(1024)]));
+}
+
+describe('archive pack/unpack', () => {
+  it('round-trips a valid relative file map', async () => {
+    const files = new Map<string, Buffer>([
+      ['manifest.json', Buffer.from('{"ok":true}')],
+      ['identity/personality.md', Buffer.from('keep this')],
+    ]);
+
+    const unpacked = await unpackFromArchive(packToArchive(files));
+
+    expect(unpacked.get('manifest.json')?.toString()).toBe('{"ok":true}');
+    expect(unpacked.get('identity/personality.md')?.toString()).toBe('keep this');
+    expect([...unpacked.keys()]).toEqual(['manifest.json', 'identity/personality.md']);
+  });
+
+  it('drops path-traversal, absolute, and link entries from a crafted archive', async () => {
+    const archive = gzipTar([
+      encodeEntry('manifest.json', Buffer.from('{"ok":true}')),
+      encodeEntry('../escape.txt', Buffer.from('nope')),
+      encodeEntry('/tmp/absolute.txt', Buffer.from('nope')),
+      encodeEntry('C:windows.txt', Buffer.from('nope')),
+      encodeEntry('nested/../../outside.txt', Buffer.from('nope')),
+      encodeEntry('link-out', Buffer.alloc(0), 'SymbolicLink', '../escape.txt'),
+      encodeEntry('hard-out', Buffer.alloc(0), 'Link', 'manifest.json'),
+    ]);
+
+    const unpacked = await unpackFromArchive(archive);
+
+    expect(unpacked.get('manifest.json')?.toString()).toBe('{"ok":true}');
+    expect(unpacked.has('../escape.txt')).toBe(false);
+    expect(unpacked.has('/tmp/absolute.txt')).toBe(false);
+    expect(unpacked.has('C:windows.txt')).toBe(false);
+    expect(unpacked.has('nested/../../outside.txt')).toBe(false);
+    expect(unpacked.has('link-out')).toBe(false);
+    expect(unpacked.has('hard-out')).toBe(false);
+    expect([...unpacked.keys()]).toEqual(['manifest.json']);
+  });
+});

--- a/src/format.ts
+++ b/src/format.ts
@@ -377,6 +377,18 @@ export function packToArchive(files: Map<string, Buffer>): Buffer {
   return gzipSync(tar);
 }
 
+function isSafeArchivePath(path: string): boolean {
+  if (!path || path.includes('\0')) {
+    return false;
+  }
+  const normalized = path.replace(/\\/g, '/');
+  if (normalized.startsWith('/') || /^[a-zA-Z]:/.test(normalized)) {
+    return false;
+  }
+  const parts = normalized.split('/');
+  return parts.every((part) => part !== '' && part !== '..');
+}
+
 /**
  * Unpack a tar.gz buffer into a file map.
  *
@@ -392,7 +404,7 @@ export async function unpackFromArchive(archive: Buffer): Promise<Map<string, Bu
       const chunks: Buffer[] = [];
       entry.on('data', (chunk: Buffer) => chunks.push(chunk));
       entry.on('end', () => {
-        if (entry.type === 'File') {
+        if (entry.type === 'File' && isSafeArchivePath(entry.path)) {
           files.set(entry.path, Buffer.concat(chunks));
         }
       });


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#16](https://github.com/dbhurley/savestate/issues/16). Users who unpack a SaveState archive no longer depend on `tar@7.5.7`, which had a critical parser DoS and several crafted-archive path advisories.

This run maps those advisories to `src/format.ts` `unpackFromArchive`, which uses `tar.Parser` to build an in-memory file map. It does not extract to user-selected disk paths. A safe patched version exists on the same major: `tar@7.5.22`. Valid SAF pack/unpack behavior is unchanged.

## Proof
- Before: production `npm audit --omit=dev` had 1 critical finding (`tar@7.5.7`, range `<=7.5.20`).
- After: `tar` is absent from the production audit. Remaining production findings: 13 high, 3 moderate, 1 low. Those are outside this issue.
- Focused: `src/__tests__/format-archive.test.ts` passes (valid round trip; crafted traversal, absolute, drive-relative, symlink, and hardlink entries are dropped).
- Full: `npm run lint`, `npm run build`, 1,305 tests, `node dist/cli.js --help`, and `node dist/cli.js --version` all passed.

## Safety
Minimum dependency change only (`tar` 7.5.7 → 7.5.22). No SAF format change, no package publish, no major-version migration.

## Residual risk
Other production audit findings remain and were not changed. Product-line authority for the fleet governor handoff is still an owner decision (#15).