### PR TITLE
Reject a directory output path on savestate export

### DIFF
--- a/src/commands/__tests__/export-directory-output.test.ts
+++ b/src/commands/__tests__/export-directory-output.test.ts
@@ -1,0 +1,98 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Command } from 'commander';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { exportState, registerContainerCommands } from '../container.js';
+
+function readManifest(file: Buffer): { agentId?: string } {
+  const manifestLength = file.readUInt32LE(16);
+  return JSON.parse(file.subarray(20, 20 + manifestLength).toString('utf-8'));
+}
+
+describe('savestate export directory output path', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-export-directory-output-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  it('registers --output / --out on export commands', () => {
+    const program = new Command();
+    registerContainerCommands(program);
+    const exportCmd = program.commands.find((command) => command.name() === 'export');
+    const containerExport = program.commands
+      .find((command) => command.name() === 'container')
+      ?.commands.find((command) => command.name() === 'export');
+    expect(exportCmd?.options.some((option) => option.long === '--output')).toBe(true);
+    expect(containerExport?.options.some((option) => option.long === '--out')).toBe(true);
+  });
+
+  it('rejects a directory output path before writing a container', async () => {
+    const dirPath = join(testDir, 'output-dir');
+    await fs.mkdir(dirPath);
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await exportState({
+      agent: 'fixture-agent',
+      out: dirPath,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    const listing = await fs.readdir(dirPath);
+    expect(result).toEqual({ written: false, out: dirPath, overwritten: false });
+    expect(listing).toEqual([]);
+    expect(error.mock.calls.flat().join('\n')).toMatch(/directory/i);
+    expect(error.mock.calls.flat().join('\n')).not.toContain('--force');
+    expect(log.mock.calls.flat().join('\n')).not.toContain('Successfully exported');
+    error.mockRestore();
+    log.mockRestore();
+  });
+
+  it('does not overwrite a directory when --force is set', async () => {
+    const dirPath = join(testDir, 'forced-dir');
+    await fs.mkdir(dirPath);
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await exportState({
+      agent: 'fixture-agent',
+      out: dirPath,
+      passphrase: 'synthetic-passphrase',
+      force: true,
+    });
+
+    const listing = await fs.readdir(dirPath);
+    expect(result).toEqual({ written: false, out: dirPath, overwritten: false });
+    expect(listing).toEqual([]);
+    expect(error.mock.calls.flat().join('\n')).toMatch(/directory/i);
+    expect(log.mock.calls.flat().join('\n')).not.toContain('Successfully exported');
+    error.mockRestore();
+    log.mockRestore();
+  });
+
+  it('still exports a non-directory output path', async () => {
+    const filePath = join(testDir, 'valid-output.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await exportState({
+      agent: 'fixture-agent',
+      out: filePath,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    const written = await fs.readFile(filePath);
+    const manifest = readManifest(written);
+
+    expect(result).toEqual({ written: true, out: filePath, overwritten: false });
+    expect(written.subarray(0, 8).toString('ascii')).toBe('SAVESTAT');
+    expect(manifest.agentId).toBe('fixture-agent');
+    log.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -214,8 +214,12 @@ export async function exportState(options: ExportOptions): Promise<ExportResult>
 
     let existed = false;
     try {
-      await fs.access(out);
+      const outStats = await fs.stat(out);
       existed = true;
+      if (outStats.isDirectory()) {
+        console.error(`Error: Output path is a directory: ${out}`);
+        return { written: false, out, overwritten: false };
+      }
     } catch {
       existed = false;
     }


### PR DESCRIPTION
## Summary

Users who pass `--output` / `--out` to a directory now get a named directory-path error instead of an overwrite prompt or a raw `EISDIR`. `savestate export` and `savestate container export` reject a directory output path before writing a container. `--force` does not overwrite a directory. A non-directory output path still exports.

Private tracking: https://github.com/dbhurley/savestate/issues/90

## Proof

- `savestate export --output` with a directory path fails with `Error: Output path is a directory`.
- The same check applies to `savestate container export --out`.
- `--force` still refuses to write into a directory.
- A synthetic export with a fake passphrase still writes a container to a file path.

## Scope

Export directory output-path validation only. No encryption, verify, adapter, import, or publish changes.