### PR TITLE
Reject an empty description on savestate verify

### DIFF
--- a/src/commands/__tests__/verify-empty-description.test.ts
+++ b/src/commands/__tests__/verify-empty-description.test.ts
@@ -1,0 +1,98 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { verifyContainer } from '../verify.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate verify empty description', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'savestate-verify-empty-description-'));
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(
+    fileName: string,
+    description?: unknown,
+  ): Promise<string> {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const actualHash = createHash('sha256').update(plaintext).digest('hex');
+    const manifest: Record<string, unknown> = {
+      formatVersion: 1,
+      created: '2026-08-19T07:01:00.000Z',
+      agentId: 'demo-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: actualHash,
+        },
+      ],
+    };
+    if (arguments.length > 1) {
+      manifest.description = description;
+    }
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('rejects a container whose description is empty', async () => {
+    const filePath = await writeContainer('description-empty.savestate', '');
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.message).toMatch(/description/i);
+    expect(result.manifest).toBeUndefined();
+  });
+
+  it('still verifies a valid container with a non-empty string description', async () => {
+    const filePath = await writeContainer('valid-description.savestate', 'demo export');
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('valid');
+    expect(result.manifest?.agentId).toBe('demo-agent');
+  });
+
+  it('still verifies a valid container without a description', async () => {
+    const filePath = await writeContainer('missing-description.savestate');
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('valid');
+    expect(result.manifest?.agentId).toBe('demo-agent');
+  });
+
+  it('does not treat a wrong passphrase as a description failure', async () => {
+    const filePath = await writeContainer('wrong-pass.savestate', 'demo export');
+
+    const result = await verifyContainer(filePath, { passphrase: 'wrong-pass' });
+
+    expect(result.status).toBe('wrong_password');
+    expect(result.message).not.toMatch(/description/i);
+  });
+});

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -478,6 +478,14 @@ export async function verifyContainer(
     };
   }
 
+
+  if ('description' in manifest && manifest.description === '') {
+    return {
+      status: 'corrupted',
+      message: 'Invalid manifest: description must not be empty',
+    };
+  }
+
   const payload = manifest.payloads.find((p: any) => p.name === 'agent_state');
   if (!payload || !payload.sha256) {
     return {


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#61](https://github.com/dbhurley/savestate/issues/61). Users no longer see a valid result when the optional manifest description is present and empty.

`savestate verify` does not reject an empty `description`. A container whose `description` is `""` still verified as valid when the rest of the file was intact. This change rejects an empty description as `corrupted` before decryption. A missing description still verifies. A non-empty string description still verifies.

## Proof
- Before: a container whose `description` was `""` verified as valid.
- After: `savestate verify` returns `corrupted` and names the description field. A non-empty string description still verifies. A missing description still verifies. Wrong-passphrase results are unchanged.
- Focused: `src/commands/__tests__/verify-empty-description.test.ts` passed (4 tests).

## Safety
No encryption, container format, live adapter, or package publish change.

## Residual risk
Import still uses the placeholder restore. Live adapter restore stays out of this issue. Product-line authority for the fleet governor handoff is still an owner decision (#15). The local governor worklog and `docs/TASKS.md` remain missing on this fleet checkout.