### PR TITLE
Record included components on savestate export manifest

### DIFF
--- a/src/commands/__tests__/export-manifest-components.test.ts
+++ b/src/commands/__tests__/export-manifest-components.test.ts
@@ -1,0 +1,62 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { exportState } from '../container.js';
+
+function readManifest(file: Buffer): {
+  components?: string[];
+} {
+  const manifestLength = file.readUInt32LE(16);
+  return JSON.parse(file.subarray(20, 20 + manifestLength).toString('utf-8'));
+}
+
+describe('savestate export manifest components', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-export-manifest-components-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  it('records selected include paths on the unencrypted manifest', async () => {
+    const filePath = join(testDir, 'include-memory-tools.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await exportState({
+      agent: 'fixture-agent',
+      out: filePath,
+      passphrase: 'synthetic-passphrase',
+      include: 'memory,tools',
+    });
+
+    const written = await fs.readFile(filePath);
+    const manifest = readManifest(written);
+
+    expect(result).toEqual({ written: true, out: filePath, overwritten: false });
+    expect(written.subarray(0, 8).toString('ascii')).toBe('SAVESTAT');
+    expect(manifest.components).toEqual(['memory', 'tools']);
+    log.mockRestore();
+  });
+
+  it('records every default component on the unencrypted manifest', async () => {
+    const filePath = join(testDir, 'default-all.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await exportState({
+      agent: 'fixture-agent',
+      out: filePath,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    const written = await fs.readFile(filePath);
+    const manifest = readManifest(written);
+
+    expect(manifest.components).toEqual(['personality', 'memory', 'tools', 'preferences']);
+    log.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -272,6 +272,8 @@ export async function exportState(options: ExportOptions): Promise<ExportResult>
       };
     }
 
+    const includedComponents = INCLUDE_PATHS.filter((path) => components[path]);
+
     reportContainerProgress(`Loading state for agent ${agent}`);
     const agentState = await getAgentState(agent, components);
     const plaintext = Buffer.from(agentState);
@@ -286,6 +288,7 @@ export async function exportState(options: ExportOptions): Promise<ExportResult>
         algorithm: 'AES-256-GCM',
         keyDerivation: 'Argon2id',
       },
+      components: includedComponents,
       payloads: [
         {
           name: 'agent_state',


### PR DESCRIPTION
## Summary

Users can inspect which state paths were packed without decrypting. `savestate export` and `savestate container export` write a `components` array on the unencrypted manifest (`personality`, `memory`, `tools`, `preferences`), matching `--include` or the default-all selection.

## Proof

- `npx vitest run src/commands/__tests__/export-manifest-components.test.ts src/commands/__tests__/container-include.test.ts src/commands/__tests__/export-description.test.ts` — 10 passed
- `--include memory,tools` writes `components: ["memory","tools"]` on the SAVESTAT manifest.
- A default export writes all four component names on the manifest.

## Scope

Export manifest `components` only. No encryption, verify, adapter, import, or publish changes.

Plasmate: https://savestate.dev and https://savestate.dev/docs/cli

Closes a slice of #156.