### PR TITLE
Reject an empty payload name on savestate verify

### DIFF
--- a/src/commands/__tests__/verify-empty-payload-name.test.ts
+++ b/src/commands/__tests__/verify-empty-payload-name.test.ts
@@ -1,0 +1,94 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { verifyContainer } from '../verify.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate verify empty payload name', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'savestate-verify-empty-payload-name-'));
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(
+    fileName: string,
+    names: unknown[],
+  ): Promise<string> {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const actualHash = createHash('sha256').update(plaintext).digest('hex');
+    const manifest = {
+      formatVersion: 1,
+      created: '2026-08-19T01:03:00.000Z',
+      agentId: 'demo-agent',
+      payloads: names.map((name) => ({
+        name,
+        contentType: 'application/json',
+        byteLength: plaintext.length,
+        sha256: actualHash,
+      })),
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('rejects a container whose payload name is empty', async () => {
+    const filePath = await writeContainer('payload-name-empty.savestate', ['', 'agent_state']);
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.message).toMatch(/payload name/i);
+    expect(result.manifest).toBeUndefined();
+  });
+
+  it('rejects a container whose payload name is whitespace-only', async () => {
+    const filePath = await writeContainer('payload-name-whitespace.savestate', ['   ', 'agent_state']);
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.message).toMatch(/payload name/i);
+    expect(result.manifest).toBeUndefined();
+  });
+
+  it('still verifies a valid container with a non-empty string payload name', async () => {
+    const filePath = await writeContainer('valid-payload-name.savestate', ['agent_state']);
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('valid');
+    expect(result.manifest?.agentId).toBe('demo-agent');
+  });
+
+  it('does not treat a wrong passphrase as a payload name failure', async () => {
+    const filePath = await writeContainer('wrong-pass.savestate', ['agent_state']);
+
+    const result = await verifyContainer(filePath, { passphrase: 'wrong-pass' });
+
+    expect(result.status).toBe('wrong_password');
+    expect(result.message).not.toMatch(/payload name/i);
+  });
+});

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -404,6 +404,24 @@ export async function verifyContainer(
     }
   }
 
+
+  if (Array.isArray(manifest.payloads)) {
+    for (const entry of manifest.payloads) {
+      if (
+        entry &&
+        typeof entry === 'object' &&
+        'name' in entry &&
+        typeof entry.name === 'string' &&
+        entry.name.trim() === ''
+      ) {
+        return {
+          status: 'corrupted',
+          message: 'Invalid manifest: payload name must not be empty',
+        };
+      }
+    }
+  }
+
   const payload = manifest.payloads.find((p: any) => p.name === 'agent_state');
   if (!payload || !payload.sha256) {
     return {


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#54](https://github.com/dbhurley/savestate/issues/54). Users no longer see a valid result when a packed payload name is empty or whitespace-only.

`savestate verify` does not reject an empty or whitespace-only `name`. A payload whose `name` is `""` still verified as valid. The container spec requires each payload `name` to be a string identifier. This change rejects an empty payload name as `corrupted` before decryption.

## Proof
- Before: a container whose payload `name` was `""` or whitespace verified as valid when another `agent_state` payload was present.
- After: `savestate verify` returns `corrupted` and names the payload name field. A non-empty string payload name still verifies. Wrong-passphrase results are unchanged.
- Focused: `src/commands/__tests__/verify-empty-payload-name.test.ts` passed (4 tests).

## Safety
No encryption, container format, live adapter, or package publish change.

## Residual risk
Import still uses the placeholder restore. Live adapter restore stays out of this issue. Product-line authority for the fleet governor handoff is still an owner decision (#15).