### PR TITLE
Reject an empty payload content type on savestate verify

### DIFF
--- a/src/commands/__tests__/verify-empty-payload-content-type.test.ts
+++ b/src/commands/__tests__/verify-empty-payload-content-type.test.ts
@@ -1,0 +1,96 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { verifyContainer } from '../verify.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate verify empty payload content type', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'savestate-verify-empty-payload-content-type-'));
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(
+    fileName: string,
+    contentType: unknown,
+  ): Promise<string> {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const actualHash = createHash('sha256').update(plaintext).digest('hex');
+    const manifest = {
+      formatVersion: 1,
+      created: '2026-08-19T01:01:00.000Z',
+      agentId: 'demo-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType,
+          byteLength: plaintext.length,
+          sha256: actualHash,
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('rejects a container whose payload content type is empty', async () => {
+    const filePath = await writeContainer('payload-content-type-empty.savestate', '');
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.message).toMatch(/payload content type/i);
+    expect(result.manifest).toBeUndefined();
+  });
+
+  it('rejects a container whose payload content type is whitespace-only', async () => {
+    const filePath = await writeContainer('payload-content-type-whitespace.savestate', '   ');
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.message).toMatch(/payload content type/i);
+    expect(result.manifest).toBeUndefined();
+  });
+
+  it('still verifies a valid container with a non-empty string payload content type', async () => {
+    const filePath = await writeContainer('valid-payload-content-type.savestate', 'application/json');
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('valid');
+    expect(result.manifest?.agentId).toBe('demo-agent');
+  });
+
+  it('does not treat a wrong passphrase as a payload content type failure', async () => {
+    const filePath = await writeContainer('wrong-pass.savestate', 'application/json');
+
+    const result = await verifyContainer(filePath, { passphrase: 'wrong-pass' });
+
+    expect(result.status).toBe('wrong_password');
+    expect(result.message).not.toMatch(/payload content type/i);
+  });
+});

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -106,6 +106,23 @@ export async function verifyContainer(
     };
   }
 
+  if (Array.isArray(manifest.payloads)) {
+    for (const entry of manifest.payloads) {
+      if (
+        entry &&
+        typeof entry === 'object' &&
+        'contentType' in entry &&
+        typeof entry.contentType === 'string' &&
+        entry.contentType.trim() === ''
+      ) {
+        return {
+          status: 'corrupted',
+          message: 'Invalid manifest: payload content type must not be empty',
+        };
+      }
+    }
+  }
+
   const payload = manifest.payloads.find((p: any) => p.name === 'agent_state');
   if (!payload || !payload.sha256) {
     return {


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#53](https://github.com/dbhurley/savestate/issues/53). Users no longer see a valid result when a packed payload content type is empty or whitespace-only.

`savestate verify` does not reject an empty or whitespace-only `contentType`. A payload whose `contentType` is `""` still verified as valid. The container spec requires each payload `contentType` to be a string MIME type. This change rejects an empty payload content type as `corrupted` before decryption.

## Proof
- Before: a container whose payload `contentType` was `""` or whitespace verified as valid.
- After: `savestate verify` returns `corrupted` and names the payload content type field. A non-empty string payload content type still verifies. Wrong-passphrase results are unchanged.
- Focused: `src/commands/__tests__/verify-empty-payload-content-type.test.ts` passed (4 tests).

## Safety
No encryption, container format, live adapter, or package publish change.

## Residual risk
Import still uses the placeholder restore. Live adapter restore stays out of this issue. Product-line authority for the fleet governor handoff is still an owner decision (#15).