### PR TITLE
Emit JSON from savestate verify

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -366,6 +366,7 @@ program
   .description('Verify integrity of a .savestate file')
   .option('-p, --passphrase <pass>', 'Passphrase for verification')
   .option('-k, --keyfile <path>', 'Keyfile for verification (alternative to passphrase)')
+  .option('--json', 'Output as JSON')
   .action(verifyCommand);
 
 // ─── savestate memory ────────────────────────────────────────

--- a/src/commands/__tests__/verify-json.test.ts
+++ b/src/commands/__tests__/verify-json.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { formatVerifyResult, verifyExitCode, type VerifyResult } from '../verify.js';
+
+const validResult: VerifyResult = {
+  status: 'valid',
+  message: 'State file is valid and verified',
+  manifest: {
+    agentId: 'demo-agent',
+    created: '2026-08-18T05:00:00.000Z',
+    formatVersion: 1,
+  },
+};
+
+describe('savestate verify --json', () => {
+  it('prints status, message, and manifest fields', () => {
+    const parsed = JSON.parse(formatVerifyResult(validResult, true)) as VerifyResult;
+    expect(parsed.status).toBe('valid');
+    expect(parsed.message).toBe('State file is valid and verified');
+    expect(parsed.manifest?.agentId).toBe('demo-agent');
+    expect(parsed.manifest?.created).toBe('2026-08-18T05:00:00.000Z');
+    expect(parsed.manifest?.formatVersion).toBe(1);
+  });
+
+  it('keeps human text when --json is omitted', () => {
+    const text = formatVerifyResult(validResult, false);
+    expect(text).toContain('State file is valid');
+    expect(text).toContain('Agent: demo-agent');
+    expect(text).toContain('Format: v1');
+    expect(text.trimStart().startsWith('{')).toBe(false);
+  });
+
+  it('keeps existing exit codes', () => {
+    expect(verifyExitCode('valid')).toBe(0);
+    expect(verifyExitCode('wrong_password')).toBe(2);
+    expect(verifyExitCode('corrupted')).toBe(1);
+    expect(verifyExitCode('invalid_format')).toBe(1);
+  });
+});

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -178,14 +178,55 @@ export async function verifyContainer(
   };
 }
 
-/**
- * CLI handler for verify command
- */
+export function verifyExitCode(status: VerifyStatus): number {
+  if (status === 'valid') {
+    return 0;
+  }
+  if (status === 'wrong_password') {
+    return 2;
+  }
+  return 1;
+}
+
+export function formatVerifyResult(result: VerifyResult, json: boolean): string {
+  if (json) {
+    return JSON.stringify(result, null, 2);
+  }
+
+  switch (result.status) {
+    case 'valid': {
+      const lines = ['✅ State file is valid'];
+      if (result.manifest) {
+        lines.push(`   Agent: ${result.manifest.agentId}`);
+        lines.push(`   Created: ${result.manifest.created}`);
+        lines.push(`   Format: v${result.manifest.formatVersion}`);
+      }
+      return lines.join('\n');
+    }
+    case 'wrong_password': {
+      const lines = ['⚠️  Wrong password (cannot decrypt)'];
+      if (result.manifest) {
+        lines.push(`   Agent: ${result.manifest.agentId}`);
+        lines.push(`   Created: ${result.manifest.created}`);
+      }
+      return lines.join('\n');
+    }
+    case 'invalid_format':
+      return `❌ Invalid format: ${result.message}`;
+    case 'corrupted': {
+      const lines = [`❌ File corrupted: ${result.message}`];
+      if (result.manifest) {
+        lines.push(`   Agent: ${result.manifest.agentId}`);
+      }
+      return lines.join('\n');
+    }
+  }
+}
+
 export async function verifyCommand(
   filePath: string,
-  options: { passphrase?: string; keyfile?: string }
+  options: { passphrase?: string; keyfile?: string; json?: boolean }
 ): Promise<void> {
-  // Validate key source
   const passphrase = options.passphrase || process.env.SAVESTATE_PASSPHRASE;
   const keyfile = options.keyfile;
 
@@ -205,38 +246,14 @@ export async function verifyCommand(
   const keySource: KeySource = keyfile ? { keyfile } : { passphrase };
 
   const result = await verifyContainer(filePath, keySource);
+  const output = formatVerifyResult(result, !!options.json);
+  const exitCode = verifyExitCode(result.status);
 
-  switch (result.status) {
-    case 'valid':
-      console.log('✅ State file is valid');
-      if (result.manifest) {
-        console.log(`   Agent: ${result.manifest.agentId}`);
-        console.log(`   Created: ${result.manifest.created}`);
-        console.log(`   Format: v${result.manifest.formatVersion}`);
-      }
-      process.exit(0);
-      break;
-
-    case 'wrong_password':
-      console.log('⚠️  Wrong password (cannot decrypt)');
-      if (result.manifest) {
-        console.log(`   Agent: ${result.manifest.agentId}`);
-        console.log(`   Created: ${result.manifest.created}`);
-      }
-      process.exit(2);
-      break;
-
-    case 'invalid_format':
-      console.error(`❌ Invalid format: ${result.message}`);
-      process.exit(1);
-      break;
-
-    case 'corrupted':
-      console.error(`❌ File corrupted: ${result.message}`);
-      if (result.manifest) {
-        console.log(`   Agent: ${result.manifest.agentId}`);
-      }
-      process.exit(1);
-      break;
+  if (options.json || result.status === 'valid' || result.status === 'wrong_password') {
+    console.log(output);
+  } else {
+    console.error(output);
   }
+
+  process.exit(exitCode);
 }


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#29](https://github.com/dbhurley/savestate/issues/29). Scripts can read a structured verify result before they import a container.

`savestate verify` printed only human text. `list`, `stats`, `doctor`, and `inspect` already offer `--json`. Issue #3 lists verify integrity before operations. This change adds `--json` and keeps the existing exit codes.

## Proof
- Before: verify prints human text only.
- After: `savestate verify --json` prints status, message, and manifest fields. Human text stays the default.
- Focused: `src/commands/__tests__/verify-json.test.ts` passes (3 tests).

## Safety
No encryption, container format, live adapter, or package publish change.

## Residual risk
Import still uses the placeholder restore. Live adapter restore stays out of this issue. Product-line authority for the fleet governor handoff is still an owner decision (#15).