### PR TITLE
Add --exclude path selection to savestate export

### DIFF
--- a/src/commands/__tests__/export-exclude.test.ts
+++ b/src/commands/__tests__/export-exclude.test.ts
@@ -1,0 +1,88 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Command } from 'commander';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { decrypt } from '../../container/crypto.js';
+import { applyExcludePaths, exportState, registerContainerCommands } from '../container.js';
+
+async function readExportedState(path: string, passphrase: string): Promise<Record<string, unknown>> {
+  const fileBuffer = await fs.readFile(path);
+  const manifestLength = fileBuffer.readUInt32LE(16);
+  const encryptedState = fileBuffer.subarray(20 + manifestLength);
+  const decrypted = await decrypt(encryptedState, { passphrase });
+  return JSON.parse(decrypted.toString()) as Record<string, unknown>;
+}
+
+describe('savestate export --exclude', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-export-exclude-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  it('registers --exclude on export commands', () => {
+    const program = new Command();
+    registerContainerCommands(program);
+    const exportCmd = program.commands.find((command) => command.name() === 'export');
+    const containerExport = program.commands
+      .find((command) => command.name() === 'container')
+      ?.commands.find((command) => command.name() === 'export');
+    expect(exportCmd?.options.some((option) => option.long === '--exclude')).toBe(true);
+    expect(containerExport?.options.some((option) => option.long === '--exclude')).toBe(true);
+  });
+
+  it('rejects an unknown exclude path before writing a container', async () => {
+    const filePath = join(testDir, 'unknown-exclude.savestate');
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    expect(applyExcludePaths(
+      { personality: true, memory: true, tools: true, preferences: true },
+      'secrets',
+    )).toEqual({
+      error: 'Error: Unknown exclude path: secrets. Allowed: personality, memory, tools, preferences.',
+    });
+
+    const result = await exportState({
+      agent: 'fixture-agent',
+      out: filePath,
+      passphrase: 'synthetic-passphrase',
+      exclude: 'secrets',
+    });
+
+    expect(result).toEqual({ written: false, out: filePath, overwritten: false });
+    await expect(fs.access(filePath)).rejects.toThrow();
+    expect(error.mock.calls.flat().join('\n')).toMatch(/unknown exclude path/i);
+    expect(log.mock.calls.flat().join('\n')).not.toContain('Successfully exported');
+    expect(log.mock.calls.flat().join('\n')).not.toContain('Encrypting agent state');
+    error.mockRestore();
+    log.mockRestore();
+  });
+
+  it('omits excluded paths from a synthetic container', async () => {
+    const filePath = join(testDir, 'exclude-personality.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await exportState({
+      agent: 'fixture-agent',
+      out: filePath,
+      passphrase: 'synthetic-passphrase',
+      exclude: 'personality',
+    });
+
+    const state = await readExportedState(filePath, 'synthetic-passphrase');
+    expect(result).toEqual({ written: true, out: filePath, overwritten: false });
+    expect(log.mock.calls.flat()).toContain('Including paths: memory, tools, preferences');
+    expect(state).not.toHaveProperty('personality');
+    expect(state).toHaveProperty('memory');
+    expect(state).toHaveProperty('tools');
+    expect(state).toHaveProperty('preferences');
+    log.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -65,6 +65,42 @@ export function parseIncludePaths(raw?: string): { components: ComponentSelectio
   };
 }
 
+export function applyExcludePaths(
+  components: ComponentSelection,
+  raw?: string,
+): { components: ComponentSelection } | { error: string } {
+  if (raw === undefined) {
+    return { components };
+  }
+
+  const parts = raw
+    .split(',')
+    .map((part) => part.trim().toLowerCase())
+    .filter((part) => part.length > 0);
+
+  if (parts.length === 0) {
+    return { error: 'Error: --exclude requires at least one path.' };
+  }
+
+  const unknown = parts.filter((part) => !INCLUDE_PATHS.includes(part as IncludePath));
+  if (unknown.length > 0) {
+    return {
+      error: `Error: Unknown exclude path: ${unknown[0]}. Allowed: ${INCLUDE_PATHS.join(', ')}.`,
+    };
+  }
+
+  const next: ComponentSelection = { ...components };
+  for (const part of parts) {
+    next[part as IncludePath] = false;
+  }
+
+  if (!INCLUDE_PATHS.some((path) => next[path])) {
+    return { error: 'Error: --exclude cannot remove every component.' };
+  }
+
+  return { components: next };
+}
+
 // Placeholder for actual agent state loading
 async function getAgentState(agentId: string, components: ComponentSelection): Promise<string> {
   console.log(`Loading state for agent: ${agentId}`);
@@ -141,6 +177,7 @@ export interface ExportOptions {
   passphrase?: string;
   keyfile?: string;
   include?: string;
+  exclude?: string;
   includePersonality?: boolean;
   includeMemory?: boolean;
   includeTools?: boolean;
@@ -259,8 +296,6 @@ export async function exportState(options: ExportOptions): Promise<ExportResult>
         process.exit(1);
       }
       components = parsed.components;
-      const included = INCLUDE_PATHS.filter((path) => components[path]);
-      console.log(`Including paths: ${included.join(', ')}`);
     } else {
       const includeAll = !options.includePersonality && !options.includeMemory && 
                          !options.includeTools && !options.includePreferences;
@@ -270,6 +305,18 @@ export async function exportState(options: ExportOptions): Promise<ExportResult>
         tools: includeAll || !!options.includeTools,
         preferences: includeAll || !!options.includePreferences,
       };
+    }
+
+    const excluded = applyExcludePaths(components, options.exclude);
+    if ('error' in excluded) {
+      console.error(excluded.error);
+      return { written: false, out, overwritten: false };
+    }
+    components = excluded.components;
+
+    if (options.include !== undefined || options.exclude !== undefined) {
+      const included = INCLUDE_PATHS.filter((path) => components[path]);
+      console.log(`Including paths: ${included.join(', ')}`);
     }
 
     reportContainerProgress(`Loading state for agent ${agent}`);
@@ -530,6 +577,7 @@ export function registerContainerCommands(program: Command) {
     .option('-p, --passphrase <pass>', 'Passphrase for encryption (or SAVESTATE_PASSPHRASE / prompt)')
     .option('-k, --keyfile <path>', 'Keyfile for encryption (alternative to passphrase)')
     .option('--include <paths>', 'Comma-separated state paths to include (personality,memory,tools,preferences)')
+    .option('--exclude <paths>', 'Comma-separated state paths to exclude (personality,memory,tools,preferences)')
     .option('--include-personality', 'Include personality data')
     .option('--include-memory', 'Include memory data')
     .option('--include-tools', 'Include tool configurations')
@@ -543,6 +591,7 @@ export function registerContainerCommands(program: Command) {
         passphrase: opts.passphrase,
         keyfile: opts.keyfile,
         include: opts.include,
+        exclude: opts.exclude,
         includePersonality: opts.includePersonality,
         includeMemory: opts.includeMemory,
         includeTools: opts.includeTools,
@@ -593,6 +642,7 @@ export function registerContainerCommands(program: Command) {
     .option('-p, --passphrase <pass>', 'Passphrase for encryption (or SAVESTATE_PASSPHRASE / prompt)')
     .option('-k, --keyfile <path>', 'Keyfile for encryption')
     .option('--include <paths>', 'Comma-separated state paths to include (personality,memory,tools,preferences)')
+    .option('--exclude <paths>', 'Comma-separated state paths to exclude (personality,memory,tools,preferences)')
     .option('--include-personality', 'Include personality data')
     .option('--include-memory', 'Include memory data')
     .option('--include-tools', 'Include tool configurations')
@@ -606,6 +656,7 @@ export function registerContainerCommands(program: Command) {
         passphrase: opts.passphrase,
         keyfile: opts.keyfile,
         include: opts.include,
+        exclude: opts.exclude,
         includePersonality: opts.includePersonality,
         includeMemory: opts.includeMemory,
         includeTools: opts.includeTools,


### PR DESCRIPTION
## Summary

Users can omit sensitive or unused state paths from an encrypted export with `--exclude personality` (or a comma-separated list). `savestate export` and `savestate container export` apply exclude after `--include` / default-all, reject unknown exclude paths before encrypting, and still pack the remaining components.

## Proof

- `npx vitest run src/commands/__tests__/export-exclude.test.ts src/commands/__tests__/container-include.test.ts` — 8 passed
- `savestate export --exclude secrets` fails with `Error: Unknown exclude path`.
- The same flag applies to `savestate container export --exclude`.
- A synthetic export with `--exclude personality` writes a `SAVESTAT` container that includes memory, tools, and preferences only.

## Scope

Export `--exclude` path selection only. No encryption, verify, adapter, import, or publish changes.

Plasmate: https://savestate.dev and https://savestate.dev/docs/cli

Closes a slice of #156.