### PR TITLE
Pin nested fast-uri patch for the MCP SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2596,9 +2596,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
       "hono": "4.12.34",
       "@hono/node-server": "1.19.17",
       "express-rate-limit": "8.6.2",
-      "ip-address": "10.5.0"
+      "ip-address": "10.5.0",
+      "fast-uri": "3.1.5"
     }
   }
 }

--- a/src/__tests__/mcp-fast-uri-types.test.ts
+++ b/src/__tests__/mcp-fast-uri-types.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+type LockPackage = {
+  version?: string;
+};
+
+type PackageLock = {
+  packages: Record<string, LockPackage>;
+};
+
+describe('MCP SDK fast-uri floors', () => {
+  it('resolves MCP stdio server imports without starting a transport', () => {
+    const pkg = JSON.parse(
+      readFileSync(join(repoRoot, 'node_modules/@modelcontextprotocol/sdk/package.json'), 'utf8'),
+    ) as { version: string };
+    expect(pkg.version).toBe('1.26.0');
+    expect(Server).toBeTypeOf('function');
+    expect(StdioServerTransport).toBeTypeOf('function');
+  });
+
+  it('pins nested fast-uri patch', () => {
+    const lock = JSON.parse(readFileSync(join(repoRoot, 'package-lock.json'), 'utf8')) as PackageLock;
+    expect(lock.packages['node_modules/@modelcontextprotocol/sdk']?.version).toBe('1.26.0');
+    expect(lock.packages['node_modules/fast-uri']?.version).toBe('3.1.5');
+  });
+});


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#21](https://github.com/dbhurley/savestate/issues/21). Users who install SaveState as an MCP memory provider no longer pull `fast-uri@3.1.0` through `@modelcontextprotocol/sdk@1.26.0`.

This run maps those advisories to the MCP SDK `ajv` install path used by `src/mcp/server.ts`. SaveState starts MCP on stdio only. HTTP mode is unimplemented. A same-major floor exists: `fast-uri@3.1.5`. It stays inside the nested `ajv@8.17.1` range (`fast-uri@^3.0.1`). MCP stdio behavior is unchanged.

## Proof
- Before: production `npm audit --omit=dev` had a high `fast-uri@3.1.0` finding (18 total: 1 critical, 13 high, 3 moderate, 1 low).
- After: `fast-uri` is absent from the production audit. Remaining production findings: 1 critical, 12 high, 3 moderate, 1 low. Those are outside this issue.
- Focused: `src/__tests__/mcp-fast-uri-types.test.ts` passes (MCP stdio imports resolve; locked `fast-uri` is `3.1.5`; SDK stays `1.26.0`).
- Full: `npm run lint`, `npm run build`, 1,305 tests, `node dist/cli.js --help`, and `node dist/cli.js --version` all passed.

## Safety
Minimum nested override only (`fast-uri` 3.1.0 → 3.1.5 under `@modelcontextprotocol/sdk`). No MCP SDK version change, no HTTP transport work, no package publish.

## Residual risk
High `undici` findings still need `6.x`. Other production audit findings remain and were not changed. Product-line authority for the fleet governor handoff is still an owner decision (#15).