### PR TITLE
List packed components on savestate verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,10 @@ savestate import <file>               Import an encrypted agent container
   -p, --passphrase <pass>            Passphrase, or SAVESTATE_PASSPHRASE / prompt
   --target <dir>                     Write restored agent state to this directory
                                      Prints read, decrypt, verify, and restore progress
+savestate verify <file>               Verify a .savestate file and list components
+  -p, --passphrase <pass>            Passphrase for verification
+  -k, --keyfile <path>               Keyfile for verification
+  --json                             Output as JSON
 
 savestate trace list                  List Askable Echoes trace runs
   --json                             Output as JSON

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -363,7 +363,7 @@ registerACLCommands(program);
 
 program
   .command('verify <file>')
-  .description('Verify integrity of a .savestate file')
+  .description('Verify integrity of a .savestate file and list packed components')
   .option('-p, --passphrase <pass>', 'Passphrase for verification')
   .option('-k, --keyfile <path>', 'Keyfile for verification (alternative to passphrase)')
   .option('--json', 'Output as JSON')

--- a/src/commands/__tests__/verify.test.ts
+++ b/src/commands/__tests__/verify.test.ts
@@ -9,7 +9,7 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { createHash, randomBytes } from 'crypto';
 import { encrypt } from '../../container/crypto.js';
-import { verifyContainer, VerifyResult } from '../verify.js';
+import { listStateComponents, verifyContainer, VerifyResult } from '../verify.js';
 
 /**
  * Create a proper 16-byte magic header per spec
@@ -87,6 +87,36 @@ describe('verifyContainer', () => {
     expect(result.status).toBe('valid');
     expect(result.manifest).toBeDefined();
     expect(result.manifest?.agentId).toBe('test-agent');
+  });
+
+  it('lists named state components and skips metadata keys', () => {
+    expect(
+      listStateComponents({
+        agentId: 'fixture-agent',
+        version: 1,
+        exportedAt: '2026-08-18T03:00:00.000Z',
+        personality: { name: 'fixture-agent' },
+        memory: { facts: [] },
+      }),
+    ).toEqual(['memory', 'personality']);
+  });
+
+  it('lists packed components after a successful synthetic verify', async () => {
+    const filePath = join(testDir, 'components.savestate');
+    const passphrase = 'synthetic-passphrase';
+
+    await createValidContainer(filePath, passphrase, {
+      agentId: 'fixture-agent',
+      version: 1,
+      exportedAt: '2026-08-18T03:00:00.000Z',
+      memory: { facts: [] },
+      tools: { enabled: [] },
+    });
+
+    const result = await verifyContainer(filePath, { passphrase });
+
+    expect(result.status).toBe('valid');
+    expect(result.components).toEqual(['memory', 'tools']);
   });
 
   it('should detect wrong password', async () => {

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -18,6 +18,19 @@ export interface VerifyResult {
     created: string;
     formatVersion: number;
   };
+  components?: string[];
+}
+
+const STATE_METADATA_KEYS = new Set(['agentId', 'version', 'exportedAt']);
+
+export function listStateComponents(state: unknown): string[] {
+  if (!state || typeof state !== 'object' || Array.isArray(state)) {
+    return [];
+  }
+
+  return Object.keys(state as Record<string, unknown>)
+    .filter((key) => !STATE_METADATA_KEYS.has(key))
+    .sort();
 }
 
 /**
@@ -179,8 +192,9 @@ export async function verifyContainer(
   }
 
   // 6. Optionally validate JSON structure
+  let components: string[] = [];
   try {
-    JSON.parse(decryptedState.toString());
+    components = listStateComponents(JSON.parse(decryptedState.toString()));
   } catch {
     return {
       status: 'corrupted',
@@ -201,6 +215,7 @@ export async function verifyContainer(
       created: manifest.created,
       formatVersion: manifest.formatVersion,
     },
+    components,
   };
 }
 
@@ -227,6 +242,9 @@ export function formatVerifyResult(result: VerifyResult, json: boolean): string 
         lines.push(`   Created: ${result.manifest.created}`);
         lines.push(`   Format: v${result.manifest.formatVersion}`);
       }
+      lines.push(
+        `   Components: ${result.components && result.components.length > 0 ? result.components.join(', ') : 'none'}`,
+      );
       return lines.join('\n');
     }
     case 'wrong_password': {


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#28](https://github.com/dbhurley/savestate/issues/28). Users can see which state components a container holds before they import it.

`savestate verify` reported only valid, agent id, created time, and format version. Issue #3 lists verify integrity before operations. This change lists named state components after a successful checksum and omits metadata keys.

## Proof
- Before: verify prints valid or invalid and no component list.
- After: `savestate verify` prints `Components: memory, tools` for a synthetic container. Metadata keys such as `agentId` stay off the list.
- Focused: `src/commands/__tests__/verify.test.ts` passes (11 tests).

## Safety
No encryption, container format, live adapter, or package publish change.

## Residual risk
Import still uses the placeholder restore. Live adapter restore stays out of this issue. Product-line authority for the fleet governor handoff is still an owner decision (#15).