### PR TITLE
Reject a directory keyfile on savestate export

### DIFF
--- a/src/commands/__tests__/export-directory-keyfile.test.ts
+++ b/src/commands/__tests__/export-directory-keyfile.test.ts
@@ -1,0 +1,103 @@
+import { randomBytes } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { Command } from 'commander';
+import { exportState, registerContainerCommands } from '../container.js';
+
+function readManifest(file: Buffer): { agentId?: string } {
+  const manifestLength = file.readUInt32LE(16);
+  return JSON.parse(file.subarray(20, 20 + manifestLength).toString('utf-8'));
+}
+
+describe('savestate export directory keyfile', () => {
+  let testDir: string;
+  const originalEnv = process.env.SAVESTATE_PASSPHRASE;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-export-directory-keyfile-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.SAVESTATE_PASSPHRASE;
+    } else {
+      process.env.SAVESTATE_PASSPHRASE = originalEnv;
+    }
+  });
+
+  it('registers --keyfile on export and container export', () => {
+    const program = new Command();
+    registerContainerCommands(program);
+    const exportCmd = program.commands.find((command) => command.name() === 'export');
+    const container = program.commands.find((command) => command.name() === 'container');
+    const containerExport = container?.commands.find((command) => command.name() === 'export');
+    expect(exportCmd?.options.find((option) => option.long === '--keyfile')).toBeDefined();
+    expect(containerExport?.options.find((option) => option.long === '--keyfile')).toBeDefined();
+  });
+
+  it('rejects a directory keyfile before writing a file', async () => {
+    process.env.SAVESTATE_PASSPHRASE = 'synthetic-env-pass';
+    const filePath = join(testDir, 'directory-keyfile.savestate');
+    const keyfileDir = join(testDir, 'keyfile-dir');
+    await fs.mkdir(keyfileDir);
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await exportState({
+      agent: 'fixture-agent',
+      out: filePath,
+      keyfile: keyfileDir,
+    });
+
+    expect(result).toEqual({ written: false, out: filePath, overwritten: false });
+    await expect(fs.access(filePath)).rejects.toThrow();
+    expect(error.mock.calls.flat().join('\n')).toMatch(/keyfile/i);
+    expect(error.mock.calls.flat().join('\n')).toMatch(/directory/i);
+    expect(log.mock.calls.flat().join('\n')).not.toContain('Encrypting agent state');
+    error.mockRestore();
+    log.mockRestore();
+  });
+
+  it('still exports a keyfile path that is a regular file', async () => {
+    const filePath = join(testDir, 'valid-keyfile.savestate');
+    const keyfilePath = join(testDir, 'synthetic.key');
+    await fs.writeFile(keyfilePath, randomBytes(32));
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await exportState({
+      agent: 'fixture-agent',
+      out: filePath,
+      keyfile: keyfilePath,
+    });
+
+    const written = await fs.readFile(filePath);
+    const manifest = readManifest(written);
+
+    expect(result).toEqual({ written: true, out: filePath, overwritten: false });
+    expect(written.subarray(0, 8).toString('ascii')).toBe('SAVESTAT');
+    expect(manifest.agentId).toBe('fixture-agent');
+    log.mockRestore();
+  });
+
+  it('keeps the current prompt or env path when --keyfile is omitted', async () => {
+    process.env.SAVESTATE_PASSPHRASE = 'synthetic-passphrase';
+    const filePath = join(testDir, 'omitted-keyfile.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await exportState({
+      agent: 'fixture-agent',
+      out: filePath,
+    });
+
+    expect(result).toEqual({ written: true, out: filePath, overwritten: false });
+    await expect(fs.access(filePath)).resolves.toBeUndefined();
+    log.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -205,7 +205,11 @@ export async function exportState(options: ExportOptions): Promise<ExportResult>
         return { written: false, out, overwritten: false };
       }
       try {
-        await fs.access(keyfile);
+        const keyfileStats = await fs.stat(keyfile);
+        if (keyfileStats.isDirectory()) {
+          console.error(`Error: Keyfile is a directory: ${keyfile}`);
+          return { written: false, out, overwritten: false };
+        }
       } catch {
         console.error(`Error: Keyfile not found: ${keyfile}`);
         return { written: false, out, overwritten: false };


### PR DESCRIPTION
## Summary

Users who pass `--keyfile` to a directory now get a named directory-keyfile error instead of a raw `EISDIR` from `readFile`. `savestate export` and `savestate container export` reject a directory keyfile path before writing a container. A regular-file keyfile still exports. Omitting `--keyfile` keeps the current passphrase prompt or env path.

Private tracking: https://github.com/dbhurley/savestate/issues/91

## Proof

- `npx vitest run src/commands/__tests__/export-directory-keyfile.test.ts` — 4 passed
- `savestate export --keyfile` with a directory path fails with `Error: Keyfile is a directory`.
- The same check applies to `savestate container export --keyfile`.
- A synthetic export with a real keyfile still writes a container.
- Export without `--keyfile` still uses SAVESTATE_PASSPHRASE or a prompt.

## Scope

Export directory-keyfile check only. No encryption, verify, adapter, import, or publish changes.

Plasmate: https://savestate.dev and https://savestate.dev/docs/cli.html