### PR TITLE
Pin nested express-rate-limit patches for the MCP SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2530,12 +2530,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
-      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.0.1"
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -2958,9 +2959,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@savestate/cli",
   "version": "0.9.0",
-  "description": "Your AI's memory. Yours. The portable, encrypted memory layer for ChatGPT, Claude, Gemini, and any agent — cross-platform search, MCP runtime, open archive format.",
+  "description": "Your AI's memory. Yours. The portable, encrypted memory layer for ChatGPT, Claude, Gemini, and any agent \u2014 cross-platform search, MCP runtime, open archive format.",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -79,7 +79,9 @@
     },
     "@modelcontextprotocol/sdk": {
       "hono": "4.12.34",
-      "@hono/node-server": "1.19.17"
+      "@hono/node-server": "1.19.17",
+      "express-rate-limit": "8.6.2",
+      "ip-address": "10.5.0"
     }
   }
 }

--- a/src/__tests__/mcp-express-rate-limit-types.test.ts
+++ b/src/__tests__/mcp-express-rate-limit-types.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+type LockPackage = {
+  version?: string;
+};
+
+type PackageLock = {
+  packages: Record<string, LockPackage>;
+};
+
+describe('MCP SDK express-rate-limit floors', () => {
+  it('resolves MCP stdio server imports without starting a transport', () => {
+    const pkg = JSON.parse(
+      readFileSync(join(repoRoot, 'node_modules/@modelcontextprotocol/sdk/package.json'), 'utf8'),
+    ) as { version: string };
+    expect(pkg.version).toBe('1.26.0');
+    expect(Server).toBeTypeOf('function');
+    expect(StdioServerTransport).toBeTypeOf('function');
+  });
+
+  it('pins nested express-rate-limit and ip-address patches', () => {
+    const lock = JSON.parse(readFileSync(join(repoRoot, 'package-lock.json'), 'utf8')) as PackageLock;
+    expect(lock.packages['node_modules/@modelcontextprotocol/sdk']?.version).toBe('1.26.0');
+    expect(lock.packages['node_modules/express-rate-limit']?.version).toBe('8.6.2');
+    expect(lock.packages['node_modules/ip-address']?.version).toBe('10.5.0');
+  });
+});


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#20](https://github.com/dbhurley/savestate/issues/20). Users who install SaveState as an MCP memory provider no longer pull `express-rate-limit@8.2.1` or `ip-address@10.0.1` through `@modelcontextprotocol/sdk@1.26.0`.

This run maps those advisories to the MCP SDK install path used by `src/mcp/server.ts`. SaveState starts MCP on stdio only. HTTP mode is unimplemented. Same-major floors exist: `express-rate-limit@8.6.2` and `ip-address@10.5.0`. Both stay inside the SDK range. MCP stdio behavior is unchanged.

## Proof
- Before: production `npm audit --omit=dev` had high `express-rate-limit` and `ip-address` findings (18 total: 1 critical, 13 high, 3 moderate, 1 low).
- After: `express-rate-limit` and `ip-address` are absent from the production audit. Remaining production findings: 1 critical, 11 high, 3 moderate, 1 low. Those are outside this issue.
- Focused: `src/__tests__/mcp-express-rate-limit-types.test.ts` passes (MCP stdio imports resolve; locked `express-rate-limit` is `8.6.2`; locked `ip-address` is `10.5.0`; SDK stays `1.26.0`).
- Full: `npm run lint`, `npm run build`, 1,305 tests, `node dist/cli.js --help`, and `node dist/cli.js --version` all passed.

## Safety
Minimum nested override only (`express-rate-limit` 8.2.1 → 8.6.2 and `ip-address` 10.0.1 → 10.5.0 under `@modelcontextprotocol/sdk`). No MCP SDK version change, no HTTP transport work, no package publish.

## Residual risk
High `undici` findings still need `6.x`. Other production audit findings remain and were not changed. Product-line authority for the fleet governor handoff is still an owner decision (#15).