### PR TITLE
Reject a non-object payload entry on savestate verify

### DIFF
--- a/src/commands/__tests__/verify-non-object-payload.test.ts
+++ b/src/commands/__tests__/verify-non-object-payload.test.ts
@@ -1,0 +1,95 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { verifyContainer } from '../verify.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate verify non-object payload entry', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'savestate-verify-non-object-payload-'));
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(
+    fileName: string,
+    payloads: unknown,
+  ): Promise<string> {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const actualHash = createHash('sha256').update(plaintext).digest('hex');
+    const validPayload = {
+      name: 'agent_state',
+      contentType: 'application/json',
+      byteLength: plaintext.length,
+      sha256: actualHash,
+    };
+    const manifest = {
+      formatVersion: 1,
+      created: '2026-08-19T08:03:00.000Z',
+      agentId: 'demo-agent',
+      payloads: payloads === undefined ? [validPayload] : payloads,
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('rejects a container whose payload entry is null', async () => {
+    const filePath = await writeContainer('payload-null.savestate', [null]);
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.message).toMatch(/payload entry/i);
+    expect(result.manifest).toBeUndefined();
+  });
+
+  it('rejects a container whose payload entry is a string', async () => {
+    const filePath = await writeContainer('payload-string.savestate', ['agent_state']);
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.message).toMatch(/payload entry/i);
+    expect(result.manifest).toBeUndefined();
+  });
+
+  it('still verifies a valid container with object payload entries', async () => {
+    const filePath = await writeContainer('valid-payloads.savestate', undefined);
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('valid');
+    expect(result.manifest?.agentId).toBe('demo-agent');
+  });
+
+  it('does not treat a wrong passphrase as a payload-entry failure', async () => {
+    const filePath = await writeContainer('wrong-pass.savestate', undefined);
+
+    const result = await verifyContainer(filePath, { passphrase: 'wrong-pass' });
+
+    expect(result.status).toBe('wrong_password');
+    expect(result.message).not.toMatch(/payload entry/i);
+  });
+});

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -208,6 +208,19 @@ export async function verifyContainer(
     };
   }
 
+  if (
+    Array.isArray(manifest.payloads) &&
+    manifest.payloads.some(
+      (entry: unknown) => entry === null || typeof entry !== 'object' || Array.isArray(entry),
+    )
+  ) {
+    return {
+      status: 'corrupted',
+      message: 'Invalid manifest: each payload entry must be an object',
+    };
+  }
+
+
 
   if (
     Array.isArray(manifest.payloads) &&


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#62](https://github.com/dbhurley/savestate/issues/62). Users no longer see a crash when a payload entry is not an object.

`savestate verify` looks up `agent_state` by reading `name` on each payload entry. A `null`, string, or number entry threw before a `corrupted` result was returned. This change rejects a non-object payload entry as `corrupted` before decryption. A valid object payload list still verifies.

## Proof
- Before: a container whose `payloads` list contained `null` or a string threw during verify.
- After: `savestate verify` returns `corrupted` and names the payload entry. A valid object payload list still verifies. Wrong-passphrase results are unchanged.
- Focused: `src/commands/__tests__/verify-non-object-payload.test.ts` passed (4 tests).

## Safety
No encryption, container format, live adapter, or package publish change.

## Residual risk
Import still uses the placeholder restore. Live adapter restore stays out of this issue. Product-line authority for the fleet governor handoff is still an owner decision (#15). The local governor worklog and `docs/TASKS.md` remain missing on this fleet checkout.