### PR TITLE
Reject a non-string payload name on savestate verify

### DIFF
--- a/src/commands/__tests__/verify-payload-name.test.ts
+++ b/src/commands/__tests__/verify-payload-name.test.ts
@@ -26,24 +26,24 @@ describe('savestate verify payload name', () => {
 
   async function writeContainer(
     fileName: string,
-    payloadName: string | undefined,
+    payloadName: unknown,
   ): Promise<string> {
     const passphrase = 'synthetic-verify-pass';
     const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
     const encryptedState = await encrypt(plaintext, { passphrase });
-    const payload: Record<string, unknown> = {
-      contentType: 'application/json',
-      byteLength: plaintext.length,
-      sha256: createHash('sha256').update(plaintext).digest('hex'),
-    };
-    if (payloadName !== undefined) {
-      payload.name = payloadName;
-    }
+    const actualHash = createHash('sha256').update(plaintext).digest('hex');
     const manifest = {
       formatVersion: 1,
-      created: '2026-08-18T13:00:00.000Z',
+      created: '2026-08-18T23:01:00.000Z',
       agentId: 'demo-agent',
-      payloads: [payload],
+      payloads: [
+        {
+          name: payloadName,
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: actualHash,
+        },
+      ],
     };
     const manifestBuffer = Buffer.from(JSON.stringify(manifest));
     const manifestLength = Buffer.alloc(4);
@@ -56,8 +56,8 @@ describe('savestate verify payload name', () => {
     return filePath;
   }
 
-  it('rejects a container whose payload name is missing', async () => {
-    const filePath = await writeContainer('missing-name.savestate', undefined);
+  it('rejects a container whose payload name is a number', async () => {
+    const filePath = await writeContainer('payload-name-number.savestate', 123);
 
     const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
 
@@ -66,8 +66,8 @@ describe('savestate verify payload name', () => {
     expect(result.manifest).toBeUndefined();
   });
 
-  it('rejects a container whose payload name is empty', async () => {
-    const filePath = await writeContainer('empty-name.savestate', '   ');
+  it('rejects a container whose payload name is an object', async () => {
+    const filePath = await writeContainer('payload-name-object.savestate', { id: 'agent_state' });
 
     const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
 
@@ -76,8 +76,8 @@ describe('savestate verify payload name', () => {
     expect(result.manifest).toBeUndefined();
   });
 
-  it('still verifies a valid container with a named payload', async () => {
-    const filePath = await writeContainer('valid-name.savestate', 'agent_state');
+  it('still verifies a valid container with a string payload name', async () => {
+    const filePath = await writeContainer('valid-payload-name.savestate', 'agent_state');
 
     const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
 
@@ -85,7 +85,7 @@ describe('savestate verify payload name', () => {
     expect(result.manifest?.agentId).toBe('demo-agent');
   });
 
-  it('does not treat a wrong passphrase as a payload-name failure', async () => {
+  it('does not treat a wrong passphrase as a payload name failure', async () => {
     const filePath = await writeContainer('wrong-pass.savestate', 'agent_state');
 
     const result = await verifyContainer(filePath, { passphrase: 'wrong-pass' });

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -352,6 +352,23 @@ export async function verifyContainer(
     };
   }
 
+
+  if (Array.isArray(manifest.payloads)) {
+    for (const entry of manifest.payloads) {
+      if (
+        entry &&
+        typeof entry === 'object' &&
+        'name' in entry &&
+        typeof entry.name !== 'string'
+      ) {
+        return {
+          status: 'corrupted',
+          message: 'Invalid manifest: payload name must be a string',
+        };
+      }
+    }
+  }
+
   const payload = manifest.payloads.find((p: any) => p.name === 'agent_state');
   if (!payload || !payload.sha256) {
     return {


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#51](https://github.com/dbhurley/savestate/issues/51). Users no longer see a missing-component result when a packed payload name is not a string.

`savestate verify` finds the `agent_state` payload by comparing `name` to a string. A value such as `123` or an object fails that lookup and looks like a missing payload. The container spec requires each payload `name` to be a string. This change rejects a non-string payload name as `corrupted` before decryption.

## Proof
- Before: a container whose payload `name` was `123` or an object failed as a missing `agent_state` payload.
- After: `savestate verify` returns `corrupted` and names the payload name field. A string payload name still verifies. Wrong-passphrase results are unchanged.
- Focused: `src/commands/__tests__/verify-payload-name.test.ts` passed (4 tests).

## Safety
No encryption, container format, live adapter, or package publish change.

## Residual risk
Import still uses the placeholder restore. Live adapter restore stays out of this issue. Product-line authority for the fleet governor handoff is still an owner decision (#15).