### PR TITLE
Refuse overwrite of an existing export file unless --force

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,10 @@ savestate migrate                     Migration wizard between platforms
   --to <platform>                    Target platform
   --list                             Show platform capabilities
   --dry-run                          Preview migration plan
+savestate export                      Export an encrypted agent container
+  -a, --agent <id>                   Agent ID to export
+  -o, --output <file>                Output file path
+  --force                            Overwrite an existing output file
 savestate import <file>               Import an encrypted agent container
   --dry-run                          Preview without restoring
   -p, --passphrase <pass>            Passphrase for decryption

--- a/src/commands/__tests__/export-overwrite.test.ts
+++ b/src/commands/__tests__/export-overwrite.test.ts
@@ -1,0 +1,68 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Command } from 'commander';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { exportState, registerContainerCommands } from '../container.js';
+
+describe('savestate export overwrite guard', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-export-overwrite-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  it('registers --force on export commands', () => {
+    const program = new Command();
+    registerContainerCommands(program);
+    const exportCmd = program.commands.find((command) => command.name() === 'export');
+    const containerExport = program.commands
+      .find((command) => command.name() === 'container')
+      ?.commands.find((command) => command.name() === 'export');
+    expect(exportCmd?.options.some((option) => option.long === '--force')).toBe(true);
+    expect(containerExport?.options.some((option) => option.long === '--force')).toBe(true);
+  });
+
+  it('refuses to replace an existing file without --force', async () => {
+    const filePath = join(testDir, 'keep.savestate');
+    await fs.writeFile(filePath, 'original-synthetic-container');
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const result = await exportState({
+      agent: 'fixture-agent',
+      out: filePath,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    expect(result).toEqual({ written: false, out: filePath, overwritten: false });
+    expect(await fs.readFile(filePath, 'utf-8')).toBe('original-synthetic-container');
+    expect(error.mock.calls.flat().join('\n')).toContain('already exists');
+    expect(error.mock.calls.flat().join('\n')).toContain('--force');
+    error.mockRestore();
+  });
+
+  it('overwrites an existing file when --force is set', async () => {
+    const filePath = join(testDir, 'replace.savestate');
+    await fs.writeFile(filePath, 'original-synthetic-container');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await exportState({
+      agent: 'fixture-agent',
+      out: filePath,
+      passphrase: 'synthetic-passphrase',
+      force: true,
+    });
+
+    const written = await fs.readFile(filePath);
+    expect(result).toEqual({ written: true, out: filePath, overwritten: true });
+    expect(written.subarray(0, 8).toString('ascii')).toBe('SAVESTAT');
+    expect(written.toString('utf-8')).not.toBe('original-synthetic-container');
+    expect(log.mock.calls.flat().join('\n')).toContain('Successfully exported');
+    log.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -89,9 +89,16 @@ export interface ExportOptions {
   includeMemory?: boolean;
   includeTools?: boolean;
   includePreferences?: boolean;
+  force?: boolean;
 }
 
-async function exportState(options: ExportOptions) {
+export interface ExportResult {
+  written: boolean;
+  out: string;
+  overwritten: boolean;
+}
+
+export async function exportState(options: ExportOptions): Promise<ExportResult> {
   try {
     const { agent, out, passphrase, keyfile } = options;
     
@@ -107,6 +114,20 @@ async function exportState(options: ExportOptions) {
         'Error: Cannot use both --passphrase and --keyfile. Choose one.',
       );
       process.exit(1);
+    }
+
+    let existed = false;
+    try {
+      await fs.access(out);
+      existed = true;
+    } catch {
+      existed = false;
+    }
+    if (existed && !options.force) {
+      console.error(
+        `Error: Output file already exists: ${out}. Use --force to overwrite.`,
+      );
+      return { written: false, out, overwritten: false };
     }
 
     const keySource: KeySource = keyfile ? { keyfile } : { passphrase };
@@ -157,9 +178,11 @@ async function exportState(options: ExportOptions) {
 
     await fs.writeFile(out, finalBuffer);
     console.log(`Successfully exported agent '${agent}' to ${out}`);
+    return { written: true, out, overwritten: existed };
   } catch (error: any) {
     console.error('Export failed:', error.message);
     process.exit(1);
+    throw error;
   }
 }
 
@@ -305,16 +328,23 @@ export function registerContainerCommands(program: Command) {
     .option('--include-memory', 'Include memory data')
     .option('--include-tools', 'Include tool configurations')
     .option('--include-preferences', 'Include user preferences')
-    .action((opts) => exportState({
-      agent: opts.agent,
-      out: opts.output,
-      passphrase: opts.passphrase,
-      keyfile: opts.keyfile,
-      includePersonality: opts.includePersonality,
-      includeMemory: opts.includeMemory,
-      includeTools: opts.includeTools,
-      includePreferences: opts.includePreferences,
-    }));
+    .option('--force', 'Overwrite an existing output file')
+    .action(async (opts) => {
+      const result = await exportState({
+        agent: opts.agent,
+        out: opts.output,
+        passphrase: opts.passphrase,
+        keyfile: opts.keyfile,
+        includePersonality: opts.includePersonality,
+        includeMemory: opts.includeMemory,
+        includeTools: opts.includeTools,
+        includePreferences: opts.includePreferences,
+        force: opts.force,
+      });
+      if (!result.written) {
+        process.exit(1);
+      }
+    });
 
   // Top-level import command (Issue #153)
   // Note: 'restore' is already used for snapshot restoration in cli.ts
@@ -350,16 +380,23 @@ export function registerContainerCommands(program: Command) {
     .option('--include-memory', 'Include memory data')
     .option('--include-tools', 'Include tool configurations')
     .option('--include-preferences', 'Include user preferences')
-    .action((opts) => exportState({
-      agent: opts.agent,
-      out: opts.out,
-      passphrase: opts.passphrase,
-      keyfile: opts.keyfile,
-      includePersonality: opts.includePersonality,
-      includeMemory: opts.includeMemory,
-      includeTools: opts.includeTools,
-      includePreferences: opts.includePreferences,
-    }));
+    .option('--force', 'Overwrite an existing output file')
+    .action(async (opts) => {
+      const result = await exportState({
+        agent: opts.agent,
+        out: opts.out,
+        passphrase: opts.passphrase,
+        keyfile: opts.keyfile,
+        includePersonality: opts.includePersonality,
+        includeMemory: opts.includeMemory,
+        includeTools: opts.includeTools,
+        includePreferences: opts.includePreferences,
+        force: opts.force,
+      });
+      if (!result.written) {
+        process.exit(1);
+      }
+    });
 
   container
     .command('import')


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#23](https://github.com/dbhurley/savestate/issues/23). Users keep an existing encrypted container when they export to the same path.

`savestate export` and `savestate container export` wrote the output file with no exists check. Import dry-run left overwrite confirmation out of scope. This change refuses the write unless `--force` is set.

## Proof
- Before: a second export to the same path replaced the file.
- After: export prints a clear error and leaves the existing file in place. `--force` overwrites.
- Focused: `src/commands/__tests__/export-overwrite.test.ts` passes (flag registration, refuse without `--force`, overwrite with `--force`).

## Safety
No encryption, container format, live adapter, or package publish change.

## Residual risk
Import still replaces agent state when `--dry-run` is omitted. Import overwrite confirmation stays out of this issue. Product-line authority for the fleet governor handoff is still an owner decision (#15).