### PR TITLE
Print key derivation on savestate verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ savestate verify <file>               Verify a .savestate file and list componen
   -p, --passphrase <pass>            Passphrase for verification
   -k, --keyfile <path>               Keyfile for verification
   --json                             Output as JSON
-                                     Prints payload checksum, size, content type, and encryption on success
+                                     Prints checksum, size, content type, encryption, and key derivation
 
 savestate trace list                  List Askable Echoes trace runs
   --json                             Output as JSON

--- a/src/commands/__tests__/verify-kdf.test.ts
+++ b/src/commands/__tests__/verify-kdf.test.ts
@@ -1,0 +1,135 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { formatVerifyKeyDerivation, verifyContainer } from '../verify.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate verify key derivation', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'savestate-verify-kdf-'));
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it('returns the manifest key derivation after a valid checksum comparison', async () => {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'], tools: [] }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest = {
+      formatVersion: 1,
+      created: '2026-08-18T10:00:00.000Z',
+      agentId: 'demo-agent',
+      encryption: {
+        algorithm: 'AES-256-GCM',
+        keyDerivation: 'Argon2id',
+      },
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: createHash('sha256').update(plaintext).digest('hex'),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, 'valid.savestate');
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(), manifestLength, manifestBuffer, encryptedState]),
+    );
+
+    const result = await verifyContainer(filePath, { passphrase });
+
+    expect(result.status).toBe('valid');
+    expect(result.keyDerivation).toBe('Argon2id');
+    expect(formatVerifyKeyDerivation(result.keyDerivation!)).toBe('   Key derivation: Argon2id');
+  });
+
+  it('falls back to Argon2id when the manifest omits key derivation', async () => {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest = {
+      formatVersion: 1,
+      created: '2026-08-18T10:00:00.000Z',
+      agentId: 'demo-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: createHash('sha256').update(plaintext).digest('hex'),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, 'no-kdf-meta.savestate');
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(), manifestLength, manifestBuffer, encryptedState]),
+    );
+
+    const result = await verifyContainer(filePath, { passphrase });
+
+    expect(result.status).toBe('valid');
+    expect(result.keyDerivation).toBe('Argon2id');
+  });
+
+  it('omits key derivation when the passphrase is wrong', async () => {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest = {
+      formatVersion: 1,
+      created: '2026-08-18T10:00:00.000Z',
+      agentId: 'demo-agent',
+      encryption: {
+        keyDerivation: 'Argon2id',
+      },
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: createHash('sha256').update(plaintext).digest('hex'),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, 'wrong-pass.savestate');
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(), manifestLength, manifestBuffer, encryptedState]),
+    );
+
+    const result = await verifyContainer(filePath, { passphrase: 'wrong-pass' });
+
+    expect(result.status).toBe('wrong_password');
+    expect(result.keyDerivation).toBeUndefined();
+  });
+
+  it('prints a Key derivation line for a known KDF', () => {
+    expect(formatVerifyKeyDerivation('Argon2id')).toBe('   Key derivation: Argon2id');
+    expect(formatVerifyKeyDerivation('Argon2id')).not.toContain('Agent:');
+  });
+});

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -17,6 +17,7 @@ export interface VerifyResult {
   payloadBytes?: number;
   contentType?: string;
   encryptionAlgorithm?: string;
+  keyDerivation?: string;
   manifest?: {
     agentId: string;
     created: string;
@@ -31,6 +32,38 @@ export function formatVerifyChecksum(checksum: string): string {
 
 export function formatVerifySize(payloadBytes: number): string {
   return `   Size: ${payloadBytes} bytes`;
+}
+
+export function formatVerifyContentType(contentType: string): string {
+  return `   Content-Type: ${contentType}`;
+}
+
+const DEFAULT_VERIFY_ENCRYPTION = 'AES-256-GCM';
+
+export function formatVerifyEncryption(algorithm: string): string {
+  return `   Encryption: ${algorithm}`;
+}
+
+function resolveEncryptionAlgorithm(manifest: { encryption?: { algorithm?: unknown } }): string {
+  const named = manifest.encryption?.algorithm;
+  if (typeof named === 'string' && named.trim().length > 0) {
+    return named;
+  }
+  return DEFAULT_VERIFY_ENCRYPTION;
+}
+
+const DEFAULT_VERIFY_KDF = 'Argon2id';
+
+export function formatVerifyKeyDerivation(kdf: string): string {
+  return `   Key derivation: ${kdf}`;
+}
+
+function resolveKeyDerivation(manifest: { encryption?: { keyDerivation?: unknown } }): string {
+  const named = manifest.encryption?.keyDerivation;
+  if (typeof named === 'string' && named.trim().length > 0) {
+    return named;
+  }
+  return DEFAULT_VERIFY_KDF;
 }
 
 const STATE_METADATA_KEYS = new Set(['agentId', 'version', 'exportedAt']);
@@ -224,6 +257,9 @@ export async function verifyContainer(
     message: 'State file is valid and verified',
     checksum: calculatedHash,
     payloadBytes: decryptedState.length,
+    contentType: typeof payload.contentType === 'string' ? payload.contentType : undefined,
+    encryptionAlgorithm: resolveEncryptionAlgorithm(manifest),
+    keyDerivation: resolveKeyDerivation(manifest),
     manifest: {
       agentId: manifest.agentId,
       created: manifest.created,
@@ -264,6 +300,15 @@ export function formatVerifyResult(result: VerifyResult, json: boolean): string 
       }
       if (result.payloadBytes !== undefined) {
         lines.push(formatVerifySize(result.payloadBytes));
+      }
+      if (result.contentType) {
+        lines.push(formatVerifyContentType(result.contentType));
+      }
+      if (result.encryptionAlgorithm) {
+        lines.push(formatVerifyEncryption(result.encryptionAlgorithm));
+      }
+      if (result.keyDerivation) {
+        lines.push(formatVerifyKeyDerivation(result.keyDerivation));
       }
       return lines.join('\n');
     }


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#34](https://github.com/dbhurley/savestate/issues/34). Users can see which key-derivation function protected a verified container before they import it.

`savestate verify` already derives a key with Argon2id, then discarded that name. Issue #3 lists verify integrity before operations. This change prints the matching KDF after a valid check.

## Proof
- Before: verify prints valid, agent, created time, and format only.
- After: `savestate verify` prints `Key derivation: <kdf>` for a valid synthetic container. Wrong-passphrase results still omit a KDF name.
- Focused: `src/commands/__tests__/verify-kdf.test.ts` passes (4 tests).

## Safety
No encryption, container format, live adapter, or package publish change.

## Residual risk
Import still uses the placeholder restore. Live adapter restore stays out of this issue. Product-line authority for the fleet governor handoff is still an owner decision (#15).