### PR TITLE
Reject a non-object manifest on savestate verify

### DIFF
--- a/src/commands/__tests__/verify-non-object-manifest.test.ts
+++ b/src/commands/__tests__/verify-non-object-manifest.test.ts
@@ -1,0 +1,99 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { verifyContainer } from '../verify.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate verify non-object manifest', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'savestate-verify-non-object-manifest-'));
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(
+    fileName: string,
+    manifestValue: unknown,
+  ): Promise<string> {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const actualHash = createHash('sha256').update(plaintext).digest('hex');
+    const manifest =
+      manifestValue === undefined
+        ? {
+            formatVersion: 1,
+            created: '2026-08-19T09:02:00.000Z',
+            agentId: 'demo-agent',
+            payloads: [
+              {
+                name: 'agent_state',
+                contentType: 'application/json',
+                byteLength: plaintext.length,
+                sha256: actualHash,
+              },
+            ],
+          }
+        : manifestValue;
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('rejects a container whose manifest is null', async () => {
+    const filePath = await writeContainer('manifest-null.savestate', null);
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.message).toMatch(/manifest must be an object/i);
+    expect(result.manifest).toBeUndefined();
+  });
+
+  it('rejects a container whose manifest is an array', async () => {
+    const filePath = await writeContainer('manifest-array.savestate', []);
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.message).toMatch(/manifest must be an object/i);
+    expect(result.manifest).toBeUndefined();
+  });
+
+  it('still verifies a valid container with an object manifest', async () => {
+    const filePath = await writeContainer('valid-manifest.savestate', undefined);
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('valid');
+    expect(result.manifest?.agentId).toBe('demo-agent');
+  });
+
+  it('does not treat a wrong passphrase as a manifest-shape failure', async () => {
+    const filePath = await writeContainer('wrong-pass.savestate', undefined);
+
+    const result = await verifyContainer(filePath, { passphrase: 'wrong-pass' });
+
+    expect(result.status).toBe('wrong_password');
+    expect(result.message).not.toMatch(/manifest must be an object/i);
+  });
+});

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -174,6 +174,14 @@ export async function verifyContainer(
     };
   }
 
+
+  if (manifest === null || typeof manifest !== 'object' || Array.isArray(manifest)) {
+    return {
+      status: 'corrupted',
+      message: 'Invalid manifest: manifest must be an object',
+    };
+  }
+
   if (
     'agentId' in manifest &&
     typeof manifest.agentId === 'string' &&


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#63](https://github.com/dbhurley/savestate/issues/63). Users no longer see a crash when the container manifest is not an object.

`savestate verify` reads `formatVersion` on the parsed manifest. A `null` manifest threw before a `corrupted` result was returned. This change rejects a non-object manifest as `corrupted` before decryption. A valid object manifest still verifies.

## Proof
- Before: a container whose manifest JSON was `null` threw during verify.
- After: `savestate verify` returns `corrupted` and names the manifest. A valid object manifest still verifies. Wrong-passphrase results are unchanged.
- Focused: `src/commands/__tests__/verify-non-object-manifest.test.ts` passed (4 tests).

## Safety
No encryption, container format, live adapter, or package publish change.

## Residual risk
Import still uses the placeholder restore. Live adapter restore stays out of this issue. Product-line authority for the fleet governor handoff is still an owner decision (#15). The local governor worklog and `docs/TASKS.md` remain missing on this fleet checkout.