### PR TITLE
Add dry-run preview to savestate import

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,9 @@ savestate migrate                     Migration wizard between platforms
   --to <platform>                    Target platform
   --list                             Show platform capabilities
   --dry-run                          Preview migration plan
+savestate import <file>               Import an encrypted agent container
+  --dry-run                          Preview without restoring
+  -p, --passphrase <pass>            Passphrase for decryption
 
 savestate trace list                  List Askable Echoes trace runs
   --json                             Output as JSON

--- a/src/commands/__tests__/import-dry-run.test.ts
+++ b/src/commands/__tests__/import-dry-run.test.ts
@@ -1,0 +1,96 @@
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Command } from 'commander';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { importState, registerContainerCommands } from '../container.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate import --dry-run', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-import-dry-run-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  async function createValidContainer(filePath: string, passphrase: string): Promise<void> {
+    const agentState = {
+      agentId: 'fixture-agent',
+      version: 1,
+      exportedAt: '2026-08-17T21:08:00.000Z',
+      personality: { name: 'fixture-agent' },
+      memory: { facts: ['synthetic'] },
+    };
+    const plaintext = Buffer.from(JSON.stringify(agentState));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest = {
+      formatVersion: 1,
+      created: '2026-08-17T21:08:00.000Z',
+      agentId: 'fixture-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: createHash('sha256').update(plaintext).digest('hex'),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    await fs.writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+  }
+
+  it('registers --dry-run on import commands', () => {
+    const program = new Command();
+    registerContainerCommands(program);
+    const importCmd = program.commands.find((command) => command.name() === 'import');
+    const containerImport = program.commands
+      .find((command) => command.name() === 'container')
+      ?.commands.find((command) => command.name() === 'import');
+    expect(importCmd?.options.some((option) => option.long === '--dry-run')).toBe(true);
+    expect(containerImport?.options.some((option) => option.long === '--dry-run')).toBe(true);
+  });
+
+  it('decrypts and previews without restoring', async () => {
+    const filePath = join(testDir, 'fixture.savestate');
+    await createValidContainer(filePath, 'synthetic-passphrase');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: filePath,
+      passphrase: 'synthetic-passphrase',
+      dryRun: true,
+    });
+
+    expect(result).toEqual({
+      dryRun: true,
+      restored: false,
+      agentId: 'fixture-agent',
+      mode: 'replace',
+      created: '2026-08-17T21:08:00.000Z',
+      components: ['personality', 'memory'],
+    });
+    expect(log.mock.calls.flat().join('\n')).toContain('DRY RUN');
+    expect(log.mock.calls.flat().join('\n')).not.toContain('Replacing state');
+    expect(log.mock.calls.flat().join('\n')).not.toContain('Successfully restored');
+    log.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -169,9 +169,25 @@ export interface RestoreOptions {
   keyfile?: string;
   merge?: boolean;
   replace?: boolean;
+  dryRun?: boolean;
 }
 
-async function importState(options: RestoreOptions) {
+export interface ImportResult {
+  dryRun: boolean;
+  restored: boolean;
+  agentId: string;
+  mode: RestoreMode;
+  created: string;
+  components: string[];
+}
+
+function listRestoredComponents(parsedState: Record<string, unknown>): string[] {
+  return Object.keys(parsedState).filter(
+    (key) => key !== 'agentId' && key !== 'version' && key !== 'exportedAt',
+  );
+}
+
+export async function importState(options: RestoreOptions): Promise<ImportResult | undefined> {
   try {
     const { in: inFile, passphrase, keyfile } = options;
     
@@ -243,12 +259,33 @@ async function importState(options: RestoreOptions) {
       process.exit(1);
     }
     
-    // 3. Restore state
+    const parsedState = JSON.parse(decryptedState.toString()) as Record<string, unknown>;
+    const components = listRestoredComponents(parsedState);
+    const result: ImportResult = {
+      dryRun: !!options.dryRun,
+      restored: !options.dryRun,
+      agentId: manifest.agentId,
+      mode,
+      created: manifest.created,
+      components,
+    };
+
+    if (options.dryRun) {
+      console.log(`\nDRY RUN — no changes will be made`);
+      console.log(`  Agent: ${manifest.agentId}`);
+      console.log(`  Mode: ${mode}`);
+      console.log(`  Original export: ${manifest.created}`);
+      console.log(`  Components: ${components.join(', ') || 'none'}`);
+      console.log(`  This was a dry run. No agent state was restored.`);
+      return result;
+    }
+
     await restoreAgentState(manifest.agentId, decryptedState.toString(), mode);
 
     console.log(`\n✓ Successfully restored agent '${manifest.agentId}' from ${inFile}`);
     console.log(`  Mode: ${mode}`);
     console.log(`  Original export: ${manifest.created}`);
+    return result;
   } catch (error: any) {
     console.error('Restore failed:', error.message);
     process.exit(1);
@@ -288,12 +325,14 @@ export function registerContainerCommands(program: Command) {
     .option('-k, --keyfile <path>', 'Keyfile for decryption (alternative to passphrase)')
     .option('--merge', 'Merge with existing state (default: replace)')
     .option('--replace', 'Replace existing state completely')
+    .option('--dry-run', 'Show what would be imported without restoring')
     .action((file, opts) => importState({
       in: file,
       passphrase: opts.passphrase,
       keyfile: opts.keyfile,
       merge: opts.merge,
       replace: opts.replace,
+      dryRun: opts.dryRun,
     }));
 
   const container = program
@@ -330,11 +369,13 @@ export function registerContainerCommands(program: Command) {
     .option('-k, --keyfile <path>', 'Keyfile for decryption')
     .option('--merge', 'Merge with existing state')
     .option('--replace', 'Replace existing state (default)')
+    .option('--dry-run', 'Show what would be imported without restoring')
     .action((opts) => importState({
       in: opts.in,
       passphrase: opts.passphrase,
       keyfile: opts.keyfile,
       merge: opts.merge,
       replace: opts.replace,
+      dryRun: opts.dryRun,
     }));
 }


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#22](https://github.com/dbhurley/savestate/issues/22). Users can preview an encrypted agent import before restore.

`savestate import` and `savestate container import` already decrypt and verify. They then restored immediately. `savestate restore` and `savestate migrate` already offer `--dry-run`. This change adds the same preview to import only.

## Proof
- Before: import decrypted, verified, and called restore with no preview flag.
- After: `--dry-run` decrypts and verifies, then prints agent ID, mode, and components. Restore is skipped.
- Focused: `src/commands/__tests__/import-dry-run.test.ts` passes (flag registration plus synthetic container preview).

## Safety
No encryption, container format, live adapter, or package publish change.

## Residual risk
Import still applies restore when `--dry-run` is omitted. Overwrite confirmation and live adapter restore stay out of this issue. Product-line authority for the fleet governor handoff is still an owner decision (#15).