### PR TITLE
Reject an invalid created timestamp on savestate verify

### DIFF
--- a/src/commands/__tests__/verify-created-timestamp.test.ts
+++ b/src/commands/__tests__/verify-created-timestamp.test.ts
@@ -1,0 +1,92 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { verifyContainer } from '../verify.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate verify created timestamp format', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'savestate-verify-created-timestamp-'));
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(fileName: string, created: string): Promise<string> {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest = {
+      formatVersion: 1,
+      created,
+      agentId: 'demo-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: createHash('sha256').update(plaintext).digest('hex'),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('rejects a container whose created timestamp is not ISO 8601', async () => {
+    const filePath = await writeContainer('invalid-created.savestate', 'not-a-timestamp');
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.message).toMatch(/created timestamp/i);
+    expect(result.manifest).toBeUndefined();
+  });
+
+  it('rejects a container whose created value is a date only', async () => {
+    const filePath = await writeContainer('date-only-created.savestate', '2026-08-18');
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.message).toMatch(/created timestamp/i);
+    expect(result.manifest).toBeUndefined();
+  });
+
+  it('still verifies a valid container with an ISO 8601 created timestamp', async () => {
+    const filePath = await writeContainer('valid-created.savestate', '2026-08-18T16:51:00.000Z');
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('valid');
+    expect(result.manifest?.agentId).toBe('demo-agent');
+  });
+
+  it('does not treat a wrong passphrase as a created-timestamp failure', async () => {
+    const filePath = await writeContainer('wrong-pass.savestate', '2026-08-18T16:51:00.000Z');
+
+    const result = await verifyContainer(filePath, { passphrase: 'wrong-pass' });
+
+    expect(result.status).toBe('wrong_password');
+    expect(result.message).not.toMatch(/created timestamp/i);
+  });
+});

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -253,6 +253,18 @@ export async function verifyContainer(
     };
   }
 
+
+  if (
+    typeof manifest.created === 'string' &&
+    manifest.created.trim() !== '' &&
+    !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/.test(manifest.created)
+  ) {
+    return {
+      status: 'corrupted',
+      message: 'Invalid manifest: created timestamp must be ISO 8601',
+    };
+  }
+
   const payload = manifest.payloads.find((p: any) => p.name === 'agent_state');
   if (!payload || !payload.sha256) {
     return {


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#43](https://github.com/dbhurley/savestate/issues/43). Users no longer see a valid result when the created timestamp is present but not ISO 8601.

`savestate verify` already continues after the structure check. A non-empty `created` value that is not an ISO 8601 timestamp still verified. The container spec requires an ISO 8601 timestamp. This change rejects a bad timestamp as `corrupted`.

## Proof
- Before: a container with `created: "not-a-timestamp"` verified as valid.
- After: `savestate verify` returns `corrupted` and names the created timestamp. A valid ISO 8601 container still verifies. Wrong-passphrase results are unchanged.
- Focused: `src/commands/__tests__/verify-created-timestamp.test.ts` passed (4 tests).

## Safety
No encryption, container format, live adapter, or package publish change.

## Residual risk
Import still uses the placeholder restore. Live adapter restore stays out of this issue. Product-line authority for the fleet governor handoff is still an owner decision (#15).