### PR TITLE
Print payload checksum on savestate verify

### DIFF
--- a/src/commands/__tests__/verify-checksum.test.ts
+++ b/src/commands/__tests__/verify-checksum.test.ts
@@ -1,0 +1,98 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { formatVerifyChecksum, verifyContainer } from '../verify.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate verify checksum', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'savestate-verify-checksum-'));
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it('returns the payload SHA-256 after a valid checksum comparison', async () => {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'], tools: [] }));
+    const expected = createHash('sha256').update(plaintext).digest('hex');
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest = {
+      formatVersion: 1,
+      created: '2026-08-18T06:00:00.000Z',
+      agentId: 'demo-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: expected,
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, 'valid.savestate');
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(), manifestLength, manifestBuffer, encryptedState]),
+    );
+
+    const result = await verifyContainer(filePath, { passphrase });
+
+    expect(result.status).toBe('valid');
+    expect(result.checksum).toBe(expected);
+    expect(formatVerifyChecksum(result.checksum!)).toBe(`   Checksum: ${expected}`);
+  });
+
+  it('omits a checksum when the passphrase is wrong', async () => {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest = {
+      formatVersion: 1,
+      created: '2026-08-18T06:00:00.000Z',
+      agentId: 'demo-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: createHash('sha256').update(plaintext).digest('hex'),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, 'wrong-pass.savestate');
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(), manifestLength, manifestBuffer, encryptedState]),
+    );
+
+    const result = await verifyContainer(filePath, { passphrase: 'wrong-pass' });
+
+    expect(result.status).toBe('wrong_password');
+    expect(result.checksum).toBeUndefined();
+  });
+
+  it('prints a Checksum line for a known hash', () => {
+    const hash = 'a'.repeat(64);
+    expect(formatVerifyChecksum(hash)).toBe(`   Checksum: ${hash}`);
+    expect(formatVerifyChecksum(hash)).not.toContain('Agent:');
+  });
+});

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -13,12 +13,17 @@ export type VerifyStatus = 'valid' | 'corrupted' | 'wrong_password' | 'invalid_f
 export interface VerifyResult {
   status: VerifyStatus;
   message: string;
+  checksum?: string;
   manifest?: {
     agentId: string;
     created: string;
     formatVersion: number;
   };
   components?: string[];
+}
+
+export function formatVerifyChecksum(checksum: string): string {
+  return `   Checksum: ${checksum}`;
 }
 
 const STATE_METADATA_KEYS = new Set(['agentId', 'version', 'exportedAt']);
@@ -210,6 +215,7 @@ export async function verifyContainer(
   return {
     status: 'valid',
     message: 'State file is valid and verified',
+    checksum: calculatedHash,
     manifest: {
       agentId: manifest.agentId,
       created: manifest.created,
@@ -245,6 +251,9 @@ export function formatVerifyResult(result: VerifyResult, json: boolean): string 
       lines.push(
         `   Components: ${result.components && result.components.length > 0 ? result.components.join(', ') : 'none'}`,
       );
+      if (result.checksum) {
+        lines.push(formatVerifyChecksum(result.checksum));
+      }
       return lines.join('\n');
     }
     case 'wrong_password': {


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#30](https://github.com/dbhurley/savestate/issues/30). Users can record or compare the verified payload hash before they import a container.

`savestate verify` already computed the payload SHA-256 and then discarded it. Issue #3 lists verify integrity before operations. This change prints the matching hash after a valid check.

## Proof
- Before: verify prints valid, agent, created time, and format only.
- After: `savestate verify` prints `Checksum: <sha256>` for a valid synthetic container. Wrong-passphrase results still omit a checksum.
- Focused: `src/commands/__tests__/verify-checksum.test.ts` passes (3 tests).

## Safety
No encryption, container format, live adapter, or package publish change.

## Residual risk
Import still uses the placeholder restore. Live adapter restore stays out of this issue. Product-line authority for the fleet governor handoff is still an owner decision (#15).