### PR TITLE
Reject a missing keyfile on savestate export

### DIFF
--- a/src/commands/__tests__/export-missing-keyfile.test.ts
+++ b/src/commands/__tests__/export-missing-keyfile.test.ts
@@ -1,0 +1,102 @@
+import { randomBytes } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { Command } from 'commander';
+import { exportState, registerContainerCommands } from '../container.js';
+
+function readManifest(file: Buffer): { agentId?: string } {
+  const manifestLength = file.readUInt32LE(16);
+  return JSON.parse(file.subarray(20, 20 + manifestLength).toString('utf-8'));
+}
+
+describe('savestate export missing keyfile', () => {
+  let testDir: string;
+  const originalEnv = process.env.SAVESTATE_PASSPHRASE;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-export-missing-keyfile-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.SAVESTATE_PASSPHRASE;
+    } else {
+      process.env.SAVESTATE_PASSPHRASE = originalEnv;
+    }
+  });
+
+  it('registers --keyfile on export and container export', () => {
+    const program = new Command();
+    registerContainerCommands(program);
+    const exportCmd = program.commands.find((command) => command.name() === 'export');
+    const container = program.commands.find((command) => command.name() === 'container');
+    const containerExport = container?.commands.find((command) => command.name() === 'export');
+    expect(exportCmd?.options.find((option) => option.long === '--keyfile')).toBeDefined();
+    expect(containerExport?.options.find((option) => option.long === '--keyfile')).toBeDefined();
+  });
+
+  it('rejects a missing keyfile before writing a file', async () => {
+    process.env.SAVESTATE_PASSPHRASE = 'synthetic-env-pass';
+    const filePath = join(testDir, 'missing-keyfile.savestate');
+    const missingKeyfile = join(testDir, 'does-not-exist.key');
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await exportState({
+      agent: 'fixture-agent',
+      out: filePath,
+      keyfile: missingKeyfile,
+    });
+
+    expect(result).toEqual({ written: false, out: filePath, overwritten: false });
+    await expect(fs.access(filePath)).rejects.toThrow();
+    expect(error.mock.calls.flat().join('\n')).toMatch(/keyfile/i);
+    expect(error.mock.calls.flat().join('\n')).toMatch(/not found/i);
+    expect(log.mock.calls.flat().join('\n')).not.toContain('Encrypting agent state');
+    error.mockRestore();
+    log.mockRestore();
+  });
+
+  it('still exports a keyfile path that exists', async () => {
+    const filePath = join(testDir, 'valid-keyfile.savestate');
+    const keyfilePath = join(testDir, 'synthetic.key');
+    await fs.writeFile(keyfilePath, randomBytes(32));
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await exportState({
+      agent: 'fixture-agent',
+      out: filePath,
+      keyfile: keyfilePath,
+    });
+
+    const written = await fs.readFile(filePath);
+    const manifest = readManifest(written);
+
+    expect(result).toEqual({ written: true, out: filePath, overwritten: false });
+    expect(written.subarray(0, 8).toString('ascii')).toBe('SAVESTAT');
+    expect(manifest.agentId).toBe('fixture-agent');
+    log.mockRestore();
+  });
+
+  it('keeps the current prompt or env path when --keyfile is omitted', async () => {
+    process.env.SAVESTATE_PASSPHRASE = 'synthetic-passphrase';
+    const filePath = join(testDir, 'omitted-keyfile.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await exportState({
+      agent: 'fixture-agent',
+      out: filePath,
+    });
+
+    expect(result).toEqual({ written: true, out: filePath, overwritten: false });
+    await expect(fs.access(filePath)).resolves.toBeUndefined();
+    log.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -204,6 +204,12 @@ export async function exportState(options: ExportOptions): Promise<ExportResult>
         console.error(`Error: Keyfile must not be empty: ${JSON.stringify(keyfile)}.`);
         return { written: false, out, overwritten: false };
       }
+      try {
+        await fs.access(keyfile);
+      } catch {
+        console.error(`Error: Keyfile not found: ${keyfile}`);
+        return { written: false, out, overwritten: false };
+      }
     }
 
     let existed = false;


### PR DESCRIPTION
## Summary

Users who pass `--keyfile` to a path that does not exist now get a named missing-keyfile error instead of a raw `ENOENT` from encryption. `savestate export` and `savestate container export` reject a missing keyfile before writing a container. A keyfile path that exists still exports. Omitting `--keyfile` keeps the current passphrase prompt or env path.

Private tracking: https://github.com/dbhurley/savestate/issues/88

## Proof

- `savestate export --keyfile` with a missing path fails with `Error: Keyfile not found` and writes no file.
- The same check applies to `savestate container export --keyfile`.
- A synthetic export with an existing fake keyfile still writes a container.
- Export without `--keyfile` still uses `SAVESTATE_PASSPHRASE`.

## Scope

Export missing-keyfile validation only. No encryption, verify, adapter, import, or publish changes.