### PR TITLE
Reject a file target path on savestate import

### DIFF
--- a/src/commands/__tests__/import-file-target.test.ts
+++ b/src/commands/__tests__/import-file-target.test.ts
@@ -1,0 +1,101 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { Command } from 'commander';
+import { exportState, importState, registerContainerCommands } from '../container.js';
+
+describe('savestate import file target path', () => {
+  let testDir: string;
+  let filePath: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-import-file-target-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+    filePath = join(testDir, 'fixture.savestate');
+    const exported = await exportState({
+      agent: 'fixture-agent',
+      out: filePath,
+      passphrase: 'synthetic-passphrase',
+    });
+    expect(exported.written).toBe(true);
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  it('registers --target on import and container import', () => {
+    const program = new Command();
+    registerContainerCommands(program);
+    const importCmd = program.commands.find((command) => command.name() === 'import');
+    const container = program.commands.find((command) => command.name() === 'container');
+    const containerImport = container?.commands.find((command) => command.name() === 'import');
+    expect(importCmd?.options.find((option) => option.long === '--target')).toBeDefined();
+    expect(containerImport?.options.find((option) => option.long === '--target')).toBeDefined();
+  });
+
+  it('rejects a file target path before restoring agent state', async () => {
+    const targetFile = join(testDir, 'not-a-directory.txt');
+    await fs.writeFile(targetFile, 'existing file');
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: filePath,
+      passphrase: 'synthetic-passphrase',
+      target: targetFile,
+    });
+
+    expect(result).toBeUndefined();
+    expect(await fs.readFile(targetFile, 'utf-8')).toBe('existing file');
+    expect(error.mock.calls.flat().join('\n')).toMatch(/target path/i);
+    expect(error.mock.calls.flat().join('\n')).toMatch(/file/i);
+    expect(log.mock.calls.flat().join('\n')).not.toContain('Successfully restored');
+    expect(log.mock.calls.flat().join('\n')).not.toContain('Wrote agent state');
+    expect(log.mock.calls.flat().join('\n')).not.toContain('Decrypting agent state');
+    error.mockRestore();
+    log.mockRestore();
+  });
+
+  it('still imports a directory target path', async () => {
+    const targetDir = join(testDir, 'restored');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: filePath,
+      passphrase: 'synthetic-passphrase',
+      target: targetDir,
+    });
+
+    const writtenPath = join(targetDir, 'agent_state.json');
+    expect(result).toMatchObject({
+      dryRun: false,
+      restored: true,
+      agentId: 'fixture-agent',
+      target: writtenPath,
+    });
+    await expect(fs.readFile(writtenPath, 'utf-8')).resolves.toContain('fixture-agent');
+    expect(log.mock.calls.flat().join('\n')).toContain(writtenPath);
+    log.mockRestore();
+  });
+
+  it('keeps the current restore path when --target is omitted', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: filePath,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    expect(result).toMatchObject({
+      dryRun: false,
+      restored: true,
+      agentId: 'fixture-agent',
+    });
+    expect(result?.target).toBeUndefined();
+    expect(log.mock.calls.flat().join('\n')).toContain('Successfully restored');
+    expect(log.mock.calls.flat().join('\n')).not.toContain('Wrote agent state');
+    log.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -350,6 +350,14 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
         console.error(`Error: Target path must not be empty: ${JSON.stringify(options.target)}.`);
         return undefined;
       }
+      try {
+        const targetStats = await fs.stat(options.target);
+        if (targetStats.isFile()) {
+          console.error(`Error: Target path is a file: ${options.target}`);
+          return undefined;
+        }
+      } catch {
+      }
     }
 
     if (passphrase !== undefined) {


### PR DESCRIPTION
## Summary

Users who pass `--target` to a regular file now get a named file-target error instead of a raw `ENOTDIR` / `EEXIST` from `mkdir`. `savestate import` and `savestate container import` reject a file target path before restoring agent state. A directory target still imports. Omitting `--target` keeps the current restore path.

Private tracking: https://github.com/dbhurley/savestate/issues/92

## Proof

- `npx vitest run src/commands/__tests__/import-file-target.test.ts` — 4 passed
- `savestate import --target` with a regular file path fails with `Error: Target path is a file`.
- The same check applies to `savestate container import --target`.
- A synthetic import with a directory target still writes `agent_state.json`.
- Import without `--target` still restores without writing a target file.

## Scope

Import file-target check only. No encryption, verify, adapter, export, or publish changes.

Plasmate: https://savestate.dev and https://savestate.dev/docs/cli.html