### PR TITLE
Reject a non-1 formatVersion on savestate verify

### DIFF
--- a/src/commands/__tests__/verify-format-version.test.ts
+++ b/src/commands/__tests__/verify-format-version.test.ts
@@ -1,0 +1,96 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { verifyContainer } from '../verify.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate verify formatVersion', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'savestate-verify-format-version-'));
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(
+    fileName: string,
+    formatVersion: unknown,
+  ): Promise<string> {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const actualHash = createHash('sha256').update(plaintext).digest('hex');
+    const manifest = {
+      formatVersion,
+      created: '2026-08-18T21:02:00.000Z',
+      agentId: 'demo-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: actualHash,
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('rejects a container whose formatVersion is not 1', async () => {
+    const filePath = await writeContainer('format-version-2.savestate', 2);
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.message).toMatch(/formatVersion/i);
+    expect(result.manifest).toBeUndefined();
+  });
+
+  it('rejects a container whose formatVersion is a string', async () => {
+    const filePath = await writeContainer('format-version-string.savestate', '1');
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.message).toMatch(/formatVersion/i);
+    expect(result.manifest).toBeUndefined();
+  });
+
+  it('still verifies a valid container with formatVersion 1', async () => {
+    const filePath = await writeContainer('valid-format-version.savestate', 1);
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('valid');
+    expect(result.manifest?.agentId).toBe('demo-agent');
+  });
+
+  it('does not treat a wrong passphrase as a formatVersion failure', async () => {
+    const filePath = await writeContainer('wrong-pass.savestate', 1);
+
+    const result = await verifyContainer(filePath, { passphrase: 'wrong-pass' });
+
+    expect(result.status).toBe('wrong_password');
+    expect(result.message).not.toMatch(/formatVersion/i);
+  });
+});

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -336,6 +336,14 @@ export async function verifyContainer(
     };
   }
 
+
+  if (manifest.formatVersion !== 1) {
+    return {
+      status: 'corrupted',
+      message: 'Invalid manifest: formatVersion must be 1',
+    };
+  }
+
   const payload = manifest.payloads.find((p: any) => p.name === 'agent_state');
   if (!payload || !payload.sha256) {
     return {


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#49](https://github.com/dbhurley/savestate/issues/49). Users no longer see a valid result when the manifest claims a format version other than 1.

`savestate verify` already checks that `formatVersion` is present and truthy. A value such as `2` or the string `"1"` still passed that check and could verify as valid. The container spec requires `formatVersion` to be the integer `1`. This change rejects a non-1 formatVersion as `corrupted` before decryption.

## Proof
- Before: a container whose `formatVersion` was `2` or `"1"` verified as valid.
- After: `savestate verify` returns `corrupted` and names formatVersion. Integer `1` still verifies. Wrong-passphrase results are unchanged.
- Focused: `src/commands/__tests__/verify-format-version.test.ts` passed (4 tests).

## Safety
No encryption, container format, live adapter, or package publish change.

## Residual risk
Import still uses the placeholder restore. Live adapter restore stays out of this issue. Product-line authority for the fleet governor handoff is still an owner decision (#15).
