### PR TITLE
Reject an empty created timestamp on savestate verify

### DIFF
--- a/src/commands/__tests__/verify-empty-created.test.ts
+++ b/src/commands/__tests__/verify-empty-created.test.ts
@@ -1,0 +1,97 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { verifyContainer } from '../verify.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate verify empty created timestamp', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'savestate-verify-empty-created-'));
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(
+    fileName: string,
+    created: string,
+  ): Promise<string> {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const actualHash = createHash('sha256').update(plaintext).digest('hex');
+    const manifest = {
+      formatVersion: 1,
+      created,
+      agentId: 'demo-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: actualHash,
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('rejects a container whose created timestamp is empty', async () => {
+    const filePath = await writeContainer('created-empty.savestate', '');
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.message).toMatch(/created timestamp/i);
+    expect(result.manifest).toBeUndefined();
+  });
+
+  it('rejects a container whose created timestamp is whitespace-only', async () => {
+    const filePath = await writeContainer('created-whitespace.savestate', '   ');
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.message).toMatch(/created timestamp/i);
+    expect(result.manifest).toBeUndefined();
+  });
+
+  it('still verifies a valid container with a non-empty ISO created timestamp', async () => {
+    const filePath = await writeContainer('valid-created.savestate', '2026-08-19T03:02:00.000Z');
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('valid');
+    expect(result.manifest?.agentId).toBe('demo-agent');
+    expect(result.manifest?.created).toBe('2026-08-19T03:02:00.000Z');
+  });
+
+  it('does not treat a wrong passphrase as a created timestamp failure', async () => {
+    const filePath = await writeContainer('wrong-pass.savestate', '2026-08-19T03:02:00.000Z');
+
+    const result = await verifyContainer(filePath, { passphrase: 'wrong-pass' });
+
+    expect(result.status).toBe('wrong_password');
+    expect(result.message).not.toMatch(/created timestamp/i);
+  });
+});

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -440,6 +440,18 @@ export async function verifyContainer(
     }
   }
 
+
+  if (
+    'created' in manifest &&
+    typeof manifest.created === 'string' &&
+    manifest.created.trim() === ''
+  ) {
+    return {
+      status: 'corrupted',
+      message: 'Invalid manifest: created timestamp must not be empty',
+    };
+  }
+
   const payload = manifest.payloads.find((p: any) => p.name === 'agent_state');
   if (!payload || !payload.sha256) {
     return {


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#56](https://github.com/dbhurley/savestate/issues/56). Users no longer see a valid result when the manifest created timestamp is empty or whitespace-only.

`savestate verify` does not reject an empty or whitespace-only `created`. A container whose `created` is `""` still verified as valid when the rest of the file was intact. The container spec requires `created` to be an ISO 8601 timestamp. This change rejects an empty created timestamp as `corrupted` before decryption.

## Proof
- Before: a container whose `created` was `""` or whitespace verified as valid.
- After: `savestate verify` returns `corrupted` and names the created timestamp field. A non-empty ISO created timestamp still verifies. Wrong-passphrase results are unchanged.
- Focused: `src/commands/__tests__/verify-empty-created.test.ts` passed (4 tests).

## Safety
No encryption, container format, live adapter, or package publish change.

## Residual risk
Import still uses the placeholder restore. Live adapter restore stays out of this issue. Product-line authority for the fleet governor handoff is still an owner decision (#15).