### PR TITLE
Write imported agent state to --target directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ savestate export                      Export an encrypted agent container
 savestate import <file>               Import an encrypted agent container
   --dry-run                          Preview without restoring
   -p, --passphrase <pass>            Passphrase for decryption
+  --target <dir>                     Write restored agent state to this directory
 
 savestate trace list                  List Askable Echoes trace runs
   --json                             Output as JSON

--- a/src/commands/__tests__/import-target.test.ts
+++ b/src/commands/__tests__/import-target.test.ts
@@ -1,0 +1,124 @@
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Command } from 'commander';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { importState, registerContainerCommands } from '../container.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate import --target', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-import-target-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  async function createValidContainer(filePath: string, passphrase: string): Promise<string> {
+    const agentState = {
+      agentId: 'fixture-agent',
+      version: 1,
+      exportedAt: '2026-08-17T23:03:00.000Z',
+      personality: { name: 'fixture-agent' },
+      memory: { facts: ['synthetic'] },
+    };
+    const plaintext = JSON.stringify(agentState);
+    const encryptedState = await encrypt(Buffer.from(plaintext), { passphrase });
+    const manifest = {
+      formatVersion: 1,
+      created: '2026-08-17T23:03:00.000Z',
+      agentId: 'fixture-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: Buffer.byteLength(plaintext),
+          sha256: createHash('sha256').update(plaintext).digest('hex'),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    await fs.writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return plaintext;
+  }
+
+  it('registers --target on import commands', () => {
+    const program = new Command();
+    registerContainerCommands(program);
+    const importCmd = program.commands.find((command) => command.name() === 'import');
+    const containerImport = program.commands
+      .find((command) => command.name() === 'container')
+      ?.commands.find((command) => command.name() === 'import');
+    expect(importCmd?.options.some((option) => option.long === '--target')).toBe(true);
+    expect(containerImport?.options.some((option) => option.long === '--target')).toBe(true);
+  });
+
+  it('writes decrypted agent state to the target directory', async () => {
+    const filePath = join(testDir, 'fixture.savestate');
+    const targetDir = join(testDir, 'restored');
+    const plaintext = await createValidContainer(filePath, 'synthetic-passphrase');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: filePath,
+      passphrase: 'synthetic-passphrase',
+      target: targetDir,
+    });
+
+    const writtenPath = join(targetDir, 'agent_state.json');
+    expect(result).toEqual({
+      dryRun: false,
+      restored: true,
+      agentId: 'fixture-agent',
+      mode: 'replace',
+      created: '2026-08-17T23:03:00.000Z',
+      components: ['personality', 'memory'],
+      target: writtenPath,
+    });
+    expect(await fs.readFile(writtenPath, 'utf-8')).toBe(plaintext);
+    expect(log.mock.calls.flat().join('\n')).toContain(writtenPath);
+    log.mockRestore();
+  });
+
+  it('keeps the current restore path when --target is omitted', async () => {
+    const filePath = join(testDir, 'no-target.savestate');
+    const strayDir = join(testDir, 'should-not-exist');
+    await createValidContainer(filePath, 'synthetic-passphrase');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: filePath,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    expect(result).toEqual({
+      dryRun: false,
+      restored: true,
+      agentId: 'fixture-agent',
+      mode: 'replace',
+      created: '2026-08-17T23:03:00.000Z',
+      components: ['personality', 'memory'],
+    });
+    await expect(fs.stat(strayDir)).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(log.mock.calls.flat().join('\n')).toContain('Successfully restored');
+    expect(log.mock.calls.flat().join('\n')).not.toContain('Wrote agent state');
+    log.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -1,7 +1,18 @@
 import { Command } from 'commander';
 import { promises as fs } from 'fs';
+import { join, resolve } from 'node:path';
 import { encrypt, decrypt, KeySource } from '../container/crypto.js';
 import { createHash } from 'node:crypto';
+
+const TARGET_STATE_FILE = 'agent_state.json';
+
+async function writeTargetState(targetDir: string, state: string): Promise<string> {
+  const resolved = resolve(targetDir);
+  await fs.mkdir(resolved, { recursive: true });
+  const outFile = join(resolved, TARGET_STATE_FILE);
+  await fs.writeFile(outFile, state);
+  return outFile;
+}
 
 interface ComponentSelection {
   personality: boolean;
@@ -193,6 +204,7 @@ export interface RestoreOptions {
   merge?: boolean;
   replace?: boolean;
   dryRun?: boolean;
+  target?: string;
 }
 
 export interface ImportResult {
@@ -202,6 +214,7 @@ export interface ImportResult {
   mode: RestoreMode;
   created: string;
   components: string[];
+  target?: string;
 }
 
 function listRestoredComponents(parsedState: Record<string, unknown>): string[] {
@@ -282,7 +295,8 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
       process.exit(1);
     }
     
-    const parsedState = JSON.parse(decryptedState.toString()) as Record<string, unknown>;
+    const stateText = decryptedState.toString();
+    const parsedState = JSON.parse(stateText) as Record<string, unknown>;
     const components = listRestoredComponents(parsedState);
     const result: ImportResult = {
       dryRun: !!options.dryRun,
@@ -303,11 +317,21 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
       return result;
     }
 
-    await restoreAgentState(manifest.agentId, decryptedState.toString(), mode);
+    let targetPath: string | undefined;
+    if (options.target) {
+      targetPath = await writeTargetState(options.target, stateText);
+      result.target = targetPath;
+      console.log(`Wrote agent state to ${targetPath}`);
+    }
+
+    await restoreAgentState(manifest.agentId, stateText, mode);
 
     console.log(`\n✓ Successfully restored agent '${manifest.agentId}' from ${inFile}`);
     console.log(`  Mode: ${mode}`);
     console.log(`  Original export: ${manifest.created}`);
+    if (targetPath) {
+      console.log(`  Target: ${targetPath}`);
+    }
     return result;
   } catch (error: any) {
     console.error('Restore failed:', error.message);
@@ -356,6 +380,7 @@ export function registerContainerCommands(program: Command) {
     .option('--merge', 'Merge with existing state (default: replace)')
     .option('--replace', 'Replace existing state completely')
     .option('--dry-run', 'Show what would be imported without restoring')
+    .option('--target <dir>', 'Write restored agent state to this directory')
     .action((file, opts) => importState({
       in: file,
       passphrase: opts.passphrase,
@@ -363,6 +388,7 @@ export function registerContainerCommands(program: Command) {
       merge: opts.merge,
       replace: opts.replace,
       dryRun: opts.dryRun,
+      target: opts.target,
     }));
 
   const container = program
@@ -407,6 +433,7 @@ export function registerContainerCommands(program: Command) {
     .option('--merge', 'Merge with existing state')
     .option('--replace', 'Replace existing state (default)')
     .option('--dry-run', 'Show what would be imported without restoring')
+    .option('--target <dir>', 'Write restored agent state to this directory')
     .action((opts) => importState({
       in: opts.in,
       passphrase: opts.passphrase,
@@ -414,5 +441,6 @@ export function registerContainerCommands(program: Command) {
       merge: opts.merge,
       replace: opts.replace,
       dryRun: opts.dryRun,
+      target: opts.target,
     }));
 }


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#24](https://github.com/dbhurley/savestate/issues/24). Users can write decrypted agent state to a chosen directory.

`savestate import` and `savestate container import` decrypted and verified, then only logged a placeholder restore. Issue #3 lists `--target <dir>` as an acceptance check. This change writes `agent_state.json` to that directory.

## Proof
- Before: import restored only by logging. No directory write.
- After: `--target <dir>` writes the decrypted agent state. Import without `--target` keeps the current restore path.
- Focused: `src/commands/__tests__/import-target.test.ts` passes (flag registration, target write, omit-target path).

## Safety
No encryption, container format, live adapter, or package publish change.

## Residual risk
Import still applies the placeholder restore when `--target` is omitted. Overwrite confirmation, progress bars, dry-run, and live adapter restore stay out of this issue. Product-line authority for the fleet governor handoff is still an owner decision (#15).