### PR TITLE
Print encryption algorithm on savestate verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ savestate verify <file>               Verify a .savestate file and list componen
   -p, --passphrase <pass>            Passphrase for verification
   -k, --keyfile <path>               Keyfile for verification
   --json                             Output as JSON
-                                     Prints payload checksum, size, and content type on success
+                                     Prints payload checksum, size, content type, and encryption on success
 
 savestate trace list                  List Askable Echoes trace runs
   --json                             Output as JSON

--- a/src/commands/__tests__/verify-encryption.test.ts
+++ b/src/commands/__tests__/verify-encryption.test.ts
@@ -1,0 +1,135 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { formatVerifyEncryption, verifyContainer } from '../verify.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate verify encryption algorithm', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'savestate-verify-enc-'));
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it('returns the manifest encryption algorithm after a valid checksum comparison', async () => {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'], tools: [] }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest = {
+      formatVersion: 1,
+      created: '2026-08-18T09:00:00.000Z',
+      agentId: 'demo-agent',
+      encryption: {
+        algorithm: 'AES-256-GCM',
+        keyDerivation: 'Argon2id',
+      },
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: createHash('sha256').update(plaintext).digest('hex'),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, 'valid.savestate');
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(), manifestLength, manifestBuffer, encryptedState]),
+    );
+
+    const result = await verifyContainer(filePath, { passphrase });
+
+    expect(result.status).toBe('valid');
+    expect(result.encryptionAlgorithm).toBe('AES-256-GCM');
+    expect(formatVerifyEncryption(result.encryptionAlgorithm!)).toBe('   Encryption: AES-256-GCM');
+  });
+
+  it('falls back to AES-256-GCM when the manifest omits encryption metadata', async () => {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest = {
+      formatVersion: 1,
+      created: '2026-08-18T09:00:00.000Z',
+      agentId: 'demo-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: createHash('sha256').update(plaintext).digest('hex'),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, 'no-enc-meta.savestate');
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(), manifestLength, manifestBuffer, encryptedState]),
+    );
+
+    const result = await verifyContainer(filePath, { passphrase });
+
+    expect(result.status).toBe('valid');
+    expect(result.encryptionAlgorithm).toBe('AES-256-GCM');
+  });
+
+  it('omits an encryption algorithm when the passphrase is wrong', async () => {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest = {
+      formatVersion: 1,
+      created: '2026-08-18T09:00:00.000Z',
+      agentId: 'demo-agent',
+      encryption: {
+        algorithm: 'AES-256-GCM',
+      },
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: createHash('sha256').update(plaintext).digest('hex'),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, 'wrong-pass.savestate');
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(), manifestLength, manifestBuffer, encryptedState]),
+    );
+
+    const result = await verifyContainer(filePath, { passphrase: 'wrong-pass' });
+
+    expect(result.status).toBe('wrong_password');
+    expect(result.encryptionAlgorithm).toBeUndefined();
+  });
+
+  it('prints an Encryption line for a known algorithm', () => {
+    expect(formatVerifyEncryption('AES-256-GCM')).toBe('   Encryption: AES-256-GCM');
+    expect(formatVerifyEncryption('AES-256-GCM')).not.toContain('Agent:');
+  });
+});

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -16,6 +16,7 @@ export interface VerifyResult {
   checksum?: string;
   payloadBytes?: number;
   contentType?: string;
+  encryptionAlgorithm?: string;
   manifest?: {
     agentId: string;
     created: string;


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#33](https://github.com/dbhurley/savestate/issues/33). Users can see which encryption algorithm protected a verified container before they import it.

`savestate verify` already decrypts the payload with AES-256-GCM, then discarded the algorithm. Issue #3 lists verify integrity before operations. This change prints the matching algorithm after a valid check.

## Proof
- Before: verify prints valid, agent, created time, and format only.
- After: `savestate verify` prints `Encryption: <algorithm>` for a valid synthetic container. Wrong-passphrase results still omit an algorithm.
- Focused: `src/commands/__tests__/verify-encryption.test.ts` passes (4 tests).

## Safety
No encryption, container format, live adapter, or package publish change.

## Residual risk
Import still uses the placeholder restore. Live adapter restore stays out of this issue. Product-line authority for the fleet governor handoff is still an owner decision (#15).