### PR TITLE
Reject an empty payloads array on savestate verify

### DIFF
--- a/src/commands/__tests__/verify-empty-payloads.test.ts
+++ b/src/commands/__tests__/verify-empty-payloads.test.ts
@@ -1,0 +1,95 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { verifyContainer } from '../verify.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate verify empty payloads', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'savestate-verify-empty-payloads-'));
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(
+    name: string,
+    payloads: Array<Record<string, unknown>>,
+  ): Promise<string> {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest = {
+      formatVersion: 1,
+      created: '2026-08-18T12:00:00.000Z',
+      agentId: 'demo-agent',
+      payloads,
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, name);
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('rejects a container whose payloads array is empty', async () => {
+    const filePath = await writeContainer('empty-payloads.savestate', []);
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.message).toMatch(/payloads/i);
+    expect(result.message).not.toMatch(/agent_state/i);
+    expect(result.manifest).toBeUndefined();
+  });
+
+  it('still verifies a valid container with one payload', async () => {
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
+    const filePath = await writeContainer('valid-payloads.savestate', [
+      {
+        name: 'agent_state',
+        contentType: 'application/json',
+        byteLength: plaintext.length,
+        sha256: createHash('sha256').update(plaintext).digest('hex'),
+      },
+    ]);
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('valid');
+    expect(result.manifest?.agentId).toBe('demo-agent');
+  });
+
+  it('does not treat a wrong passphrase as an empty-payloads failure', async () => {
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
+    const filePath = await writeContainer('wrong-pass.savestate', [
+      {
+        name: 'agent_state',
+        contentType: 'application/json',
+        byteLength: plaintext.length,
+        sha256: createHash('sha256').update(plaintext).digest('hex'),
+      },
+    ]);
+
+    const result = await verifyContainer(filePath, { passphrase: 'wrong-pass' });
+
+    expect(result.status).toBe('wrong_password');
+    expect(result.message).not.toMatch(/payloads must contain/i);
+  });
+});

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -190,6 +190,14 @@ export async function verifyContainer(
     };
   }
 
+
+  if (!Array.isArray(manifest.payloads) || manifest.payloads.length === 0) {
+    return {
+      status: 'corrupted',
+      message: 'Invalid manifest: payloads must contain at least one payload',
+    };
+  }
+
   const payload = manifest.payloads.find((p: any) => p.name === 'agent_state');
   if (!payload || !payload.sha256) {
     return {


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#38](https://github.com/dbhurley/savestate/issues/38). Users no longer see a missing-component error when the required payloads list is empty.

`savestate verify` already rejected a missing `payloads` field, then looked for `agent_state`. An empty array passed the structure check. The container spec requires at least one payload. This change rejects an empty list as `corrupted`.

## Proof
- Before: a container with `payloads: []` failed as a missing `agent_state` payload.
- After: `savestate verify` returns `corrupted` and names the empty payloads list. A valid one-payload container still verifies. Wrong-passphrase results are unchanged.
- Focused: `src/commands/__tests__/verify-empty-payloads.test.ts` passed (3 tests).

## Safety
No encryption, container format, live adapter, or package publish change.

## Residual risk
Import still uses the placeholder restore. Live adapter restore stays out of this issue. Product-line authority for the fleet governor handoff is still an owner decision (#15).