### PR TITLE
Reject non-zero reserved header bytes on savestate verify

### DIFF
--- a/src/commands/__tests__/verify-reserved-header.test.ts
+++ b/src/commands/__tests__/verify-reserved-header.test.ts
@@ -1,0 +1,85 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { verifyContainer } from '../verify.js';
+
+function createMagicHeader(version = 1, reservedByte = 0): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  if (reservedByte !== 0) {
+    header.writeUInt8(reservedByte, 9);
+  }
+  return header;
+}
+
+describe('savestate verify reserved header', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'savestate-verify-reserved-'));
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(name: string, reservedByte = 0): Promise<string> {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest = {
+      formatVersion: 1,
+      created: '2026-08-18T11:00:00.000Z',
+      agentId: 'demo-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: createHash('sha256').update(plaintext).digest('hex'),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, name);
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1, reservedByte), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('rejects a container whose reserved header bytes are not zero', async () => {
+    const filePath = await writeContainer('nonzero-reserved.savestate', 1);
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('invalid_format');
+    expect(result.message).toMatch(/reserved header/i);
+    expect(result.manifest).toBeUndefined();
+  });
+
+  it('still verifies a valid container with zero reserved bytes', async () => {
+    const filePath = await writeContainer('zero-reserved.savestate');
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('valid');
+    expect(result.manifest?.agentId).toBe('demo-agent');
+  });
+
+  it('does not treat a wrong passphrase as a reserved-header failure', async () => {
+    const filePath = await writeContainer('wrong-pass.savestate');
+
+    const result = await verifyContainer(filePath, { passphrase: 'wrong-pass' });
+
+    expect(result.status).toBe('wrong_password');
+    expect(result.message).not.toMatch(/reserved header/i);
+  });
+});

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -75,6 +75,14 @@ export async function verifyContainer(
     };
   }
 
+  const reserved = fileBuffer.subarray(9, 16);
+  if (!reserved.every((byte) => byte === 0)) {
+    return {
+      status: 'invalid_format',
+      message: 'Reserved header bytes must be zero',
+    };
+  }
+
   // 3. Parse manifest
   let manifest: any;
   let manifestEnd: number;


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#35](https://github.com/dbhurley/savestate/issues/35). Users no longer see a valid result when reserved header bytes are non-zero.

`savestate verify` already checked magic and version, then ignored bytes 9-15. The container spec requires those reserved bytes to be zero. This change rejects that header as `invalid_format`.

## Proof
- Before: a container with a non-zero reserved byte still verified as valid.
- After: `savestate verify` returns `invalid_format` and names the reserved header. Zero reserved bytes still verify. Wrong-passphrase results are unchanged.
- Focused: `src/commands/__tests__/verify-reserved-header.test.ts` passes (3 tests).

## Safety
No encryption, container format, live adapter, or package publish change.

## Residual risk
Import still uses the placeholder restore. Live adapter restore stays out of this issue. Product-line authority for the fleet governor handoff is still an owner decision (#15).