### PR TITLE
Reject a directory keyfile on savestate import

### DIFF
--- a/src/commands/__tests__/import-directory-keyfile.test.ts
+++ b/src/commands/__tests__/import-directory-keyfile.test.ts
@@ -1,0 +1,112 @@
+import { randomBytes } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { Command } from 'commander';
+import { exportState, importState, registerContainerCommands } from '../container.js';
+
+describe('savestate import directory keyfile', () => {
+  let testDir: string;
+  let filePath: string;
+  const originalEnv = process.env.SAVESTATE_PASSPHRASE;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-import-directory-keyfile-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+    filePath = join(testDir, 'fixture.savestate');
+    const exported = await exportState({
+      agent: 'fixture-agent',
+      out: filePath,
+      passphrase: 'synthetic-passphrase',
+    });
+    expect(exported.written).toBe(true);
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.SAVESTATE_PASSPHRASE;
+    } else {
+      process.env.SAVESTATE_PASSPHRASE = originalEnv;
+    }
+  });
+
+  it('registers --keyfile on import and container import', () => {
+    const program = new Command();
+    registerContainerCommands(program);
+    const importCmd = program.commands.find((command) => command.name() === 'import');
+    const container = program.commands.find((command) => command.name() === 'container');
+    const containerImport = container?.commands.find((command) => command.name() === 'import');
+    expect(importCmd?.options.find((option) => option.long === '--keyfile')).toBeDefined();
+    expect(containerImport?.options.find((option) => option.long === '--keyfile')).toBeDefined();
+  });
+
+  it('rejects a directory keyfile before restoring agent state', async () => {
+    process.env.SAVESTATE_PASSPHRASE = 'synthetic-env-pass';
+    const keyfileDir = join(testDir, 'keyfile-dir');
+    await fs.mkdir(keyfileDir);
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: filePath,
+      keyfile: keyfileDir,
+    });
+
+    expect(result).toBeUndefined();
+    expect(error.mock.calls.flat().join('\n')).toMatch(/keyfile/i);
+    expect(error.mock.calls.flat().join('\n')).toMatch(/directory/i);
+    expect(log.mock.calls.flat().join('\n')).not.toContain('Successfully restored');
+    expect(log.mock.calls.flat().join('\n')).not.toContain('Decrypting agent state');
+    error.mockRestore();
+    log.mockRestore();
+  });
+
+  it('still imports a keyfile path that is a regular file', async () => {
+    const keyfilePath = join(testDir, 'synthetic.key');
+    const keyfileExport = join(testDir, 'keyfile-fixture.savestate');
+    await fs.writeFile(keyfilePath, randomBytes(32));
+    const exported = await exportState({
+      agent: 'fixture-agent',
+      out: keyfileExport,
+      keyfile: keyfilePath,
+    });
+    expect(exported.written).toBe(true);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: keyfileExport,
+      keyfile: keyfilePath,
+      dryRun: true,
+    });
+
+    expect(result).toMatchObject({
+      dryRun: true,
+      restored: false,
+      agentId: 'fixture-agent',
+    });
+    expect(log.mock.calls.flat().join('\n')).toContain('DRY RUN');
+    log.mockRestore();
+  });
+
+  it('keeps the current prompt or env path when --keyfile is omitted', async () => {
+    process.env.SAVESTATE_PASSPHRASE = 'synthetic-passphrase';
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: filePath,
+      dryRun: true,
+    });
+
+    expect(result).toMatchObject({
+      dryRun: true,
+      restored: false,
+      agentId: 'fixture-agent',
+    });
+    log.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -357,7 +357,11 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
         return undefined;
       }
       try {
-        await fs.access(keyfile);
+        const keyfileStats = await fs.stat(keyfile);
+        if (keyfileStats.isDirectory()) {
+          console.error(`Error: Keyfile is a directory: ${keyfile}`);
+          return undefined;
+        }
       } catch {
         console.error(`Error: Keyfile not found: ${keyfile}`);
         return undefined;


### PR DESCRIPTION
## Summary

Users who pass `--keyfile` to a directory now get a named directory-keyfile error instead of a raw `EISDIR` from `readFile`. `savestate import` and `savestate container import` reject a directory keyfile path before restoring agent state. A regular-file keyfile still imports. Omitting `--keyfile` keeps the current passphrase prompt or env path.

Private tracking: https://github.com/dbhurley/savestate/issues/93

## Proof

- `npx vitest run src/commands/__tests__/import-directory-keyfile.test.ts` — 4 passed
- `savestate import --keyfile` with a directory path fails with `Error: Keyfile is a directory`.
- The same check applies to `savestate container import --keyfile`.
- A synthetic import with a real keyfile still decrypts.
- Import without `--keyfile` still uses SAVESTATE_PASSPHRASE or a prompt.

## Scope

Import directory-keyfile check only. No encryption, verify, adapter, export, or publish changes.

Plasmate: https://savestate.dev and https://savestate.dev/docs/cli.html