### PR TITLE
Print payload size on savestate verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ savestate verify <file>               Verify a .savestate file and list componen
   -p, --passphrase <pass>            Passphrase for verification
   -k, --keyfile <path>               Keyfile for verification
   --json                             Output as JSON
+                                     Prints payload checksum and size on success
 
 savestate trace list                  List Askable Echoes trace runs
   --json                             Output as JSON

--- a/src/commands/__tests__/verify-size.test.ts
+++ b/src/commands/__tests__/verify-size.test.ts
@@ -1,0 +1,96 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { formatVerifySize, verifyContainer } from '../verify.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate verify size', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'savestate-verify-size-'));
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it('returns the decrypted payload length after a valid checksum comparison', async () => {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'], tools: [] }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest = {
+      formatVersion: 1,
+      created: '2026-08-18T07:00:00.000Z',
+      agentId: 'demo-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: createHash('sha256').update(plaintext).digest('hex'),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, 'valid.savestate');
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(), manifestLength, manifestBuffer, encryptedState]),
+    );
+
+    const result = await verifyContainer(filePath, { passphrase });
+
+    expect(result.status).toBe('valid');
+    expect(result.payloadBytes).toBe(plaintext.length);
+    expect(formatVerifySize(result.payloadBytes!)).toBe(`   Size: ${plaintext.length} bytes`);
+  });
+
+  it('omits a size when the passphrase is wrong', async () => {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest = {
+      formatVersion: 1,
+      created: '2026-08-18T07:00:00.000Z',
+      agentId: 'demo-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: createHash('sha256').update(plaintext).digest('hex'),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, 'wrong-pass.savestate');
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(), manifestLength, manifestBuffer, encryptedState]),
+    );
+
+    const result = await verifyContainer(filePath, { passphrase: 'wrong-pass' });
+
+    expect(result.status).toBe('wrong_password');
+    expect(result.payloadBytes).toBeUndefined();
+  });
+
+  it('prints a Size line for a known byte count', () => {
+    expect(formatVerifySize(42)).toBe('   Size: 42 bytes');
+    expect(formatVerifySize(42)).not.toContain('Agent:');
+  });
+});

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -14,6 +14,7 @@ export interface VerifyResult {
   status: VerifyStatus;
   message: string;
   checksum?: string;
+  payloadBytes?: number;
   manifest?: {
     agentId: string;
     created: string;
@@ -24,6 +25,10 @@ export interface VerifyResult {
 
 export function formatVerifyChecksum(checksum: string): string {
   return `   Checksum: ${checksum}`;
+}
+
+export function formatVerifySize(payloadBytes: number): string {
+  return `   Size: ${payloadBytes} bytes`;
 }
 
 const STATE_METADATA_KEYS = new Set(['agentId', 'version', 'exportedAt']);
@@ -216,6 +221,7 @@ export async function verifyContainer(
     status: 'valid',
     message: 'State file is valid and verified',
     checksum: calculatedHash,
+    payloadBytes: decryptedState.length,
     manifest: {
       agentId: manifest.agentId,
       created: manifest.created,
@@ -253,6 +259,9 @@ export function formatVerifyResult(result: VerifyResult, json: boolean): string 
       );
       if (result.checksum) {
         lines.push(formatVerifyChecksum(result.checksum));
+      }
+      if (result.payloadBytes !== undefined) {
+        lines.push(formatVerifySize(result.payloadBytes));
       }
       return lines.join('\n');
     }


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#31](https://github.com/dbhurley/savestate/issues/31). Users can see how large the verified payload is before they import a container.

`savestate verify` already decrypted the payload and then discarded its length. Issue #3 lists verify integrity before operations. This change prints the matching size after a valid check.

## Proof
- Before: verify prints valid, agent, created time, and format only.
- After: `savestate verify` prints `Size: <n> bytes` for a valid synthetic container. Wrong-passphrase results still omit a size.
- Focused: `src/commands/__tests__/verify-size.test.ts` passes (3 tests).

## Safety
No encryption, container format, live adapter, or package publish change.

## Residual risk
Import still uses the placeholder restore. Live adapter restore stays out of this issue. Product-line authority for the fleet governor handoff is still an owner decision (#15).