### PR TITLE
Reject an empty keyfile on savestate export

### DIFF
--- a/src/commands/__tests__/export-empty-keyfile.test.ts
+++ b/src/commands/__tests__/export-empty-keyfile.test.ts
@@ -1,0 +1,113 @@
+import { randomBytes } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { Command } from 'commander';
+import { exportState, registerContainerCommands } from '../container.js';
+
+function readManifest(file: Buffer): { agentId?: string } {
+  const manifestLength = file.readUInt32LE(16);
+  return JSON.parse(file.subarray(20, 20 + manifestLength).toString('utf-8'));
+}
+
+describe('savestate export empty keyfile', () => {
+  let testDir: string;
+  const originalEnv = process.env.SAVESTATE_PASSPHRASE;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-export-empty-keyfile-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.SAVESTATE_PASSPHRASE;
+    } else {
+      process.env.SAVESTATE_PASSPHRASE = originalEnv;
+    }
+  });
+
+  it('registers --keyfile on export and container export', () => {
+    const program = new Command();
+    registerContainerCommands(program);
+    const exportCmd = program.commands.find((command) => command.name() === 'export');
+    const container = program.commands.find((command) => command.name() === 'container');
+    const containerExport = container?.commands.find((command) => command.name() === 'export');
+    expect(exportCmd?.options.find((option) => option.long === '--keyfile')).toBeDefined();
+    expect(containerExport?.options.find((option) => option.long === '--keyfile')).toBeDefined();
+  });
+
+  it('rejects an empty keyfile before writing a file', async () => {
+    process.env.SAVESTATE_PASSPHRASE = 'synthetic-env-pass';
+    const filePath = join(testDir, 'empty-keyfile.savestate');
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const result = await exportState({
+      agent: 'fixture-agent',
+      out: filePath,
+      keyfile: '',
+    });
+
+    expect(result).toEqual({ written: false, out: filePath, overwritten: false });
+    await expect(fs.access(filePath)).rejects.toThrow();
+    expect(error.mock.calls.flat().join('\n')).toMatch(/keyfile/i);
+    error.mockRestore();
+  });
+
+  it('rejects a whitespace-only keyfile before writing a file', async () => {
+    const filePath = join(testDir, 'whitespace-keyfile.savestate');
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const result = await exportState({
+      agent: 'fixture-agent',
+      out: filePath,
+      keyfile: '   ',
+    });
+
+    expect(result).toEqual({ written: false, out: filePath, overwritten: false });
+    await expect(fs.access(filePath)).rejects.toThrow();
+    expect(error.mock.calls.flat().join('\n')).toMatch(/keyfile/i);
+    error.mockRestore();
+  });
+
+  it('still exports a non-empty keyfile path', async () => {
+    const filePath = join(testDir, 'valid-keyfile.savestate');
+    const keyfilePath = join(testDir, 'synthetic.key');
+    await fs.writeFile(keyfilePath, randomBytes(32));
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await exportState({
+      agent: 'fixture-agent',
+      out: filePath,
+      keyfile: keyfilePath,
+    });
+
+    const written = await fs.readFile(filePath);
+    const manifest = readManifest(written);
+
+    expect(result).toEqual({ written: true, out: filePath, overwritten: false });
+    expect(written.subarray(0, 8).toString('ascii')).toBe('SAVESTAT');
+    expect(manifest.agentId).toBe('fixture-agent');
+    log.mockRestore();
+  });
+
+  it('keeps the current prompt or env path when --keyfile is omitted', async () => {
+    process.env.SAVESTATE_PASSPHRASE = 'synthetic-passphrase';
+    const filePath = join(testDir, 'omitted-keyfile.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await exportState({
+      agent: 'fixture-agent',
+      out: filePath,
+    });
+
+    expect(result).toEqual({ written: true, out: filePath, overwritten: false });
+    await expect(fs.access(filePath)).resolves.toBeUndefined();
+    log.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -199,6 +199,13 @@ export async function exportState(options: ExportOptions): Promise<ExportResult>
       }
     }
 
+    if (keyfile !== undefined) {
+      if (typeof keyfile !== 'string' || keyfile.trim() === '') {
+        console.error(`Error: Keyfile must not be empty: ${JSON.stringify(keyfile)}.`);
+        return { written: false, out, overwritten: false };
+      }
+    }
+
     let existed = false;
     try {
       await fs.access(out);


### PR DESCRIPTION
## Summary

Users who pass an empty or whitespace-only `--keyfile` on export now get a named empty-keyfile error instead of a passphrase prompt, env fallback, or a whitespace path. `savestate export` and `savestate container export` reject blank keyfile flags before writing a container. A non-empty keyfile path still exports. Omitting `--keyfile` keeps the current passphrase prompt or env path.

Private tracking: https://github.com/dbhurley/savestate/issues/86

## Proof

- `savestate export --keyfile ""` and `savestate export --keyfile "   "` fail with `Error: Keyfile must not be empty`.
- The same check applies to `savestate container export --keyfile`.
- A synthetic export with a fake keyfile still writes a container.
- Export without `--keyfile` still uses SAVESTATE_PASSPHRASE or a prompt.

## Scope

Export keyfile validation only. No encryption, verify, adapter, import, or publish changes.