### PR TITLE
Add documented container-v1-minimal manifest fixture

### DIFF
--- a/src/container/__tests__/container-v1-minimal-fixture.test.ts
+++ b/src/container/__tests__/container-v1-minimal-fixture.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const fixturePath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../../test/fixtures/container-v1-minimal.json'
+);
+
+const REQUIRED_PAYLOAD_FIELDS = ['name', 'contentType', 'byteLength', 'sha256'] as const;
+
+describe('container-v1-minimal fixture', () => {
+  it('matches the documented v1 required fields', () => {
+    const manifest = JSON.parse(readFileSync(fixturePath, 'utf8')) as {
+      formatVersion: number;
+      created: string;
+      payloads: Array<Record<string, unknown>>;
+    };
+
+    expect(manifest.formatVersion).toBe(1);
+    expect(manifest.created).toBe('2026-03-04T12:00:00Z');
+    expect(Array.isArray(manifest.payloads)).toBe(true);
+    expect(manifest.payloads.length).toBeGreaterThan(0);
+
+    for (const payload of manifest.payloads) {
+      for (const field of REQUIRED_PAYLOAD_FIELDS) {
+        expect(payload[field], field).toBeTruthy();
+      }
+      expect(payload.byteLength).toBe(44);
+      expect(payload.sha256).toBe(
+        '847c0a3ba356da0c127ec6a4b13f163dbca6e493887da801463e20bda8687122'
+      );
+    }
+  });
+});

--- a/test/fixtures/container-v1-minimal.json
+++ b/test/fixtures/container-v1-minimal.json
@@ -1,0 +1,18 @@
+{
+  "formatVersion": 1,
+  "created": "2026-03-04T12:00:00Z",
+  "agentId": "synthetic-fixture-agent",
+  "description": "Checked-in synthetic container v1 manifest example",
+  "encryption": {
+    "algorithm": "AES-256-GCM",
+    "keyDerivation": "Argon2id"
+  },
+  "payloads": [
+    {
+      "name": "personality",
+      "contentType": "application/json",
+      "byteLength": 44,
+      "sha256": "847c0a3ba356da0c127ec6a4b13f163dbca6e493887da801463e20bda8687122"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#36](https://github.com/dbhurley/savestate/issues/36). Readers of the container spec can now open the example it names.

`docs/state-container-v1.md` pointed at `test/fixtures/container-v1-minimal.json`, but that file was missing on `main` at `0d657d4`. This change checks in a synthetic v1 manifest and a focused field test.

## Proof
- Before: the documented fixture path did not exist.
- After: the fixture has `formatVersion` 1, `created`, and one payload with `name`, `contentType`, `byteLength`, and `sha256`.
- Focused: `src/container/__tests__/container-v1-minimal-fixture.test.ts` passes (1 test).

## Safety
No CLI, crypto, adapter, or package publish change. Synthetic data only.

## Residual risk
This is not the blocked #17 CLI journey fixture. Product-line authority for the fleet governor handoff is still an owner decision (#15).