### PR TITLE
Reject a non-object encryption field on savestate verify

### DIFF
--- a/src/commands/__tests__/verify-non-object-encryption.test.ts
+++ b/src/commands/__tests__/verify-non-object-encryption.test.ts
@@ -1,0 +1,124 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { verifyContainer } from '../verify.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate verify non-object encryption', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'savestate-verify-non-object-encryption-'));
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(
+    fileName: string,
+    encryption?: unknown,
+  ): Promise<string> {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const actualHash = createHash('sha256').update(plaintext).digest('hex');
+    const manifest: Record<string, unknown> = {
+      formatVersion: 1,
+      created: '2026-08-19T12:06:00.000Z',
+      agentId: 'demo-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: actualHash,
+        },
+      ],
+    };
+    if (arguments.length > 1) {
+      manifest.encryption = encryption;
+    }
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('rejects a container whose encryption field is a string', async () => {
+    const filePath = await writeContainer('string-encryption.savestate', 'AES-256-GCM');
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.message).toMatch(/encryption must be an object/i);
+    expect(result.manifest).toBeUndefined();
+  });
+
+  it('rejects a container whose encryption field is an array', async () => {
+    const filePath = await writeContainer('array-encryption.savestate', ['AES-256-GCM']);
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.message).toMatch(/encryption must be an object/i);
+    expect(result.manifest).toBeUndefined();
+  });
+
+  it('rejects a container whose encryption field is null', async () => {
+    const filePath = await writeContainer('null-encryption.savestate', null);
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.message).toMatch(/encryption must be an object/i);
+    expect(result.manifest).toBeUndefined();
+  });
+
+  it('still verifies a valid container that omits encryption', async () => {
+    const filePath = await writeContainer('omitted-encryption.savestate');
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('valid');
+    expect(result.manifest?.agentId).toBe('demo-agent');
+  });
+
+  it('still verifies a valid container with an object encryption field', async () => {
+    const filePath = await writeContainer('object-encryption.savestate', {
+      algorithm: 'AES-256-GCM',
+      keyDerivation: 'Argon2id',
+    });
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('valid');
+    expect(result.manifest?.agentId).toBe('demo-agent');
+  });
+
+  it('does not treat a wrong passphrase as an encryption object failure', async () => {
+    const filePath = await writeContainer('wrong-pass.savestate', {
+      algorithm: 'AES-256-GCM',
+      keyDerivation: 'Argon2id',
+    });
+
+    const result = await verifyContainer(filePath, { passphrase: 'wrong-pass' });
+
+    expect(result.status).toBe('wrong_password');
+    expect(result.message).not.toMatch(/encryption must be an object/i);
+  });
+});

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -548,6 +548,19 @@ export async function verifyContainer(
     };
   }
 
+
+  if (
+    'encryption' in manifest &&
+    (manifest.encryption === null ||
+      typeof manifest.encryption !== 'object' ||
+      Array.isArray(manifest.encryption))
+  ) {
+    return {
+      status: 'corrupted',
+      message: 'Invalid manifest: encryption must be an object',
+    };
+  }
+
   const payload = manifest.payloads.find((p: any) => p.name === 'agent_state');
   if (!payload || !payload.sha256) {
     return {


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#67](https://github.com/dbhurley/savestate/issues/67). Users can now tell when a container encryption field is present but is not an object.

`savestate verify` ignored the type of `encryption`. A container whose `encryption` field was a string, array, or null could still verify as valid. This change rejects a non-object encryption field as `corrupted` before decryption. A valid container that omits encryption, or includes an object encryption field, still verifies.

## Proof
- Before: a container whose `encryption` was a string, array, or null verified as valid.
- After: `savestate verify` returns `corrupted` and names encryption. A valid omitted or object encryption field still verifies. Wrong-passphrase results are unchanged.
- Focused: `src/commands/__tests__/verify-non-object-encryption.test.ts` passed (6 tests).

## Safety
No encryption, container format, live adapter, or package publish change.

## Residual risk
Import still uses the placeholder restore. Live adapter restore stays out of this issue. Product-line authority for the fleet governor handoff is still an owner decision (#15). The local governor worklog and `docs/TASKS.md` remain missing on this fleet checkout.