### PR TITLE
Reject a non-string created timestamp on savestate verify

### DIFF
--- a/src/commands/__tests__/verify-nonstring-created.test.ts
+++ b/src/commands/__tests__/verify-nonstring-created.test.ts
@@ -1,0 +1,96 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { verifyContainer } from '../verify.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate verify non-string created', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'savestate-verify-nonstring-created-'));
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(
+    fileName: string,
+    created: unknown,
+  ): Promise<string> {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const actualHash = createHash('sha256').update(plaintext).digest('hex');
+    const manifest = {
+      formatVersion: 1,
+      created,
+      agentId: 'demo-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: actualHash,
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('rejects a container whose created timestamp is a number', async () => {
+    const filePath = await writeContainer('created-number.savestate', 1755571380);
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.message).toMatch(/created/i);
+    expect(result.manifest).toBeUndefined();
+  });
+
+  it('rejects a container whose created timestamp is a boolean', async () => {
+    const filePath = await writeContainer('created-boolean.savestate', true);
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.message).toMatch(/created/i);
+    expect(result.manifest).toBeUndefined();
+  });
+
+  it('still verifies a valid container with a string created timestamp', async () => {
+    const filePath = await writeContainer('valid-created.savestate', '2026-08-19T05:03:00.000Z');
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('valid');
+    expect(result.manifest?.agentId).toBe('demo-agent');
+  });
+
+  it('does not treat a wrong passphrase as a created timestamp failure', async () => {
+    const filePath = await writeContainer('wrong-pass.savestate', '2026-08-19T05:03:00.000Z');
+
+    const result = await verifyContainer(filePath, { passphrase: 'wrong-pass' });
+
+    expect(result.status).toBe('wrong_password');
+    expect(result.message).not.toMatch(/created/i);
+  });
+});

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -452,6 +452,14 @@ export async function verifyContainer(
     };
   }
 
+
+  if ('created' in manifest && typeof manifest.created !== 'string') {
+    return {
+      status: 'corrupted',
+      message: 'Invalid manifest: created must be a string',
+    };
+  }
+
   const payload = manifest.payloads.find((p: any) => p.name === 'agent_state');
   if (!payload || !payload.sha256) {
     return {


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#58](https://github.com/dbhurley/savestate/issues/58). Users no longer see a valid result when the manifest created timestamp is not a string.

`savestate verify` does not check the type of `created`. A container whose `created` is a number, boolean, or object still verified as valid when the rest of the file was intact. This change rejects a non-string created timestamp as `corrupted` before decryption.

## Proof
- Before: a container whose `created` was a number or boolean verified as valid.
- After: `savestate verify` returns `corrupted` and names the created field. A string created timestamp still verifies. Wrong-passphrase results are unchanged.
- Focused: `src/commands/__tests__/verify-nonstring-created.test.ts` passed (4 tests).

## Safety
No encryption, container format, live adapter, or package publish change.

## Residual risk
Import still uses the placeholder restore. Live adapter restore stays out of this issue. Product-line authority for the fleet governor handoff is still an owner decision (#15). The local governor worklog and `docs/TASKS.md` remain missing on this fleet checkout.