### PR TITLE
Reject an empty agentId on savestate verify

### DIFF
--- a/src/commands/__tests__/verify-empty-agentid.test.ts
+++ b/src/commands/__tests__/verify-empty-agentid.test.ts
@@ -1,0 +1,96 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { verifyContainer } from '../verify.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate verify empty agentId', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'savestate-verify-empty-agentid-'));
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(
+    fileName: string,
+    agentId: string,
+  ): Promise<string> {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const actualHash = createHash('sha256').update(plaintext).digest('hex');
+    const manifest = {
+      formatVersion: 1,
+      created: '2026-08-19T04:00:00.000Z',
+      agentId,
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: actualHash,
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('rejects a container whose agentId is empty', async () => {
+    const filePath = await writeContainer('agentid-empty.savestate', '');
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.message).toMatch(/agentId/i);
+    expect(result.manifest).toBeUndefined();
+  });
+
+  it('rejects a container whose agentId is whitespace-only', async () => {
+    const filePath = await writeContainer('agentid-whitespace.savestate', '   ');
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.message).toMatch(/agentId/i);
+    expect(result.manifest).toBeUndefined();
+  });
+
+  it('still verifies a valid container with a non-empty agentId', async () => {
+    const filePath = await writeContainer('valid-agentid.savestate', 'demo-agent');
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('valid');
+    expect(result.manifest?.agentId).toBe('demo-agent');
+  });
+
+  it('does not treat a wrong passphrase as an agentId failure', async () => {
+    const filePath = await writeContainer('wrong-pass.savestate', 'demo-agent');
+
+    const result = await verifyContainer(filePath, { passphrase: 'wrong-pass' });
+
+    expect(result.status).toBe('wrong_password');
+    expect(result.message).not.toMatch(/agentId/i);
+  });
+});

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -98,6 +98,17 @@ export async function verifyContainer(
     };
   }
 
+  if (
+    'agentId' in manifest &&
+    typeof manifest.agentId === 'string' &&
+    manifest.agentId.trim() === ''
+  ) {
+    return {
+      status: 'corrupted',
+      message: 'Invalid manifest: agentId must not be empty',
+    };
+  }
+
   // Validate manifest structure
   if (!manifest.formatVersion || !manifest.agentId || !manifest.payloads) {
     return {


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#57](https://github.com/dbhurley/savestate/issues/57). Users no longer see a valid result when the manifest agentId is empty or whitespace-only.

`savestate verify` does not reject a whitespace-only `agentId`. A container whose `agentId` is `"   "` still verified as valid when the rest of the file was intact. An empty string failed only as generic invalid structure. This change rejects an empty or whitespace-only agentId as `corrupted` before decryption.

## Proof
- Before: a container whose `agentId` was whitespace-only verified as valid. An empty `agentId` failed as generic invalid structure.
- After: `savestate verify` returns `corrupted` and names the agentId field. A non-empty agentId still verifies. Wrong-passphrase results are unchanged.
- Focused: `src/commands/__tests__/verify-empty-agentid.test.ts` passed (4 tests).

## Safety
No encryption, container format, live adapter, or package publish change.

## Residual risk
Import still uses the placeholder restore. Live adapter restore stays out of this issue. Product-line authority for the fleet governor handoff is still an owner decision (#15).