### PR TITLE
Add --include path selection to savestate import

### DIFF
--- a/src/commands/__tests__/import-include.test.ts
+++ b/src/commands/__tests__/import-include.test.ts
@@ -1,0 +1,130 @@
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Command } from 'commander';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { applyImportInclude, importState, registerContainerCommands } from '../container.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate import --include', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-import-include-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  async function createValidContainer(filePath: string, passphrase: string): Promise<void> {
+    const agentState = {
+      agentId: 'fixture-agent',
+      version: 1,
+      exportedAt: '2026-08-21T15:00:00.000Z',
+      personality: { name: 'fixture-agent' },
+      memory: { facts: ['synthetic'] },
+      tools: { enabled: [] },
+    };
+    const plaintext = Buffer.from(JSON.stringify(agentState));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest = {
+      formatVersion: 1,
+      created: '2026-08-21T15:00:00.000Z',
+      agentId: 'fixture-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: createHash('sha256').update(plaintext).digest('hex'),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    await fs.writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+  }
+
+  it('registers --include on import commands', () => {
+    const program = new Command();
+    registerContainerCommands(program);
+    const importCmd = program.commands.find((command) => command.name() === 'import');
+    const containerImport = program.commands
+      .find((command) => command.name() === 'container')
+      ?.commands.find((command) => command.name() === 'import');
+    expect(importCmd?.options.some((option) => option.long === '--include')).toBe(true);
+    expect(containerImport?.options.some((option) => option.long === '--include')).toBe(true);
+  });
+
+  it('rejects an unknown include path before restoring', async () => {
+    const filePath = join(testDir, 'unknown-include.savestate');
+    await createValidContainer(filePath, 'synthetic-passphrase');
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    expect(applyImportInclude({ memory: { facts: [] } }, 'secrets')).toEqual({
+      error:
+        'Error: Unknown include path: secrets. Allowed: personality, memory, tools, preferences, conversation_history.',
+    });
+
+    const result = await importState({
+      in: filePath,
+      passphrase: 'synthetic-passphrase',
+      include: 'secrets',
+    });
+
+    expect(result).toBeUndefined();
+    expect(error.mock.calls.flat().join('\n')).toMatch(/unknown include path/i);
+    expect(log.mock.calls.flat().join('\n')).not.toContain('Successfully restored');
+    expect(log.mock.calls.flat().join('\n')).not.toContain('Decrypting agent state');
+    error.mockRestore();
+    log.mockRestore();
+  });
+
+  it('restores only selected components to the target directory', async () => {
+    const filePath = join(testDir, 'include-memory.savestate');
+    const targetDir = join(testDir, 'restored');
+    await createValidContainer(filePath, 'synthetic-passphrase');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: filePath,
+      passphrase: 'synthetic-passphrase',
+      include: 'memory',
+      target: targetDir,
+    });
+
+    const writtenPath = join(targetDir, 'agent_state.json');
+    const written = JSON.parse(await fs.readFile(writtenPath, 'utf-8')) as Record<string, unknown>;
+
+    expect(result).toEqual({
+      dryRun: false,
+      restored: true,
+      agentId: 'fixture-agent',
+      mode: 'replace',
+      created: '2026-08-21T15:00:00.000Z',
+      components: ['memory'],
+      target: writtenPath,
+    });
+    expect(log.mock.calls.flat()).toContain('Including paths: memory');
+    expect(written).toHaveProperty('memory');
+    expect(written).toHaveProperty('agentId', 'fixture-agent');
+    expect(written).not.toHaveProperty('personality');
+    expect(written).not.toHaveProperty('tools');
+    log.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -132,6 +132,47 @@ export function applyExcludePaths(
   return { components: next };
 }
 
+const IMPORT_METADATA_KEYS = new Set(['agentId', 'version', 'exportedAt']);
+
+export function applyImportInclude(
+  state: Record<string, unknown>,
+  raw?: string,
+): { state: Record<string, unknown>; components: string[] } | { error: string } {
+  if (raw === undefined) {
+    return {
+      state,
+      components: Object.keys(state).filter((key) => !IMPORT_METADATA_KEYS.has(key)),
+    };
+  }
+
+  const parsed = parseIncludePaths(raw);
+  if ('error' in parsed) {
+    return parsed;
+  }
+
+  const selected = INCLUDE_PATHS.filter((path) => parsed.components[path]);
+  const next: Record<string, unknown> = {};
+  for (const key of IMPORT_METADATA_KEYS) {
+    if (key in state) {
+      next[key] = state[key];
+    }
+  }
+
+  const components: string[] = [];
+  for (const path of selected) {
+    if (path in state) {
+      next[path] = state[path];
+      components.push(path);
+    }
+  }
+
+  if (components.length === 0) {
+    return { error: 'Error: --include matched no components in this archive.' };
+  }
+
+  return { state: next, components };
+}
+
 // Placeholder for actual agent state loading
 async function getAgentState(agentId: string, components: ComponentSelection): Promise<string> {
   console.log(`Loading state for agent: ${agentId}`);
@@ -424,6 +465,7 @@ export interface RestoreOptions {
   replace?: boolean;
   dryRun?: boolean;
   target?: string;
+  include?: string;
 }
 
 export interface ImportResult {
@@ -436,12 +478,6 @@ export interface ImportResult {
   target?: string;
 }
 
-function listRestoredComponents(parsedState: Record<string, unknown>): string[] {
-  return Object.keys(parsedState).filter(
-    (key) => key !== 'agentId' && key !== 'version' && key !== 'exportedAt',
-  );
-}
-
 export async function importState(options: RestoreOptions): Promise<ImportResult | undefined> {
   try {
     const { in: inFile, passphrase, keyfile } = options;
@@ -449,6 +485,14 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
     if (typeof inFile !== 'string' || inFile.trim() === '') {
       console.error(`Error: Input path must not be empty: ${JSON.stringify(inFile)}.`);
       return undefined;
+    }
+
+    if (options.include !== undefined) {
+      const parsed = parseIncludePaths(options.include);
+      if ('error' in parsed) {
+        console.error(parsed.error);
+        return undefined;
+      }
     }
 
     if (options.target !== undefined) {
@@ -566,9 +610,19 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
       process.exit(1);
     }
     
-    const stateText = decryptedState.toString();
-    const parsedState = JSON.parse(stateText) as Record<string, unknown>;
-    const components = listRestoredComponents(parsedState);
+    let stateText = decryptedState.toString();
+    let parsedState = JSON.parse(stateText) as Record<string, unknown>;
+    const selected = applyImportInclude(parsedState, options.include);
+    if ('error' in selected) {
+      console.error(selected.error);
+      return undefined;
+    }
+    if (options.include !== undefined) {
+      parsedState = selected.state;
+      stateText = JSON.stringify(parsedState, null, 2);
+      console.log(`Including paths: ${selected.components.join(', ')}`);
+    }
+    const components = selected.components;
     const result: ImportResult = {
       dryRun: !!options.dryRun,
       restored: !options.dryRun,
@@ -655,6 +709,7 @@ export function registerContainerCommands(program: Command) {
     .description('Import agent state from an encrypted .savestate file. Prints byte-size progress.')
     .option('-p, --passphrase <pass>', 'Passphrase for decryption (or SAVESTATE_PASSPHRASE / prompt)')
     .option('-k, --keyfile <path>', 'Keyfile for decryption (alternative to passphrase)')
+    .option('--include <paths>', 'Comma-separated state paths to restore (personality,memory,tools,preferences,conversation_history)')
     .option('--merge', 'Merge with existing state (default: replace)')
     .option('--replace', 'Replace existing state completely')
     .option('--dry-run', 'Show what would be imported without restoring')
@@ -668,6 +723,7 @@ export function registerContainerCommands(program: Command) {
         replace: opts.replace,
         dryRun: opts.dryRun,
         target: opts.target,
+        include: opts.include,
       });
       if (!result) {
         process.exit(1);
@@ -719,6 +775,7 @@ export function registerContainerCommands(program: Command) {
     .requiredOption('-i, --in <file>', 'Input file path (.savestate)')
     .option('-p, --passphrase <pass>', 'Passphrase for decryption (or SAVESTATE_PASSPHRASE / prompt)')
     .option('-k, --keyfile <path>', 'Keyfile for decryption')
+    .option('--include <paths>', 'Comma-separated state paths to restore (personality,memory,tools,preferences,conversation_history)')
     .option('--merge', 'Merge with existing state')
     .option('--replace', 'Replace existing state (default)')
     .option('--dry-run', 'Show what would be imported without restoring')
@@ -732,6 +789,7 @@ export function registerContainerCommands(program: Command) {
         replace: opts.replace,
         dryRun: opts.dryRun,
         target: opts.target,
+        include: opts.include,
       });
       if (!result) {
         process.exit(1);


### PR DESCRIPTION
## Summary
- Add `--include` on `savestate import` / `savestate container import` so a full archive can restore only selected paths (`personality`, `memory`, `tools`, `preferences`, `conversation_history`).
- Unknown include paths fail before decrypt; a selection that matches nothing in the archive is rejected.

## Proof
Focused vitest (not full suite):
`npx vitest run src/commands/__tests__/import-include.test.ts src/commands/__tests__/import-dry-run.test.ts src/commands/__tests__/import-target.test.ts` — 8 passed.

Plasmate: https://savestate.dev and https://savestate.dev/docs/cli.html

Follow-on to selective export (#156). No READY-labeled issue was open; this is the next small CLI increment.