### PR TITLE
Show byte-size progress on export and import

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,10 +197,12 @@ savestate export                      Export an encrypted agent container
   -o, --output <file>                Output file path
   --force                            Overwrite an existing output file
   -p, --passphrase <pass>            Passphrase, or SAVESTATE_PASSPHRASE / prompt
+                                     Prints load, encrypt, and write byte sizes
 savestate import <file>               Import an encrypted agent container
   --dry-run                          Preview without restoring
   -p, --passphrase <pass>            Passphrase, or SAVESTATE_PASSPHRASE / prompt
   --target <dir>                     Write restored agent state to this directory
+                                     Prints read, decrypt, verify, and restore progress
 
 savestate trace list                  List Askable Echoes trace runs
   --json                             Output as JSON

--- a/src/commands/__tests__/container-progress.test.ts
+++ b/src/commands/__tests__/container-progress.test.ts
@@ -1,0 +1,105 @@
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Command } from 'commander';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  exportState,
+  importState,
+  registerContainerCommands,
+  reportContainerProgress,
+} from '../container.js';
+
+const fixtureRoot = join(
+  fileURLToPath(new URL('.', import.meta.url)),
+  'fixtures-container-progress',
+);
+
+describe('savestate export/import progress', () => {
+  beforeAll(async () => {
+    await fs.mkdir(fixtureRoot, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(fixtureRoot, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('registers progress help on export and import commands', () => {
+    const program = new Command();
+    registerContainerCommands(program);
+    const exportCmd = program.commands.find((command) => command.name() === 'export');
+    const importCmd = program.commands.find((command) => command.name() === 'import');
+    const container = program.commands.find((command) => command.name() === 'container');
+    const containerExport = container?.commands.find((command) => command.name() === 'export');
+    const containerImport = container?.commands.find((command) => command.name() === 'import');
+    const help = 'byte-size progress';
+    expect(exportCmd?.description()).toContain(help);
+    expect(importCmd?.description()).toContain(help);
+    expect(containerExport?.description()).toContain(help);
+    expect(containerImport?.description()).toContain(help);
+  });
+
+  it('formats a phase with an optional byte size', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    expect(reportContainerProgress('Encrypting agent state', 128)).toBe(
+      'Encrypting agent state (128 bytes)',
+    );
+    expect(reportContainerProgress('Restoring agent fixture-agent')).toBe(
+      'Restoring agent fixture-agent',
+    );
+    expect(log).toHaveBeenCalledWith('Encrypting agent state (128 bytes)');
+  });
+
+  it('prints encrypt and write byte sizes during export', async () => {
+    const out = join(fixtureRoot, 'progress-export.savestate');
+    const lines: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((message?: unknown) => {
+      if (typeof message === 'string') {
+        lines.push(message);
+      }
+    });
+
+    await exportState({
+      agent: 'fixture-agent',
+      out,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    const file = await fs.stat(out);
+    expect(lines.some((line) => line.startsWith('Encrypting agent state (') && line.endsWith(' bytes)'))).toBe(true);
+    expect(lines).toContain(`Writing ${out} (${file.size} bytes)`);
+    expect(file.size).toBeGreaterThan(0);
+  });
+
+  it('prints read, decrypt, verify, and restore progress during import', async () => {
+    const out = join(fixtureRoot, 'progress-import.savestate');
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    await exportState({
+      agent: 'fixture-agent',
+      out,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    const lines: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((message?: unknown) => {
+      if (typeof message === 'string') {
+        lines.push(message);
+      }
+    });
+
+    await importState({
+      in: out,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    const file = await fs.stat(out);
+    expect(lines).toContain(`Reading ${out} (${file.size} bytes)`);
+    expect(lines.some((line) => line.startsWith('Decrypting agent state (') && line.endsWith(' bytes)'))).toBe(true);
+    expect(lines.some((line) => line.startsWith('Verifying integrity (') && line.endsWith(' bytes)'))).toBe(true);
+    expect(lines).toContain('Restoring agent fixture-agent');
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -127,6 +127,12 @@ async function resolveKeySource(
   return { passphrase: await getPassphrase({ confirm: options?.confirm }) };
 }
 
+export function reportContainerProgress(phase: string, bytes?: number): string {
+  const message = bytes === undefined ? phase : `${phase} (${bytes} bytes)`;
+  console.log(message);
+  return message;
+}
+
 export async function exportState(options: ExportOptions): Promise<ExportResult> {
   try {
     const { agent, out, passphrase, keyfile } = options;
@@ -157,6 +163,7 @@ export async function exportState(options: ExportOptions): Promise<ExportResult>
       preferences: includeAll || !!options.includePreferences,
     };
 
+    reportContainerProgress(`Loading state for agent ${agent}`);
     const agentState = await getAgentState(agent, components);
     const plaintext = Buffer.from(agentState);
 
@@ -175,6 +182,7 @@ export async function exportState(options: ExportOptions): Promise<ExportResult>
     };
 
     const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    reportContainerProgress('Encrypting agent state', plaintext.length);
     const encryptedState = await encrypt(plaintext, keySource);
 
     // Magic header: 8 bytes "SAVESTAT" + 1 byte version + 7 bytes reserved = 16 bytes
@@ -191,6 +199,7 @@ export async function exportState(options: ExportOptions): Promise<ExportResult>
       encryptedState,
     ]);
 
+    reportContainerProgress(`Writing ${out}`, finalBuffer.length);
     await fs.writeFile(out, finalBuffer);
     console.log(`Successfully exported agent '${agent}' to ${out}`);
     return { written: true, out, overwritten: existed };
@@ -244,6 +253,7 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
     }
 
     const fileBuffer = await fs.readFile(inFile);
+    reportContainerProgress(`Reading ${inFile}`, fileBuffer.length);
 
     // 1. Read header and manifest
     const magic = fileBuffer.subarray(0, 8).toString('ascii');
@@ -264,6 +274,7 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
 
     // 2. Decrypt and verify
     const encryptedState = fileBuffer.subarray(manifestEnd);
+    reportContainerProgress('Decrypting agent state', encryptedState.length);
     let decryptedState: Buffer;
     try {
       decryptedState = await decrypt(encryptedState, keySource);
@@ -278,6 +289,7 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
       process.exit(1);
     }
 
+    reportContainerProgress('Verifying integrity', decryptedState.length);
     const calculatedHash = createHash('sha256').update(decryptedState).digest('hex');
     if (calculatedHash !== payload.sha256) {
       console.error('Error: Integrity check failed. The file may be corrupted or tampered with.');
@@ -313,6 +325,7 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
       console.log(`Wrote agent state to ${targetPath}`);
     }
 
+    reportContainerProgress(`Restoring agent ${manifest.agentId}`);
     await restoreAgentState(manifest.agentId, stateText, mode);
 
     console.log(`\n✓ Successfully restored agent '${manifest.agentId}' from ${inFile}`);
@@ -332,7 +345,7 @@ export function registerContainerCommands(program: Command) {
   // Top-level export command (Issue #152)
   program
     .command('export')
-    .description('Export agent state to an encrypted .savestate file')
+    .description('Export agent state to an encrypted .savestate file. Prints byte-size progress.')
     .requiredOption('-a, --agent <id>', 'ID of the agent to export')
     .option('-o, --output <file>', 'Output file path', 'agent.savestate')
     .option('-p, --passphrase <pass>', 'Passphrase for encryption (or SAVESTATE_PASSPHRASE / prompt)')
@@ -363,7 +376,7 @@ export function registerContainerCommands(program: Command) {
   // Note: 'restore' is already used for snapshot restoration in cli.ts
   program
     .command('import <file>')
-    .description('Import agent state from an encrypted .savestate file')
+    .description('Import agent state from an encrypted .savestate file. Prints byte-size progress.')
     .option('-p, --passphrase <pass>', 'Passphrase for decryption (or SAVESTATE_PASSPHRASE / prompt)')
     .option('-k, --keyfile <path>', 'Keyfile for decryption (alternative to passphrase)')
     .option('--merge', 'Merge with existing state (default: replace)')
@@ -386,7 +399,7 @@ export function registerContainerCommands(program: Command) {
 
   container
     .command('export')
-    .description('Export agent state to an encrypted file.')
+    .description('Export agent state to an encrypted file. Prints byte-size progress.')
     .requiredOption('-a, --agent <id>', 'ID of the agent to export')
     .requiredOption('-o, --out <file>', 'Output file path (.savestate)')
     .option('-p, --passphrase <pass>', 'Passphrase for encryption (or SAVESTATE_PASSPHRASE / prompt)')
@@ -415,7 +428,7 @@ export function registerContainerCommands(program: Command) {
 
   container
     .command('import')
-    .description('Import agent state from an encrypted file.')
+    .description('Import agent state from an encrypted file. Prints byte-size progress.')
     .requiredOption('-i, --in <file>', 'Input file path (.savestate)')
     .option('-p, --passphrase <pass>', 'Passphrase for decryption (or SAVESTATE_PASSPHRASE / prompt)')
     .option('-k, --keyfile <path>', 'Keyfile for decryption')


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#26](https://github.com/dbhurley/savestate/issues/26). Users can see whether a large agent container is still packing or unpacking.

`savestate export` and `savestate import` stayed silent until the final line. Issue #3 lists progress indication for large state files. This change prints phase and byte-size progress on the registered commands.

## Proof
- Before: export and import print only the final success or error line.
- After: export prints load, encrypt, and write sizes. Import prints read, decrypt, verify, and restore progress.
- Focused: `src/commands/__tests__/container-progress.test.ts` passes (help text, byte-size format, export phases, import phases).

## Safety
No encryption, container format, live adapter, or package publish change.

## Residual risk
Import still uses the placeholder restore. Overwrite confirmation, `--target`, live adapter restore, and `--include <paths>` stay out of this issue. Product-line authority for the fleet governor handoff is still an owner decision (#15).