### PR TITLE
Reject an empty target path on savestate import

### DIFF
--- a/src/commands/__tests__/import-empty-target.test.ts
+++ b/src/commands/__tests__/import-empty-target.test.ts
@@ -1,0 +1,105 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { exportState, importState } from '../container.js';
+
+describe('savestate import empty target path', () => {
+  let testDir: string;
+  let filePath: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-import-empty-target-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+    filePath = join(testDir, 'fixture.savestate');
+    const exported = await exportState({
+      agent: 'fixture-agent',
+      out: filePath,
+      passphrase: 'synthetic-passphrase',
+    });
+    expect(exported.written).toBe(true);
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+    await fs.rm('   ', { recursive: true, force: true });
+  });
+
+  it('rejects an empty target path before writing restored state', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: filePath,
+      passphrase: 'synthetic-passphrase',
+      target: '',
+    });
+
+    expect(result).toBeUndefined();
+    expect(error.mock.calls.flat().join('\n')).toMatch(/target path/i);
+    expect(log.mock.calls.flat().join('\n')).not.toContain('Successfully restored');
+    expect(log.mock.calls.flat().join('\n')).not.toContain('Wrote agent state');
+    error.mockRestore();
+    log.mockRestore();
+  });
+
+  it('rejects a whitespace-only target path before writing restored state', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: filePath,
+      passphrase: 'synthetic-passphrase',
+      target: '   ',
+    });
+
+    expect(result).toBeUndefined();
+    await expect(fs.access('   ')).rejects.toThrow();
+    expect(error.mock.calls.flat().join('\n')).toMatch(/target path/i);
+    expect(log.mock.calls.flat().join('\n')).not.toContain('Successfully restored');
+    expect(log.mock.calls.flat().join('\n')).not.toContain('Wrote agent state');
+    error.mockRestore();
+    log.mockRestore();
+  });
+
+  it('still imports a non-empty target path', async () => {
+    const targetDir = join(testDir, 'restored');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: filePath,
+      passphrase: 'synthetic-passphrase',
+      target: targetDir,
+    });
+
+    const writtenPath = join(targetDir, 'agent_state.json');
+    expect(result).toMatchObject({
+      dryRun: false,
+      restored: true,
+      agentId: 'fixture-agent',
+      target: writtenPath,
+    });
+    await expect(fs.readFile(writtenPath, 'utf-8')).resolves.toContain('fixture-agent');
+    expect(log.mock.calls.flat().join('\n')).toContain(writtenPath);
+    log.mockRestore();
+  });
+
+  it('keeps the current restore path when --target is omitted', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: filePath,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    expect(result).toMatchObject({
+      dryRun: false,
+      restored: true,
+      agentId: 'fixture-agent',
+    });
+    expect(result?.target).toBeUndefined();
+    expect(log.mock.calls.flat().join('\n')).toContain('Successfully restored');
+    expect(log.mock.calls.flat().join('\n')).not.toContain('Wrote agent state');
+    log.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -317,6 +317,13 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
       return undefined;
     }
 
+    if (options.target !== undefined) {
+      if (typeof options.target !== 'string' || options.target.trim() === '') {
+        console.error(`Error: Target path must not be empty: ${JSON.stringify(options.target)}.`);
+        return undefined;
+      }
+    }
+
     const keySource = await resolveKeySource(passphrase, keyfile);
 
     // Determine restore mode


### PR DESCRIPTION
## Summary

Users who pass an empty or whitespace-only `--target` path on import now get a named empty-path error instead of a skipped write or a blank directory. `savestate import` and `savestate container import` reject blank target paths before writing restored agent state. A non-empty target still imports. Omitting `--target` keeps the current restore path.

Private tracking: https://github.com/dbhurley/savestate/issues/83

## Proof

- `savestate import <file> --target ""` and `savestate import <file> --target "   "` fail with `Error: Target path must not be empty`.
- The same check applies to `savestate container import --target`.
- A synthetic container with a fake passphrase still imports to a real target path.
- Import without `--target` still restores without writing a target file.

## Scope

Import target path validation only. No encryption, verify, adapter, or publish changes.