### PR TITLE
Print the optional manifest description on savestate verify

### DIFF
--- a/src/commands/__tests__/verify-description.test.ts
+++ b/src/commands/__tests__/verify-description.test.ts
@@ -1,0 +1,103 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { verifyContainer } from '../verify.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate verify optional description', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'savestate-verify-description-'));
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(
+    fileName: string,
+    description?: string,
+  ): Promise<string> {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const actualHash = createHash('sha256').update(plaintext).digest('hex');
+    const manifest: Record<string, unknown> = {
+      formatVersion: 1,
+      created: '2026-08-19T05:04:00.000Z',
+      agentId: 'demo-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: actualHash,
+        },
+      ],
+    };
+    if (description !== undefined) {
+      manifest.description = description;
+    }
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('returns the description when the manifest has a non-empty string', async () => {
+    const filePath = await writeContainer(
+      'with-description.savestate',
+      'Minimal v1 container for verify',
+    );
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('valid');
+    expect(result.manifest?.description).toBe('Minimal v1 container for verify');
+  });
+
+  it('still verifies a valid container without a description', async () => {
+    const filePath = await writeContainer('no-description.savestate');
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('valid');
+    expect(result.manifest?.description).toBeUndefined();
+  });
+
+  it('does not invent a description from whitespace', async () => {
+    const filePath = await writeContainer('blank-description.savestate', '   ');
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('valid');
+    expect(result.manifest?.description).toBeUndefined();
+  });
+
+  it('does not treat a wrong passphrase as a description failure', async () => {
+    const filePath = await writeContainer(
+      'wrong-pass.savestate',
+      'Labeled container',
+    );
+
+    const result = await verifyContainer(filePath, { passphrase: 'wrong-pass' });
+
+    expect(result.status).toBe('wrong_password');
+    expect(result.manifest?.description).toBeUndefined();
+  });
+});

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -22,6 +22,7 @@ export interface VerifyResult {
     agentId: string;
     created: string;
     formatVersion: number;
+    description?: string;
   };
   components?: string[];
 }
@@ -64,6 +65,15 @@ function resolveKeyDerivation(manifest: { encryption?: { keyDerivation?: unknown
     return named;
   }
   return DEFAULT_VERIFY_KDF;
+}
+
+
+function optionalDescription(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const description = value.trim();
+  return description.length > 0 ? description : undefined;
 }
 
 const STATE_METADATA_KEYS = new Set(['agentId', 'version', 'exportedAt']);
@@ -522,6 +532,8 @@ export async function verifyContainer(
     };
   }
 
+  const description = optionalDescription(manifest.description);
+
   return {
     status: 'valid',
     message: 'State file is valid and verified',
@@ -534,6 +546,7 @@ export async function verifyContainer(
       agentId: manifest.agentId,
       created: manifest.created,
       formatVersion: manifest.formatVersion,
+      ...(description ? { description } : {}),
     },
     components,
   };
@@ -561,6 +574,9 @@ export function formatVerifyResult(result: VerifyResult, json: boolean): string 
         lines.push(`   Agent: ${result.manifest.agentId}`);
         lines.push(`   Created: ${result.manifest.created}`);
         lines.push(`   Format: v${result.manifest.formatVersion}`);
+        if (result.manifest.description) {
+          lines.push(`   Description: ${result.manifest.description}`);
+        }
       }
       lines.push(
         `   Components: ${result.components && result.components.length > 0 ? result.components.join(', ') : 'none'}`,


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#59](https://github.com/dbhurley/savestate/issues/59). Users can now see a labeled container's description before import.

`savestate verify` printed Agent, Created, and Format. It did not print the optional manifest description. A container with a description looked the same as one without. This change returns and prints a non-empty description on a valid verify.

## Proof
- Before: a valid container with a description verified and omitted the description.
- After: `savestate verify` includes the description on a valid result and prints it. A container without a description still verifies and does not invent one. Wrong-passphrase results are unchanged.
- Focused: `src/commands/__tests__/verify-description.test.ts` passed (4 tests).

## Safety
No encryption, container format, live adapter, or package publish change.

## Residual risk
Import still uses the placeholder restore. Live adapter restore stays out of this issue. Product-line authority for the fleet governor handoff is still an owner decision (#15).