### PR TITLE
Reject a missing output directory on savestate export

### DIFF
--- a/src/commands/__tests__/export-missing-output-dir.test.ts
+++ b/src/commands/__tests__/export-missing-output-dir.test.ts
@@ -1,0 +1,78 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { Command } from 'commander';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { exportState, registerContainerCommands } from '../container.js';
+
+function readManifest(file: Buffer): { agentId?: string } {
+  const manifestLength = file.readUInt32LE(16);
+  return JSON.parse(file.subarray(20, 20 + manifestLength).toString('utf-8'));
+}
+
+describe('savestate export missing output directory', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-export-missing-output-dir-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  it('registers --output / --out on export commands', () => {
+    const program = new Command();
+    registerContainerCommands(program);
+    const exportCmd = program.commands.find((command) => command.name() === 'export');
+    const containerExport = program.commands
+      .find((command) => command.name() === 'container')
+      ?.commands.find((command) => command.name() === 'export');
+    expect(exportCmd?.options.some((option) => option.long === '--output')).toBe(true);
+    expect(containerExport?.options.some((option) => option.long === '--out')).toBe(true);
+  });
+
+  it('rejects a missing output directory before writing a container', async () => {
+    const missingDir = join(testDir, 'does-not-exist');
+    const filePath = join(missingDir, 'missing-dir.savestate');
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await exportState({
+      agent: 'fixture-agent',
+      out: filePath,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    expect(result).toEqual({ written: false, out: filePath, overwritten: false });
+    await expect(fs.access(filePath)).rejects.toThrow();
+    await expect(fs.access(missingDir)).rejects.toThrow();
+    expect(error.mock.calls.flat().join('\n')).toMatch(/output directory/i);
+    expect(error.mock.calls.flat().join('\n')).toMatch(/not found/i);
+    expect(error.mock.calls.flat().join('\n')).toContain(dirname(filePath));
+    expect(log.mock.calls.flat().join('\n')).not.toContain('Successfully exported');
+    expect(log.mock.calls.flat().join('\n')).not.toContain('Encrypting agent state');
+    error.mockRestore();
+    log.mockRestore();
+  });
+
+  it('still exports when the output directory exists', async () => {
+    const filePath = join(testDir, 'valid-output.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await exportState({
+      agent: 'fixture-agent',
+      out: filePath,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    const written = await fs.readFile(filePath);
+    const manifest = readManifest(written);
+
+    expect(result).toEqual({ written: true, out: filePath, overwritten: false });
+    expect(written.subarray(0, 8).toString('ascii')).toBe('SAVESTAT');
+    expect(manifest.agentId).toBe('fixture-agent');
+    log.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { promises as fs } from 'fs';
-import { join, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { createHash } from 'node:crypto';
 import { encrypt, decrypt, KeySource } from '../container/crypto.js';
 import { getPassphrase } from '../passphrase.js';
@@ -226,6 +226,12 @@ export async function exportState(options: ExportOptions): Promise<ExportResult>
       }
     } catch {
       existed = false;
+      try {
+        await fs.stat(dirname(out));
+      } catch {
+        console.error(`Error: Output directory not found: ${dirname(out)}`);
+        return { written: false, out, overwritten: false };
+      }
     }
     if (existed && !options.force) {
       console.error(


### PR DESCRIPTION
## Summary

Users who export to a path whose parent directory does not exist now get a named output-directory error instead of a raw `ENOENT` from `writeFile`. `savestate export` and `savestate container export` reject a missing output directory before encrypting or writing a container. An existing parent directory still exports.

## Proof

- `npx vitest run src/commands/__tests__/export-missing-output-dir.test.ts` — 3 passed
- `savestate export --output missing-dir/file.savestate` fails with `Error: Output directory not found`.
- The same check applies to `savestate container export --out`.
- A synthetic export into an existing directory still writes a `SAVESTAT` container.

## Scope

Export missing-output-directory check only. No encryption, verify, adapter, import, or publish changes.

Plasmate: https://savestate.dev and https://savestate.dev/docs