### PR TITLE
Export only selected state paths with --include

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ savestate export                      Export an encrypted agent container
   -a, --agent <id>                   Agent ID to export
   -o, --output <file>                Output file path
   --force                            Overwrite an existing output file
+  --include <paths>                  Only pack named state paths
   -p, --passphrase <pass>            Passphrase, or SAVESTATE_PASSPHRASE / prompt
                                      Prints load, encrypt, and write byte sizes
 savestate import <file>               Import an encrypted agent container

--- a/src/commands/__tests__/container-include.test.ts
+++ b/src/commands/__tests__/container-include.test.ts
@@ -1,0 +1,97 @@
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Command } from 'commander';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { decrypt } from '../../container/crypto.js';
+import {
+  exportState,
+  parseIncludePaths,
+  registerContainerCommands,
+} from '../container.js';
+
+const fixtureRoot = join(
+  fileURLToPath(new URL('.', import.meta.url)),
+  'fixtures-container-include',
+);
+
+async function readExportedState(path: string, passphrase: string): Promise<Record<string, unknown>> {
+  const fileBuffer = await fs.readFile(path);
+  const manifestLength = fileBuffer.readUInt32LE(16);
+  const encryptedState = fileBuffer.subarray(20 + manifestLength);
+  const decrypted = await decrypt(encryptedState, { passphrase });
+  return JSON.parse(decrypted.toString()) as Record<string, unknown>;
+}
+
+describe('savestate export --include', () => {
+  beforeAll(async () => {
+    await fs.mkdir(fixtureRoot, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(fixtureRoot, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('registers --include on export commands', () => {
+    const program = new Command();
+    registerContainerCommands(program);
+    const exportCmd = program.commands.find((command) => command.name() === 'export');
+    const container = program.commands.find((command) => command.name() === 'container');
+    const containerExport = container?.commands.find((command) => command.name() === 'export');
+    expect(exportCmd?.options.some((option) => option.long === '--include')).toBe(true);
+    expect(containerExport?.options.some((option) => option.long === '--include')).toBe(true);
+    expect(exportCmd?.description()).toContain('path selection');
+    expect(containerExport?.description()).toContain('path selection');
+  });
+
+  it('parses comma-separated include paths', () => {
+    expect(parseIncludePaths('memory,personality')).toEqual({
+      components: {
+        personality: true,
+        memory: true,
+        tools: false,
+        preferences: false,
+      },
+    });
+  });
+
+  it('rejects an unknown include path', () => {
+    expect(parseIncludePaths('memory,secrets')).toEqual({
+      error: 'Error: Unknown include path: secrets. Allowed: personality, memory, tools, preferences.',
+    });
+  });
+
+  it('rejects an empty include list', () => {
+    expect(parseIncludePaths(' , ')).toEqual({
+      error: 'Error: --include requires at least one path.',
+    });
+  });
+
+  it('packs only the named paths into a synthetic container', async () => {
+    const out = join(fixtureRoot, 'include-memory.savestate');
+    const lines: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((message?: unknown) => {
+      if (typeof message === 'string') {
+        lines.push(message);
+      }
+    });
+
+    await exportState({
+      agent: 'fixture-agent',
+      out,
+      passphrase: 'synthetic-passphrase',
+      include: 'memory',
+    });
+
+    const state = await readExportedState(out, 'synthetic-passphrase');
+    expect(lines).toContain('Including paths: memory');
+    expect(state).toHaveProperty('memory');
+    expect(state).not.toHaveProperty('personality');
+    expect(state).not.toHaveProperty('tools');
+    expect(state).not.toHaveProperty('preferences');
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -15,11 +15,54 @@ async function writeTargetState(targetDir: string, state: string): Promise<strin
   return outFile;
 }
 
-interface ComponentSelection {
+export const INCLUDE_PATHS = ['personality', 'memory', 'tools', 'preferences'] as const;
+
+export type IncludePath = (typeof INCLUDE_PATHS)[number];
+
+export interface ComponentSelection {
   personality: boolean;
   memory: boolean;
   tools: boolean;
   preferences: boolean;
+}
+
+export function parseIncludePaths(raw?: string): { components: ComponentSelection } | { error: string } {
+  if (raw === undefined) {
+    return {
+      components: {
+        personality: true,
+        memory: true,
+        tools: true,
+        preferences: true,
+      },
+    };
+  }
+
+  const parts = raw
+    .split(',')
+    .map((part) => part.trim().toLowerCase())
+    .filter((part) => part.length > 0);
+
+  if (parts.length === 0) {
+    return { error: 'Error: --include requires at least one path.' };
+  }
+
+  const unknown = parts.filter((part) => !INCLUDE_PATHS.includes(part as IncludePath));
+  if (unknown.length > 0) {
+    return {
+      error: `Error: Unknown include path: ${unknown[0]}. Allowed: ${INCLUDE_PATHS.join(', ')}.`,
+    };
+  }
+
+  const selected = new Set(parts);
+  return {
+    components: {
+      personality: selected.has('personality'),
+      memory: selected.has('memory'),
+      tools: selected.has('tools'),
+      preferences: selected.has('preferences'),
+    },
+  };
 }
 
 // Placeholder for actual agent state loading
@@ -97,6 +140,7 @@ export interface ExportOptions {
   out: string;
   passphrase?: string;
   keyfile?: string;
+  include?: string;
   includePersonality?: boolean;
   includeMemory?: boolean;
   includeTools?: boolean;
@@ -153,15 +197,26 @@ export async function exportState(options: ExportOptions): Promise<ExportResult>
 
     const keySource = await resolveKeySource(passphrase, keyfile, { confirm: true });
 
-    // Determine which components to include (default: all)
-    const includeAll = !options.includePersonality && !options.includeMemory && 
-                       !options.includeTools && !options.includePreferences;
-    const components: ComponentSelection = {
-      personality: includeAll || !!options.includePersonality,
-      memory: includeAll || !!options.includeMemory,
-      tools: includeAll || !!options.includeTools,
-      preferences: includeAll || !!options.includePreferences,
-    };
+    let components: ComponentSelection;
+    if (options.include !== undefined) {
+      const parsed = parseIncludePaths(options.include);
+      if ('error' in parsed) {
+        console.error(parsed.error);
+        process.exit(1);
+      }
+      components = parsed.components;
+      const included = INCLUDE_PATHS.filter((path) => components[path]);
+      console.log(`Including paths: ${included.join(', ')}`);
+    } else {
+      const includeAll = !options.includePersonality && !options.includeMemory && 
+                         !options.includeTools && !options.includePreferences;
+      components = {
+        personality: includeAll || !!options.includePersonality,
+        memory: includeAll || !!options.includeMemory,
+        tools: includeAll || !!options.includeTools,
+        preferences: includeAll || !!options.includePreferences,
+      };
+    }
 
     reportContainerProgress(`Loading state for agent ${agent}`);
     const agentState = await getAgentState(agent, components);
@@ -345,11 +400,12 @@ export function registerContainerCommands(program: Command) {
   // Top-level export command (Issue #152)
   program
     .command('export')
-    .description('Export agent state to an encrypted .savestate file. Prints byte-size progress.')
+    .description('Export agent state to an encrypted .savestate file with optional path selection. Prints byte-size progress.')
     .requiredOption('-a, --agent <id>', 'ID of the agent to export')
     .option('-o, --output <file>', 'Output file path', 'agent.savestate')
     .option('-p, --passphrase <pass>', 'Passphrase for encryption (or SAVESTATE_PASSPHRASE / prompt)')
     .option('-k, --keyfile <path>', 'Keyfile for encryption (alternative to passphrase)')
+    .option('--include <paths>', 'Comma-separated state paths to include (personality,memory,tools,preferences)')
     .option('--include-personality', 'Include personality data')
     .option('--include-memory', 'Include memory data')
     .option('--include-tools', 'Include tool configurations')
@@ -361,6 +417,7 @@ export function registerContainerCommands(program: Command) {
         out: opts.output,
         passphrase: opts.passphrase,
         keyfile: opts.keyfile,
+        include: opts.include,
         includePersonality: opts.includePersonality,
         includeMemory: opts.includeMemory,
         includeTools: opts.includeTools,
@@ -399,11 +456,12 @@ export function registerContainerCommands(program: Command) {
 
   container
     .command('export')
-    .description('Export agent state to an encrypted file. Prints byte-size progress.')
+    .description('Export agent state to an encrypted file with optional path selection. Prints byte-size progress.')
     .requiredOption('-a, --agent <id>', 'ID of the agent to export')
     .requiredOption('-o, --out <file>', 'Output file path (.savestate)')
     .option('-p, --passphrase <pass>', 'Passphrase for encryption (or SAVESTATE_PASSPHRASE / prompt)')
     .option('-k, --keyfile <path>', 'Keyfile for encryption')
+    .option('--include <paths>', 'Comma-separated state paths to include (personality,memory,tools,preferences)')
     .option('--include-personality', 'Include personality data')
     .option('--include-memory', 'Include memory data')
     .option('--include-tools', 'Include tool configurations')
@@ -415,6 +473,7 @@ export function registerContainerCommands(program: Command) {
         out: opts.out,
         passphrase: opts.passphrase,
         keyfile: opts.keyfile,
+        include: opts.include,
         includePersonality: opts.includePersonality,
         includeMemory: opts.includeMemory,
         includeTools: opts.includeTools,


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#27](https://github.com/dbhurley/savestate/issues/27). Users can pack only the state paths they name.

`savestate export` accepted only boolean flags such as `--include-personality`. Issue #3 lists `--include <paths>`. This change adds that flag on the registered export commands and rejects unknown paths.

## Proof
- Before: export packs every component unless four separate boolean flags are set.
- After: `savestate export --include memory` packs only memory. Unknown paths fail with a clear error.
- Focused: `src/commands/__tests__/container-include.test.ts` passes (help text, parse, unknown path, empty list, synthetic export).

## Safety
No encryption, container format, live adapter, or package publish change.

## Residual risk
Import still uses the placeholder restore. Live adapter restore and `--include` on import stay out of this issue. Product-line authority for the fleet governor handoff is still an owner decision (#15).