### PR TITLE
Reject an empty encryption algorithm on savestate verify

### DIFF
--- a/src/commands/__tests__/verify-empty-encryption-algorithm.test.ts
+++ b/src/commands/__tests__/verify-empty-encryption-algorithm.test.ts
@@ -1,0 +1,118 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { verifyContainer } from '../verify.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate verify empty encryption algorithm', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'savestate-verify-empty-algorithm-'));
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(
+    fileName: string,
+    encryption?: unknown,
+  ): Promise<string> {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const actualHash = createHash('sha256').update(plaintext).digest('hex');
+    const manifest: Record<string, unknown> = {
+      formatVersion: 1,
+      created: '2026-08-19T14:02:00.000Z',
+      agentId: 'demo-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: actualHash,
+        },
+      ],
+    };
+    if (arguments.length > 1) {
+      manifest.encryption = encryption;
+    }
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('rejects a container whose encryption algorithm is empty', async () => {
+    const filePath = await writeContainer('empty-algorithm.savestate', {
+      algorithm: '',
+      keyDerivation: 'Argon2id',
+    });
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.message).toMatch(/encryption algorithm must not be empty/i);
+    expect(result.manifest).toBeUndefined();
+  });
+
+  it('still verifies a valid container that omits encryption', async () => {
+    const filePath = await writeContainer('omitted-encryption.savestate');
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('valid');
+    expect(result.manifest?.agentId).toBe('demo-agent');
+  });
+
+  it('still verifies a valid container whose encryption object omits algorithm', async () => {
+    const filePath = await writeContainer('omitted-algorithm.savestate', {
+      keyDerivation: 'Argon2id',
+    });
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('valid');
+    expect(result.manifest?.agentId).toBe('demo-agent');
+  });
+
+  it('still verifies a valid container with a non-empty string algorithm', async () => {
+    const filePath = await writeContainer('string-algorithm.savestate', {
+      algorithm: 'AES-256-GCM',
+      keyDerivation: 'Argon2id',
+    });
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('valid');
+    expect(result.manifest?.agentId).toBe('demo-agent');
+  });
+
+  it('does not treat a wrong passphrase as an empty algorithm failure', async () => {
+    const filePath = await writeContainer('wrong-pass.savestate', {
+      algorithm: 'AES-256-GCM',
+      keyDerivation: 'Argon2id',
+    });
+
+    const result = await verifyContainer(filePath, { passphrase: 'wrong-pass' });
+
+    expect(result.status).toBe('wrong_password');
+    expect(result.message).not.toMatch(/encryption algorithm must not be empty/i);
+  });
+});

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -561,6 +561,21 @@ export async function verifyContainer(
     };
   }
 
+
+  if (
+    manifest.encryption &&
+    typeof manifest.encryption === 'object' &&
+    !Array.isArray(manifest.encryption) &&
+    'algorithm' in manifest.encryption &&
+    typeof manifest.encryption.algorithm === 'string' &&
+    manifest.encryption.algorithm.trim() === ''
+  ) {
+    return {
+      status: 'corrupted',
+      message: 'Invalid manifest: encryption algorithm must not be empty',
+    };
+  }
+
   const payload = manifest.payloads.find((p: any) => p.name === 'agent_state');
   if (!payload || !payload.sha256) {
     return {


### PR DESCRIPTION
## Summary
Resolves [dbhurley/savestate#70](https://github.com/dbhurley/savestate/issues/70). Users can now tell when a container encryption algorithm is present but empty.

`savestate verify` treated a blank `encryption.algorithm` as omitted and fell back to AES-256-GCM. A container whose algorithm was `""` could still verify as valid. This change rejects an empty algorithm as `corrupted` before decryption. A valid container that omits encryption, omits algorithm, or includes a non-empty string algorithm still verifies.

## Proof
- Before: a container whose `encryption.algorithm` was empty verified as valid and printed the default algorithm.
- After: `savestate verify` returns `corrupted` and names the encryption algorithm. A valid omitted or non-empty algorithm still verifies. Wrong-passphrase results are unchanged.
- Focused: `src/commands/__tests__/verify-empty-encryption-algorithm.test.ts` passed (5 tests). Related `verify-encryption` and `verify-non-object-encryption` tests still pass (10 tests).

## Safety
No encryption, container format, live adapter, or package publish change.

## Residual risk
Import still uses the placeholder restore. Live adapter restore stays out of this issue. Product-line authority for the fleet governor handoff is still an owner decision (#15). The local governor worklog and `docs/TASKS.md` remain missing on this fleet checkout.