### PR TITLE
Reject an empty keyfile on savestate import

### DIFF
--- a/src/commands/__tests__/import-empty-keyfile.test.ts
+++ b/src/commands/__tests__/import-empty-keyfile.test.ts
@@ -1,0 +1,129 @@
+import { randomBytes } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { Command } from 'commander';
+import { exportState, importState, registerContainerCommands } from '../container.js';
+
+describe('savestate import empty keyfile', () => {
+  let testDir: string;
+  let passphraseFilePath: string;
+  let keyfilePath: string;
+  let keyfileContainerPath: string;
+  const originalEnv = process.env.SAVESTATE_PASSPHRASE;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-import-empty-keyfile-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+    passphraseFilePath = join(testDir, 'passphrase-fixture.savestate');
+    const passphraseExported = await exportState({
+      agent: 'fixture-agent',
+      out: passphraseFilePath,
+      passphrase: 'synthetic-passphrase',
+    });
+    expect(passphraseExported.written).toBe(true);
+
+    keyfilePath = join(testDir, 'synthetic.key');
+    await fs.writeFile(keyfilePath, randomBytes(32));
+    keyfileContainerPath = join(testDir, 'keyfile-fixture.savestate');
+    const keyfileExported = await exportState({
+      agent: 'fixture-agent',
+      out: keyfileContainerPath,
+      keyfile: keyfilePath,
+    });
+    expect(keyfileExported.written).toBe(true);
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.SAVESTATE_PASSPHRASE;
+    } else {
+      process.env.SAVESTATE_PASSPHRASE = originalEnv;
+    }
+  });
+
+  it('registers --keyfile on import and container import', () => {
+    const program = new Command();
+    registerContainerCommands(program);
+    const importCmd = program.commands.find((command) => command.name() === 'import');
+    const container = program.commands.find((command) => command.name() === 'container');
+    const containerImport = container?.commands.find((command) => command.name() === 'import');
+    expect(importCmd?.options.find((option) => option.long === '--keyfile')).toBeDefined();
+    expect(containerImport?.options.find((option) => option.long === '--keyfile')).toBeDefined();
+  });
+
+  it('rejects an empty keyfile before decrypting', async () => {
+    process.env.SAVESTATE_PASSPHRASE = 'synthetic-env-pass';
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: passphraseFilePath,
+      keyfile: '',
+    });
+
+    expect(result).toBeUndefined();
+    expect(error.mock.calls.flat().join('\n')).toMatch(/keyfile/i);
+    expect(log.mock.calls.flat().join('\n')).not.toContain('Successfully restored');
+    expect(log.mock.calls.flat().join('\n')).not.toContain('Decrypting agent state');
+    error.mockRestore();
+    log.mockRestore();
+  });
+
+  it('rejects a whitespace-only keyfile before decrypting', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: passphraseFilePath,
+      keyfile: '   ',
+    });
+
+    expect(result).toBeUndefined();
+    expect(error.mock.calls.flat().join('\n')).toMatch(/keyfile/i);
+    expect(log.mock.calls.flat().join('\n')).not.toContain('Successfully restored');
+    expect(log.mock.calls.flat().join('\n')).not.toContain('Decrypting agent state');
+    error.mockRestore();
+    log.mockRestore();
+  });
+
+  it('still imports a non-empty keyfile path', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: keyfileContainerPath,
+      keyfile: keyfilePath,
+      dryRun: true,
+    });
+
+    expect(result).toMatchObject({
+      dryRun: true,
+      restored: false,
+      agentId: 'fixture-agent',
+    });
+    expect(log.mock.calls.flat().join('\n')).toContain('DRY RUN');
+    log.mockRestore();
+  });
+
+  it('keeps the current prompt or env path when --keyfile is omitted', async () => {
+    process.env.SAVESTATE_PASSPHRASE = 'synthetic-passphrase';
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: passphraseFilePath,
+      dryRun: true,
+    });
+
+    expect(result).toMatchObject({
+      dryRun: true,
+      restored: false,
+      agentId: 'fixture-agent',
+    });
+    log.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -345,6 +345,13 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
       }
     }
 
+    if (keyfile !== undefined) {
+      if (typeof keyfile !== 'string' || keyfile.trim() === '') {
+        console.error(`Error: Keyfile must not be empty: ${JSON.stringify(keyfile)}.`);
+        return undefined;
+      }
+    }
+
     const keySource = await resolveKeySource(passphrase, keyfile);
 
     // Determine restore mode


### PR DESCRIPTION
## Summary

Users who pass an empty or whitespace-only `--keyfile` on import now get a named empty-keyfile error instead of a passphrase prompt, env fallback, or a whitespace path. `savestate import` and `savestate container import` reject blank keyfile flags before decrypting a container. A non-empty keyfile path still imports. Omitting `--keyfile` keeps the current passphrase prompt or env path.

Private tracking: https://github.com/dbhurley/savestate/issues/87

## Proof

- `savestate import --keyfile ""` and `savestate import --keyfile "   "` fail with `Error: Keyfile must not be empty`.
- The same check applies to `savestate container import --keyfile`.
- A synthetic import with a fake keyfile still decrypts in dry-run.
- Import without `--keyfile` still uses SAVESTATE_PASSPHRASE or a prompt.

## Scope

Import keyfile validation only. No encryption, verify, adapter, export, or publish changes.