### PR TITLE
Reject a non-numeric formatVersion on savestate verify

### DIFF
--- a/src/commands/__tests__/verify-non-numeric-format-version.test.ts
+++ b/src/commands/__tests__/verify-non-numeric-format-version.test.ts
@@ -1,0 +1,97 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { verifyContainer } from '../verify.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate verify non-numeric formatVersion', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'savestate-verify-non-numeric-format-version-'));
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(
+    fileName: string,
+    formatVersion: unknown = 1,
+  ): Promise<string> {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const actualHash = createHash('sha256').update(plaintext).digest('hex');
+    const manifest = {
+      formatVersion,
+      created: '2026-08-19T10:02:00.000Z',
+      agentId: 'demo-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: actualHash,
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('rejects a container whose formatVersion is a string', async () => {
+    const filePath = await writeContainer('string-format-version.savestate', '1');
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.message).toMatch(/formatVersion must be a number/i);
+    expect(result.manifest).toBeUndefined();
+  });
+
+  it('rejects a container whose formatVersion is a boolean', async () => {
+    const filePath = await writeContainer('boolean-format-version.savestate', true);
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.message).toMatch(/formatVersion must be a number/i);
+    expect(result.manifest).toBeUndefined();
+  });
+
+  it('still verifies a valid container with numeric formatVersion 1', async () => {
+    const filePath = await writeContainer('valid-format-version.savestate', 1);
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('valid');
+    expect(result.manifest?.agentId).toBe('demo-agent');
+    expect(result.manifest?.formatVersion).toBe(1);
+  });
+
+  it('does not treat a wrong passphrase as a formatVersion type failure', async () => {
+    const filePath = await writeContainer('wrong-pass.savestate', 1);
+
+    const result = await verifyContainer(filePath, { passphrase: 'wrong-pass' });
+
+    expect(result.status).toBe('wrong_password');
+    expect(result.message).not.toMatch(/formatVersion must be a number/i);
+  });
+});

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -206,6 +206,20 @@ export async function verifyContainer(
     };
   }
 
+
+  if (
+    manifest !== null &&
+    typeof manifest === 'object' &&
+    !Array.isArray(manifest) &&
+    'formatVersion' in manifest &&
+    typeof manifest.formatVersion !== 'number'
+  ) {
+    return {
+      status: 'corrupted',
+      message: 'Invalid manifest: formatVersion must be a number',
+    };
+  }
+
   // Validate manifest structure
   if (!manifest.formatVersion || !manifest.agentId || !manifest.payloads) {
     return {


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#65](https://github.com/dbhurley/savestate/issues/65). Users can now tell when a container formatVersion is present but is not a number.

`savestate verify` treated a string or boolean `formatVersion` as present and continued. A container with `formatVersion` `"1"` could still verify as valid. This change rejects a non-numeric formatVersion as `corrupted` before decryption. A valid numeric `formatVersion` 1 still verifies.

## Proof
- Before: a container whose `formatVersion` was the string `"1"` verified as valid.
- After: `savestate verify` returns `corrupted` and names formatVersion. A valid numeric formatVersion 1 still verifies. Wrong-passphrase results are unchanged.
- Focused: `src/commands/__tests__/verify-non-numeric-format-version.test.ts` passed (4 tests).

## Safety
No encryption, container format, live adapter, or package publish change.

## Residual risk
Import still uses the placeholder restore. Live adapter restore stays out of this issue. Product-line authority for the fleet governor handoff is still an owner decision (#15). The local governor worklog and `docs/TASKS.md` remain missing on this fleet checkout.