### PR TITLE
Prompt for a passphrase when export and import omit key flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,9 +196,10 @@ savestate export                      Export an encrypted agent container
   -a, --agent <id>                   Agent ID to export
   -o, --output <file>                Output file path
   --force                            Overwrite an existing output file
+  -p, --passphrase <pass>            Passphrase, or SAVESTATE_PASSPHRASE / prompt
 savestate import <file>               Import an encrypted agent container
   --dry-run                          Preview without restoring
-  -p, --passphrase <pass>            Passphrase for decryption
+  -p, --passphrase <pass>            Passphrase, or SAVESTATE_PASSPHRASE / prompt
   --target <dir>                     Write restored agent state to this directory
 
 savestate trace list                  List Askable Echoes trace runs

--- a/src/commands/__tests__/passphrase-prompt.test.ts
+++ b/src/commands/__tests__/passphrase-prompt.test.ts
@@ -1,0 +1,113 @@
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Command } from 'commander';
+import { afterEach, beforeAll, afterAll, describe, expect, it, vi } from 'vitest';
+import { decrypt } from '../../container/crypto.js';
+import { exportState, importState, registerContainerCommands } from '../container.js';
+
+const fixtureRoot = join(
+  fileURLToPath(new URL('.', import.meta.url)),
+  'fixtures-passphrase-prompt',
+);
+
+describe('savestate export/import passphrase prompt', () => {
+  const originalEnv = process.env.SAVESTATE_PASSPHRASE;
+
+  beforeAll(async () => {
+    await fs.mkdir(fixtureRoot, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(fixtureRoot, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.SAVESTATE_PASSPHRASE;
+    } else {
+      process.env.SAVESTATE_PASSPHRASE = originalEnv;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('registers passphrase fallback help on export and import commands', () => {
+    const program = new Command();
+    registerContainerCommands(program);
+    const exportCmd = program.commands.find((command) => command.name() === 'export');
+    const importCmd = program.commands.find((command) => command.name() === 'import');
+    const container = program.commands.find((command) => command.name() === 'container');
+    const containerExport = container?.commands.find((command) => command.name() === 'export');
+    const containerImport = container?.commands.find((command) => command.name() === 'import');
+    const help = 'SAVESTATE_PASSPHRASE / prompt';
+    expect(exportCmd?.options.find((option) => option.long === '--passphrase')?.description).toContain(help);
+    expect(importCmd?.options.find((option) => option.long === '--passphrase')?.description).toContain(help);
+    expect(containerExport?.options.find((option) => option.long === '--passphrase')?.description).toContain(help);
+    expect(containerImport?.options.find((option) => option.long === '--passphrase')?.description).toContain(help);
+  });
+
+  it('exports with SAVESTATE_PASSPHRASE when key flags are omitted', async () => {
+    process.env.SAVESTATE_PASSPHRASE = 'synthetic-passphrase';
+    const out = join(fixtureRoot, 'env-export.savestate');
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await exportState({
+      agent: 'fixture-agent',
+      out,
+    });
+
+    expect(result).toEqual({ written: true, out, overwritten: false });
+    const fileBuffer = await fs.readFile(out);
+    const magic = fileBuffer.subarray(0, 8).toString('ascii');
+    expect(magic).toBe('SAVESTAT');
+    const manifestLength = fileBuffer.readUInt32LE(16);
+    const encryptedState = fileBuffer.subarray(20 + manifestLength);
+    const decrypted = await decrypt(encryptedState, { passphrase: 'synthetic-passphrase' });
+    expect(JSON.parse(decrypted.toString()).agentId).toBe('fixture-agent');
+  });
+
+  it('keeps an explicit --passphrase ahead of SAVESTATE_PASSPHRASE', async () => {
+    process.env.SAVESTATE_PASSPHRASE = 'env-pass-word';
+    const out = join(fixtureRoot, 'flag-export.savestate');
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await exportState({
+      agent: 'fixture-agent',
+      out,
+      passphrase: 'flag-pass-word',
+    });
+
+    const fileBuffer = await fs.readFile(out);
+    const manifestLength = fileBuffer.readUInt32LE(16);
+    const encryptedState = fileBuffer.subarray(20 + manifestLength);
+    await expect(decrypt(encryptedState, { passphrase: 'flag-pass-word' })).resolves.toBeInstanceOf(Buffer);
+    await expect(decrypt(encryptedState, { passphrase: 'env-pass-word' })).rejects.toThrow();
+  });
+
+  it('imports with SAVESTATE_PASSPHRASE when key flags are omitted', async () => {
+    const out = join(fixtureRoot, 'roundtrip.savestate');
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    await exportState({
+      agent: 'fixture-agent',
+      out,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    process.env.SAVESTATE_PASSPHRASE = 'synthetic-passphrase';
+    await importState({ in: out });
+    expect(true).toBe(true);
+  });
+
+  it('fails without writing when no passphrase is available', async () => {
+    delete process.env.SAVESTATE_PASSPHRASE;
+    const out = join(fixtureRoot, 'missing.savestate');
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const exit = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit:${code ?? 0}`);
+    }) as never);
+
+    await expect(exportState({ agent: 'fixture-agent', out })).rejects.toThrow('process.exit:1');
+    expect(exit).toHaveBeenCalledWith(1);
+    await expect(fs.stat(out)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -1,8 +1,9 @@
 import { Command } from 'commander';
 import { promises as fs } from 'fs';
 import { join, resolve } from 'node:path';
-import { encrypt, decrypt, KeySource } from '../container/crypto.js';
 import { createHash } from 'node:crypto';
+import { encrypt, decrypt, KeySource } from '../container/crypto.js';
+import { getPassphrase } from '../passphrase.js';
 
 const TARGET_STATE_FILE = 'agent_state.json';
 
@@ -109,23 +110,26 @@ export interface ExportResult {
   overwritten: boolean;
 }
 
+async function resolveKeySource(
+  passphrase?: string,
+  keyfile?: string,
+  options?: { confirm?: boolean },
+): Promise<KeySource> {
+  if (passphrase && keyfile) {
+    throw new Error('Cannot use both --passphrase and --keyfile. Choose one.');
+  }
+  if (keyfile) {
+    return { keyfile };
+  }
+  if (passphrase) {
+    return { passphrase };
+  }
+  return { passphrase: await getPassphrase({ confirm: options?.confirm }) };
+}
+
 export async function exportState(options: ExportOptions): Promise<ExportResult> {
   try {
     const { agent, out, passphrase, keyfile } = options;
-    
-    // Validate key source
-    if (!passphrase && !keyfile) {
-      console.error(
-        'Error: Either --passphrase or --keyfile is required for encryption.',
-      );
-      process.exit(1);
-    }
-    if (passphrase && keyfile) {
-      console.error(
-        'Error: Cannot use both --passphrase and --keyfile. Choose one.',
-      );
-      process.exit(1);
-    }
 
     let existed = false;
     try {
@@ -141,7 +145,7 @@ export async function exportState(options: ExportOptions): Promise<ExportResult>
       return { written: false, out, overwritten: false };
     }
 
-    const keySource: KeySource = keyfile ? { keyfile } : { passphrase };
+    const keySource = await resolveKeySource(passphrase, keyfile, { confirm: true });
 
     // Determine which components to include (default: all)
     const includeAll = !options.includePersonality && !options.includeMemory && 
@@ -226,22 +230,7 @@ function listRestoredComponents(parsedState: Record<string, unknown>): string[] 
 export async function importState(options: RestoreOptions): Promise<ImportResult | undefined> {
   try {
     const { in: inFile, passphrase, keyfile } = options;
-    
-    // Validate key source
-    if (!passphrase && !keyfile) {
-      console.error(
-        'Error: Either --passphrase or --keyfile is required for decryption.',
-      );
-      process.exit(1);
-    }
-    if (passphrase && keyfile) {
-      console.error(
-        'Error: Cannot use both --passphrase and --keyfile. Choose one.',
-      );
-      process.exit(1);
-    }
-
-    const keySource: KeySource = keyfile ? { keyfile } : { passphrase };
+    const keySource = await resolveKeySource(passphrase, keyfile);
 
     // Determine restore mode
     const mode: RestoreMode = options.merge ? 'merge' : 'replace';
@@ -346,7 +335,7 @@ export function registerContainerCommands(program: Command) {
     .description('Export agent state to an encrypted .savestate file')
     .requiredOption('-a, --agent <id>', 'ID of the agent to export')
     .option('-o, --output <file>', 'Output file path', 'agent.savestate')
-    .option('-p, --passphrase <pass>', 'Passphrase for encryption')
+    .option('-p, --passphrase <pass>', 'Passphrase for encryption (or SAVESTATE_PASSPHRASE / prompt)')
     .option('-k, --keyfile <path>', 'Keyfile for encryption (alternative to passphrase)')
     .option('--include-personality', 'Include personality data')
     .option('--include-memory', 'Include memory data')
@@ -375,7 +364,7 @@ export function registerContainerCommands(program: Command) {
   program
     .command('import <file>')
     .description('Import agent state from an encrypted .savestate file')
-    .option('-p, --passphrase <pass>', 'Passphrase for decryption')
+    .option('-p, --passphrase <pass>', 'Passphrase for decryption (or SAVESTATE_PASSPHRASE / prompt)')
     .option('-k, --keyfile <path>', 'Keyfile for decryption (alternative to passphrase)')
     .option('--merge', 'Merge with existing state (default: replace)')
     .option('--replace', 'Replace existing state completely')
@@ -400,7 +389,7 @@ export function registerContainerCommands(program: Command) {
     .description('Export agent state to an encrypted file.')
     .requiredOption('-a, --agent <id>', 'ID of the agent to export')
     .requiredOption('-o, --out <file>', 'Output file path (.savestate)')
-    .option('-p, --passphrase <pass>', 'Passphrase for encryption')
+    .option('-p, --passphrase <pass>', 'Passphrase for encryption (or SAVESTATE_PASSPHRASE / prompt)')
     .option('-k, --keyfile <path>', 'Keyfile for encryption')
     .option('--include-personality', 'Include personality data')
     .option('--include-memory', 'Include memory data')
@@ -428,7 +417,7 @@ export function registerContainerCommands(program: Command) {
     .command('import')
     .description('Import agent state from an encrypted file.')
     .requiredOption('-i, --in <file>', 'Input file path (.savestate)')
-    .option('-p, --passphrase <pass>', 'Passphrase for decryption')
+    .option('-p, --passphrase <pass>', 'Passphrase for decryption (or SAVESTATE_PASSPHRASE / prompt)')
     .option('-k, --keyfile <path>', 'Keyfile for decryption')
     .option('--merge', 'Merge with existing state')
     .option('--replace', 'Replace existing state (default)')


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#25](https://github.com/dbhurley/savestate/issues/25). Users can export or import an encrypted agent container without putting the passphrase on the command line.

`savestate export` and `savestate import` exited when both `--passphrase` and `--keyfile` were missing. Issue #3 lists a password prompt. This change uses `getPassphrase()` so a missing key reads `SAVESTATE_PASSPHRASE` or prompts on a TTY.

## Proof
- Before: omit both key flags and export/import exit with a required-flag error.
- After: omit both flags and the command uses `SAVESTATE_PASSPHRASE` or a hidden TTY prompt. Explicit `--passphrase` or `--keyfile` keeps the current path.
- Focused: `src/commands/__tests__/passphrase-prompt.test.ts` passes (flag help, env fallback, flag wins over env, import env path, missing passphrase does not write).

## Safety
No encryption, container format, live adapter, or package publish change.

## Residual risk
Import still uses the placeholder restore. Overwrite confirmation, progress bars, dry-run, `--target`, and live adapter restore stay out of this issue. Product-line authority for the fleet governor handoff is still an owner decision (#15).