### PR TITLE
Reject an invalid payload checksum format on savestate verify

### DIFF
--- a/src/commands/__tests__/verify-payload-checksum-format.test.ts
+++ b/src/commands/__tests__/verify-payload-checksum-format.test.ts
@@ -1,0 +1,101 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { verifyContainer } from '../verify.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate verify payload checksum format', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'savestate-verify-payload-checksum-format-'));
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(fileName: string, extraSha256: string): Promise<string> {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const actualHash = createHash('sha256').update(plaintext).digest('hex');
+    const manifest = {
+      formatVersion: 1,
+      created: '2026-08-18T17:02:00.000Z',
+      agentId: 'demo-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: actualHash,
+        },
+        {
+          name: 'memory',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: extraSha256,
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('rejects a container whose payload checksum is not hex', async () => {
+    const filePath = await writeContainer('invalid-checksum.savestate', 'not-a-hex-digest');
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.message).toMatch(/payload checksum/i);
+    expect(result.manifest).toBeUndefined();
+  });
+
+  it('rejects a container whose payload checksum is the wrong length', async () => {
+    const filePath = await writeContainer('short-checksum.savestate', 'abc123');
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.message).toMatch(/payload checksum/i);
+    expect(result.manifest).toBeUndefined();
+  });
+
+  it('still verifies a valid container with hex SHA-256 payload checksums', async () => {
+    const actualHash = createHash('sha256').update(Buffer.from(JSON.stringify({ memory: ['demo'] }))).digest('hex');
+    const filePath = await writeContainer('valid-checksum.savestate', actualHash);
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('valid');
+    expect(result.manifest?.agentId).toBe('demo-agent');
+  });
+
+  it('does not treat a wrong passphrase as a checksum format failure', async () => {
+    const actualHash = createHash('sha256').update(Buffer.from(JSON.stringify({ memory: ['demo'] }))).digest('hex');
+    const filePath = await writeContainer('wrong-pass.savestate', actualHash);
+
+    const result = await verifyContainer(filePath, { passphrase: 'wrong-pass' });
+
+    expect(result.status).toBe('wrong_password');
+    expect(result.message).not.toMatch(/payload checksum/i);
+  });
+});

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -265,6 +265,22 @@ export async function verifyContainer(
     };
   }
 
+
+  if (
+    Array.isArray(manifest.payloads) &&
+    manifest.payloads.some(
+      (entry: { sha256?: unknown }) =>
+        typeof entry?.sha256 === 'string' &&
+        entry.sha256.trim() !== '' &&
+        !/^[0-9a-fA-F]{64}$/.test(entry.sha256),
+    )
+  ) {
+    return {
+      status: 'corrupted',
+      message: 'Invalid manifest: payload checksum must be a hex SHA-256 digest',
+    };
+  }
+
   const payload = manifest.payloads.find((p: any) => p.name === 'agent_state');
   if (!payload || !payload.sha256) {
     return {


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#44](https://github.com/dbhurley/savestate/issues/44). Users no longer see a valid result when a packed payload checksum is present but is not a hex SHA-256 digest.

`savestate verify` already accepted a second payload that had a name and size. A payload with a non-empty `sha256` that is not 64 hex characters still decrypted, then failed as a checksum mismatch. The container spec requires each payload checksum to be a hex-encoded hash. This change rejects a malformed checksum as `corrupted` before decryption.

## Proof
- Before: a container whose extra payload checksum was `not-a-hex-digest` decrypted, then failed as a checksum mismatch.
- After: `savestate verify` returns `corrupted` and names the payload checksum. A hex SHA-256 checksum still verifies. Wrong-passphrase results are unchanged.
- Focused: `src/commands/__tests__/verify-payload-checksum-format.test.ts` passes (4 tests).

## Safety
No encryption, container format, live adapter, or package publish change.

## Residual risk
Import still uses the placeholder restore. Live adapter restore stays out of this issue. Product-line authority for the fleet governor handoff is still an owner decision (#15).