### PR TITLE
Reject a non-string agentId on savestate verify

### DIFF
--- a/src/commands/__tests__/verify-agent-id.test.ts
+++ b/src/commands/__tests__/verify-agent-id.test.ts
@@ -1,0 +1,96 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { verifyContainer } from '../verify.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate verify agentId', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'savestate-verify-agent-id-'));
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(
+    fileName: string,
+    agentId: unknown,
+  ): Promise<string> {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const actualHash = createHash('sha256').update(plaintext).digest('hex');
+    const manifest = {
+      formatVersion: 1,
+      created: '2026-08-18T22:01:00.000Z',
+      agentId,
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: actualHash,
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('rejects a container whose agentId is a number', async () => {
+    const filePath = await writeContainer('agent-id-number.savestate', 123);
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.message).toMatch(/agentId/i);
+    expect(result.manifest).toBeUndefined();
+  });
+
+  it('rejects a container whose agentId is an object', async () => {
+    const filePath = await writeContainer('agent-id-object.savestate', { id: 'demo-agent' });
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.message).toMatch(/agentId/i);
+    expect(result.manifest).toBeUndefined();
+  });
+
+  it('still verifies a valid container with a string agentId', async () => {
+    const filePath = await writeContainer('valid-agent-id.savestate', 'demo-agent');
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('valid');
+    expect(result.manifest?.agentId).toBe('demo-agent');
+  });
+
+  it('does not treat a wrong passphrase as an agentId failure', async () => {
+    const filePath = await writeContainer('wrong-pass.savestate', 'demo-agent');
+
+    const result = await verifyContainer(filePath, { passphrase: 'wrong-pass' });
+
+    expect(result.status).toBe('wrong_password');
+    expect(result.message).not.toMatch(/agentId/i);
+  });
+});

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -344,6 +344,14 @@ export async function verifyContainer(
     };
   }
 
+
+  if (typeof manifest.agentId !== 'string') {
+    return {
+      status: 'corrupted',
+      message: 'Invalid manifest: agentId must be a string',
+    };
+  }
+
   const payload = manifest.payloads.find((p: any) => p.name === 'agent_state');
   if (!payload || !payload.sha256) {
     return {


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#50](https://github.com/dbhurley/savestate/issues/50). Users no longer see a valid result when the manifest agentId is not a string.

`savestate verify` already checks that `agentId` is present and truthy. A value such as `123` or an object still passed that check and could verify as valid. The container spec requires `agentId` to be a string. This change rejects a non-string agentId as `corrupted` before decryption.

## Proof
- Before: a container whose `agentId` was `123` or an object verified as valid.
- After: `savestate verify` returns `corrupted` and names agentId. A string agentId still verifies. Wrong-passphrase results are unchanged.
- Focused: `src/commands/__tests__/verify-agent-id.test.ts` passed (4 tests).

## Safety
No encryption, container format, live adapter, or package publish change.

## Residual risk
Import still uses the placeholder restore. Live adapter restore stays out of this issue. Product-line authority for the fleet governor handoff is still an owner decision (#15).