### PR TITLE
Pin nested path-to-regexp patch for @vercel/node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -840,6 +840,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -853,6 +854,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -866,6 +868,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -879,6 +882,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -892,6 +896,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -905,6 +910,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -918,6 +924,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -931,6 +938,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -944,6 +952,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -957,6 +966,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -970,6 +980,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -983,6 +994,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -996,6 +1008,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1009,6 +1022,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1022,6 +1036,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1035,6 +1050,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1048,6 +1064,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1061,6 +1078,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1074,6 +1092,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1087,6 +1106,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1100,6 +1120,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1113,6 +1134,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1126,6 +1148,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1139,6 +1162,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1152,6 +1176,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1390,6 +1415,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@vercel/node/node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "license": "MIT"
     },
     "node_modules/@vercel/node/node_modules/typescript": {
       "version": "4.9.5",
@@ -2673,6 +2704,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3574,12 +3606,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/path-to-regexp": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.1.0.tgz",
-      "integrity": "sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==",
-      "license": "MIT"
     },
     "node_modules/path-to-regexp-updated": {
       "name": "path-to-regexp",

--- a/package.json
+++ b/package.json
@@ -72,5 +72,10 @@
     "@vitest/coverage-v8": "^4.0.18",
     "typescript": "^5.8.3",
     "vitest": "^4.0.18"
+  },
+  "overrides": {
+    "@vercel/node": {
+      "path-to-regexp": "6.3.0"
+    }
   }
 }

--- a/src/__tests__/vercel-node-types.test.ts
+++ b/src/__tests__/vercel-node-types.test.ts
@@ -1,0 +1,52 @@
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const require = createRequire(import.meta.url);
+
+type LockPackage = {
+  version?: string;
+  name?: string;
+};
+
+type PackageLock = {
+  packages: Record<string, LockPackage>;
+};
+
+function vercelNodePathToRegexpVersion(lock: PackageLock): string | undefined {
+  const nested = lock.packages['node_modules/@vercel/node/node_modules/path-to-regexp']?.version;
+  if (nested) {
+    return nested;
+  }
+  return lock.packages['node_modules/path-to-regexp']?.version;
+}
+
+describe('vercel node API types', () => {
+  it('resolves @vercel/node and accepts VercelRequest/VercelResponse handlers', () => {
+    const pkg = require('@vercel/node/package.json') as { version: string };
+    expect(pkg.version.startsWith('5.')).toBe(true);
+    expect(require.resolve('@vercel/node')).toContain('@vercel/node');
+
+    const handler = (req: VercelRequest, res: VercelResponse): void => {
+      res.status(204).end(req.method ?? 'GET');
+    };
+    expect(typeof handler).toBe('function');
+  });
+
+  it('keeps vercel.json parseable and pins the nested path-to-regexp patch', () => {
+    const config = JSON.parse(readFileSync(join(repoRoot, 'vercel.json'), 'utf8')) as {
+      version: number;
+      outputDirectory: string;
+    };
+    expect(config.version).toBe(2);
+    expect(config.outputDirectory).toBe('site');
+
+    const lock = JSON.parse(readFileSync(join(repoRoot, 'package-lock.json'), 'utf8')) as PackageLock;
+    expect(lock.packages['node_modules/@vercel/node']?.version).toBe('5.5.28');
+    expect(vercelNodePathToRegexpVersion(lock)).toBe('6.3.0');
+  });
+});


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#18](https://github.com/dbhurley/savestate/issues/18). Users who hit SaveState Cloud API routes no longer pull `path-to-regexp@6.1.0` through `@vercel/node@5.5.28`.

This run maps the high `@vercel/node` chain to type imports in `api/account.ts`, `api/storage.ts`, `api/webhook.ts`, and the other `/api` handlers. Same-major `@vercel/node` 5.x through `5.10.1` still pins the vulnerable nested copies. A safe nested bump exists for `path-to-regexp@6.3.0`. High `undici` findings require `6.x` and stay out of this issue. Serverless request handling is unchanged.

## Proof
- Before: production `npm audit --omit=dev` reported `@vercel/node` as high through `path-to-regexp@6.1.0` (GHSA-9wv6-86v2-598j) and `undici@5.28.4`.
- After: `@vercel/node` is moderate (remaining `ajv` via `@vercel/static-config`). Nested `path-to-regexp` is `6.3.0`. `undici` highs remain and need a major bump.
- Focused: `src/__tests__/vercel-node-types.test.ts` passes (API types resolve; `vercel.json` parses; nested `path-to-regexp` is `6.3.0`).
- Full: `npm run lint`, `npm run build`, 1,305 tests, `node dist/cli.js --help`, and `node dist/cli.js --version` all passed.

## Safety
Minimum nested override only (`path-to-regexp` 6.1.0 → 6.3.0 under `@vercel/node`). No `@vercel/node` major change, no API behavior change, no package publish.

## Residual risk
High `undici` findings in this chain still need `6.x`. Other production audit findings remain and were not changed. Product-line authority for the fleet governor handoff is still an owner decision (#15).