### PR TITLE
Add conversation_history path to savestate export

### DIFF
--- a/src/commands/__tests__/container-include.test.ts
+++ b/src/commands/__tests__/container-include.test.ts
@@ -55,13 +55,14 @@ describe('savestate export --include', () => {
         memory: true,
         tools: false,
         preferences: false,
+        conversation_history: false,
       },
     });
   });
 
   it('rejects an unknown include path', () => {
     expect(parseIncludePaths('memory,secrets')).toEqual({
-      error: 'Error: Unknown include path: secrets. Allowed: personality, memory, tools, preferences.',
+      error: 'Error: Unknown include path: secrets. Allowed: personality, memory, tools, preferences, conversation_history.',
     });
   });
 
@@ -93,5 +94,6 @@ describe('savestate export --include', () => {
     expect(state).not.toHaveProperty('personality');
     expect(state).not.toHaveProperty('tools');
     expect(state).not.toHaveProperty('preferences');
+    expect(state).not.toHaveProperty('conversation_history');
   });
 });

--- a/src/commands/__tests__/export-conversation-history.test.ts
+++ b/src/commands/__tests__/export-conversation-history.test.ts
@@ -1,0 +1,82 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Command } from 'commander';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { decrypt } from '../../container/crypto.js';
+import {
+  exportState,
+  parseIncludePaths,
+  registerContainerCommands,
+} from '../container.js';
+
+async function readExportedState(path: string, passphrase: string): Promise<Record<string, unknown>> {
+  const fileBuffer = await fs.readFile(path);
+  const manifestLength = fileBuffer.readUInt32LE(16);
+  const encryptedState = fileBuffer.subarray(20 + manifestLength);
+  const decrypted = await decrypt(encryptedState, { passphrase });
+  return JSON.parse(decrypted.toString()) as Record<string, unknown>;
+}
+
+describe('savestate export --include conversation_history', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-export-conversation-history-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('lists conversation_history in --include help', () => {
+    const program = new Command();
+    registerContainerCommands(program);
+    const exportCmd = program.commands.find((command) => command.name() === 'export');
+    const include = exportCmd?.options.find((option) => option.long === '--include');
+    expect(include?.description).toContain('conversation_history');
+  });
+
+  it('parses conversation_history as an include path', () => {
+    expect(parseIncludePaths('conversation_history')).toEqual({
+      components: {
+        personality: false,
+        memory: false,
+        tools: false,
+        preferences: false,
+        conversation_history: true,
+      },
+    });
+  });
+
+  it('packs conversation_history into a synthetic container', async () => {
+    const filePath = join(testDir, 'conversation-history.savestate');
+    const lines: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((message?: unknown) => {
+      if (typeof message === 'string') {
+        lines.push(message);
+      }
+    });
+
+    const result = await exportState({
+      agent: 'fixture-agent',
+      out: filePath,
+      passphrase: 'synthetic-passphrase',
+      include: 'conversation_history',
+    });
+
+    const state = await readExportedState(filePath, 'synthetic-passphrase');
+    expect(result).toEqual({ written: true, out: filePath, overwritten: false });
+    expect(lines).toContain('Including paths: conversation_history');
+    expect(state).toHaveProperty('conversation_history');
+    expect(state).not.toHaveProperty('personality');
+    expect(state).not.toHaveProperty('memory');
+    expect(state).not.toHaveProperty('tools');
+    expect(state).not.toHaveProperty('preferences');
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -15,7 +15,7 @@ async function writeTargetState(targetDir: string, state: string): Promise<strin
   return outFile;
 }
 
-export const INCLUDE_PATHS = ['personality', 'memory', 'tools', 'preferences'] as const;
+export const INCLUDE_PATHS = ['personality', 'memory', 'tools', 'preferences', 'conversation_history'] as const;
 
 export type IncludePath = (typeof INCLUDE_PATHS)[number];
 
@@ -24,6 +24,7 @@ export interface ComponentSelection {
   memory: boolean;
   tools: boolean;
   preferences: boolean;
+  conversation_history: boolean;
 }
 
 export function parseIncludePaths(raw?: string): { components: ComponentSelection } | { error: string } {
@@ -34,6 +35,7 @@ export function parseIncludePaths(raw?: string): { components: ComponentSelectio
         memory: true,
         tools: true,
         preferences: true,
+        conversation_history: true,
       },
     };
   }
@@ -61,6 +63,7 @@ export function parseIncludePaths(raw?: string): { components: ComponentSelectio
       memory: selected.has('memory'),
       tools: selected.has('tools'),
       preferences: selected.has('preferences'),
+      conversation_history: selected.has('conversation_history'),
     },
   };
 }
@@ -105,6 +108,12 @@ async function getAgentState(agentId: string, components: ComponentSelection): P
       language: 'en',
       timezone: 'UTC',
       formatting: {},
+    };
+  }
+
+  if (components.conversation_history) {
+    state.conversation_history = {
+      threads: [],
     };
   }
   
@@ -269,6 +278,7 @@ export async function exportState(options: ExportOptions): Promise<ExportResult>
         memory: includeAll || !!options.includeMemory,
         tools: includeAll || !!options.includeTools,
         preferences: includeAll || !!options.includePreferences,
+        conversation_history: includeAll,
       };
     }
 
@@ -529,7 +539,7 @@ export function registerContainerCommands(program: Command) {
     .option('-o, --output <file>', 'Output file path', 'agent.savestate')
     .option('-p, --passphrase <pass>', 'Passphrase for encryption (or SAVESTATE_PASSPHRASE / prompt)')
     .option('-k, --keyfile <path>', 'Keyfile for encryption (alternative to passphrase)')
-    .option('--include <paths>', 'Comma-separated state paths to include (personality,memory,tools,preferences)')
+    .option('--include <paths>', 'Comma-separated state paths to include (personality,memory,tools,preferences,conversation_history)')
     .option('--include-personality', 'Include personality data')
     .option('--include-memory', 'Include memory data')
     .option('--include-tools', 'Include tool configurations')
@@ -592,7 +602,7 @@ export function registerContainerCommands(program: Command) {
     .requiredOption('-o, --out <file>', 'Output file path (.savestate)')
     .option('-p, --passphrase <pass>', 'Passphrase for encryption (or SAVESTATE_PASSPHRASE / prompt)')
     .option('-k, --keyfile <path>', 'Keyfile for encryption')
-    .option('--include <paths>', 'Comma-separated state paths to include (personality,memory,tools,preferences)')
+    .option('--include <paths>', 'Comma-separated state paths to include (personality,memory,tools,preferences,conversation_history)')
     .option('--include-personality', 'Include personality data')
     .option('--include-memory', 'Include memory data')
     .option('--include-tools', 'Include tool configurations')


### PR DESCRIPTION
## Summary

Users can select `conversation_history` as an export component with `--include conversation_history` (or a comma-separated list). Default exports still include all components. `savestate export` and `savestate container export` pack a top-level `conversation_history` payload separately from `memory`.

## Proof

- `npx vitest run src/commands/__tests__/export-conversation-history.test.ts src/commands/__tests__/container-include.test.ts` — 8 passed
- `--include conversation_history` writes a `SAVESTAT` container with conversation history only.
- `--include memory` still omits conversation history.
- Unknown include paths list `conversation_history` among allowed values.

## Scope

Export `--include conversation_history` only. No encryption, verify, adapter, import, or publish changes.

Plasmate: https://savestate.dev and https://savestate.dev/docs/cli.html

Closes a slice of #156.