### PR TITLE
Pin nested hono patches for the MCP SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -588,9 +588,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -2861,9 +2861,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.8.tgz",
-      "integrity": "sha512-eVkB/CYCCei7K2WElZW9yYQFWssG0DhaDhVvr7wy5jJ22K+ck8fWW0EsLpB0sITUTvPnc97+rrbQqIr5iqiy9Q==",
+      "version": "4.12.34",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.34.tgz",
+      "integrity": "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -76,6 +76,10 @@
   "overrides": {
     "@vercel/node": {
       "path-to-regexp": "6.3.0"
+    },
+    "@modelcontextprotocol/sdk": {
+      "hono": "4.12.34",
+      "@hono/node-server": "1.19.17"
     }
   }
 }

--- a/src/__tests__/mcp-hono-types.test.ts
+++ b/src/__tests__/mcp-hono-types.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+type LockPackage = {
+  version?: string;
+};
+
+type PackageLock = {
+  packages: Record<string, LockPackage>;
+};
+
+describe('MCP SDK hono floors', () => {
+  it('resolves MCP stdio server imports without starting a transport', () => {
+    const pkg = JSON.parse(
+      readFileSync(join(repoRoot, 'node_modules/@modelcontextprotocol/sdk/package.json'), 'utf8'),
+    ) as { version: string };
+    expect(pkg.version).toBe('1.26.0');
+    expect(Server).toBeTypeOf('function');
+    expect(StdioServerTransport).toBeTypeOf('function');
+  });
+
+  it('pins nested hono and @hono/node-server patches', () => {
+    const lock = JSON.parse(readFileSync(join(repoRoot, 'package-lock.json'), 'utf8')) as PackageLock;
+    expect(lock.packages['node_modules/@modelcontextprotocol/sdk']?.version).toBe('1.26.0');
+    expect(lock.packages['node_modules/hono']?.version).toBe('4.12.34');
+    expect(lock.packages['node_modules/@hono/node-server']?.version).toBe('1.19.17');
+  });
+});


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#19](https://github.com/dbhurley/savestate/issues/19). Users who install SaveState as an MCP memory provider no longer pull `hono@4.11.8` or `@hono/node-server@1.19.9` through `@modelcontextprotocol/sdk@1.26.0`.

This run maps those advisories to the MCP SDK install path used by `src/mcp/server.ts`. SaveState starts MCP on stdio only. HTTP mode is unimplemented. Same-major floors exist: `hono@4.12.34` and `@hono/node-server@1.19.17`. Both stay inside the SDK ranges. MCP stdio behavior is unchanged.

## Proof
- Before: production `npm audit --omit=dev` had high `hono` and `@hono/node-server` findings (18 total: 1 critical, 13 high, 3 moderate, 1 low).
- After: `hono` and `@hono/node-server` are absent from the production audit. Remaining production findings: 1 critical, 11 high, 3 moderate, 1 low. Those are outside this issue.
- Focused: `src/__tests__/mcp-hono-types.test.ts` passes (MCP stdio imports resolve; locked `hono` is `4.12.34`; locked `@hono/node-server` is `1.19.17`; SDK stays `1.26.0`).
- Full: `npm run lint`, `npm run build`, 1,305 tests, `node dist/cli.js --help`, and `node dist/cli.js --version` all passed.

## Safety
Minimum nested override only (`hono` 4.11.8 → 4.12.34 and `@hono/node-server` 1.19.9 → 1.19.17 under `@modelcontextprotocol/sdk`). No MCP SDK version change, no HTTP transport work, no package publish.

## Residual risk
High `undici` findings still need `6.x`. Other production audit findings remain and were not changed. Product-line authority for the fleet governor handoff is still an owner decision (#15).