### PR TITLE
Add --exclude path selection to savestate import

### DIFF
--- a/src/commands/__tests__/import-exclude.test.ts
+++ b/src/commands/__tests__/import-exclude.test.ts
@@ -1,0 +1,130 @@
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Command } from 'commander';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { applyImportExclude, importState, registerContainerCommands } from '../container.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate import --exclude', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-import-exclude-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  async function createValidContainer(filePath: string, passphrase: string): Promise<void> {
+    const agentState = {
+      agentId: 'fixture-agent',
+      version: 1,
+      exportedAt: '2026-08-21T16:00:00.000Z',
+      personality: { name: 'fixture-agent' },
+      memory: { facts: ['synthetic'] },
+      tools: { enabled: [] },
+    };
+    const plaintext = Buffer.from(JSON.stringify(agentState));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest = {
+      formatVersion: 1,
+      created: '2026-08-21T16:00:00.000Z',
+      agentId: 'fixture-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: createHash('sha256').update(plaintext).digest('hex'),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    await fs.writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+  }
+
+  it('registers --exclude on import commands', () => {
+    const program = new Command();
+    registerContainerCommands(program);
+    const importCmd = program.commands.find((command) => command.name() === 'import');
+    const containerImport = program.commands
+      .find((command) => command.name() === 'container')
+      ?.commands.find((command) => command.name() === 'import');
+    expect(importCmd?.options.some((option) => option.long === '--exclude')).toBe(true);
+    expect(containerImport?.options.some((option) => option.long === '--exclude')).toBe(true);
+  });
+
+  it('rejects an unknown exclude path before restoring', async () => {
+    const filePath = join(testDir, 'unknown-exclude.savestate');
+    await createValidContainer(filePath, 'synthetic-passphrase');
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    expect(applyImportExclude({ memory: { facts: [] } }, 'secrets')).toEqual({
+      error:
+        'Error: Unknown exclude path: secrets. Allowed: personality, memory, tools, preferences, conversation_history.',
+    });
+
+    const result = await importState({
+      in: filePath,
+      passphrase: 'synthetic-passphrase',
+      exclude: 'secrets',
+    });
+
+    expect(result).toBeUndefined();
+    expect(error.mock.calls.flat().join('\n')).toMatch(/unknown exclude path/i);
+    expect(log.mock.calls.flat().join('\n')).not.toContain('Successfully restored');
+    expect(log.mock.calls.flat().join('\n')).not.toContain('Decrypting agent state');
+    error.mockRestore();
+    log.mockRestore();
+  });
+
+  it('omits excluded components from the target directory', async () => {
+    const filePath = join(testDir, 'exclude-personality.savestate');
+    const targetDir = join(testDir, 'restored');
+    await createValidContainer(filePath, 'synthetic-passphrase');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: filePath,
+      passphrase: 'synthetic-passphrase',
+      exclude: 'personality',
+      target: targetDir,
+    });
+
+    const writtenPath = join(targetDir, 'agent_state.json');
+    const written = JSON.parse(await fs.readFile(writtenPath, 'utf-8')) as Record<string, unknown>;
+
+    expect(result).toEqual({
+      dryRun: false,
+      restored: true,
+      agentId: 'fixture-agent',
+      mode: 'replace',
+      created: '2026-08-21T16:00:00.000Z',
+      components: ['memory', 'tools'],
+      target: writtenPath,
+    });
+    expect(log.mock.calls.flat()).toContain('Including paths: memory, tools');
+    expect(written).toHaveProperty('memory');
+    expect(written).toHaveProperty('tools');
+    expect(written).toHaveProperty('agentId', 'fixture-agent');
+    expect(written).not.toHaveProperty('personality');
+    log.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -132,6 +132,55 @@ export function applyExcludePaths(
   return { components: next };
 }
 
+const IMPORT_METADATA_KEYS = new Set(['agentId', 'version', 'exportedAt']);
+
+export function applyImportExclude(
+  state: Record<string, unknown>,
+  raw?: string,
+): { state: Record<string, unknown>; components: string[] } | { error: string } {
+  if (raw === undefined) {
+    return {
+      state,
+      components: Object.keys(state).filter((key) => !IMPORT_METADATA_KEYS.has(key)),
+    };
+  }
+
+  const parsed = applyExcludePaths(
+    {
+      personality: true,
+      memory: true,
+      tools: true,
+      preferences: true,
+      conversation_history: true,
+    },
+    raw,
+  );
+  if ('error' in parsed) {
+    return parsed;
+  }
+
+  const next: Record<string, unknown> = {};
+  for (const key of IMPORT_METADATA_KEYS) {
+    if (key in state) {
+      next[key] = state[key];
+    }
+  }
+
+  const components: string[] = [];
+  for (const path of INCLUDE_PATHS) {
+    if (parsed.components[path] && path in state) {
+      next[path] = state[path];
+      components.push(path);
+    }
+  }
+
+  if (components.length === 0) {
+    return { error: 'Error: --exclude matched no remaining components in this archive.' };
+  }
+
+  return { state: next, components };
+}
+
 // Placeholder for actual agent state loading
 async function getAgentState(agentId: string, components: ComponentSelection): Promise<string> {
   console.log(`Loading state for agent: ${agentId}`);
@@ -424,6 +473,7 @@ export interface RestoreOptions {
   replace?: boolean;
   dryRun?: boolean;
   target?: string;
+  exclude?: string;
 }
 
 export interface ImportResult {
@@ -436,12 +486,6 @@ export interface ImportResult {
   target?: string;
 }
 
-function listRestoredComponents(parsedState: Record<string, unknown>): string[] {
-  return Object.keys(parsedState).filter(
-    (key) => key !== 'agentId' && key !== 'version' && key !== 'exportedAt',
-  );
-}
-
 export async function importState(options: RestoreOptions): Promise<ImportResult | undefined> {
   try {
     const { in: inFile, passphrase, keyfile } = options;
@@ -449,6 +493,23 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
     if (typeof inFile !== 'string' || inFile.trim() === '') {
       console.error(`Error: Input path must not be empty: ${JSON.stringify(inFile)}.`);
       return undefined;
+    }
+
+    if (options.exclude !== undefined) {
+      const parsed = applyExcludePaths(
+        {
+          personality: true,
+          memory: true,
+          tools: true,
+          preferences: true,
+          conversation_history: true,
+        },
+        options.exclude,
+      );
+      if ('error' in parsed) {
+        console.error(parsed.error);
+        return undefined;
+      }
     }
 
     if (options.target !== undefined) {
@@ -566,9 +627,19 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
       process.exit(1);
     }
     
-    const stateText = decryptedState.toString();
-    const parsedState = JSON.parse(stateText) as Record<string, unknown>;
-    const components = listRestoredComponents(parsedState);
+    let stateText = decryptedState.toString();
+    let parsedState = JSON.parse(stateText) as Record<string, unknown>;
+    const selected = applyImportExclude(parsedState, options.exclude);
+    if ('error' in selected) {
+      console.error(selected.error);
+      return undefined;
+    }
+    if (options.exclude !== undefined) {
+      parsedState = selected.state;
+      stateText = JSON.stringify(parsedState, null, 2);
+      console.log(`Including paths: ${selected.components.join(', ')}`);
+    }
+    const components = selected.components;
     const result: ImportResult = {
       dryRun: !!options.dryRun,
       restored: !options.dryRun,
@@ -655,6 +726,7 @@ export function registerContainerCommands(program: Command) {
     .description('Import agent state from an encrypted .savestate file. Prints byte-size progress.')
     .option('-p, --passphrase <pass>', 'Passphrase for decryption (or SAVESTATE_PASSPHRASE / prompt)')
     .option('-k, --keyfile <path>', 'Keyfile for decryption (alternative to passphrase)')
+    .option('--exclude <paths>', 'Comma-separated state paths to skip (personality,memory,tools,preferences,conversation_history)')
     .option('--merge', 'Merge with existing state (default: replace)')
     .option('--replace', 'Replace existing state completely')
     .option('--dry-run', 'Show what would be imported without restoring')
@@ -668,6 +740,7 @@ export function registerContainerCommands(program: Command) {
         replace: opts.replace,
         dryRun: opts.dryRun,
         target: opts.target,
+        exclude: opts.exclude,
       });
       if (!result) {
         process.exit(1);
@@ -719,6 +792,7 @@ export function registerContainerCommands(program: Command) {
     .requiredOption('-i, --in <file>', 'Input file path (.savestate)')
     .option('-p, --passphrase <pass>', 'Passphrase for decryption (or SAVESTATE_PASSPHRASE / prompt)')
     .option('-k, --keyfile <path>', 'Keyfile for decryption')
+    .option('--exclude <paths>', 'Comma-separated state paths to skip (personality,memory,tools,preferences,conversation_history)')
     .option('--merge', 'Merge with existing state')
     .option('--replace', 'Replace existing state (default)')
     .option('--dry-run', 'Show what would be imported without restoring')
@@ -732,6 +806,7 @@ export function registerContainerCommands(program: Command) {
         replace: opts.replace,
         dryRun: opts.dryRun,
         target: opts.target,
+        exclude: opts.exclude,
       });
       if (!result) {
         process.exit(1);


### PR DESCRIPTION
## Summary
- Add `--exclude` on `savestate import` / `savestate container import` so a full archive can restore while skipping selected paths (`personality`, `memory`, `tools`, `preferences`, `conversation_history`).
- Unknown exclude paths fail before decrypt; excluding every remaining archive component is rejected.

## Proof
Focused vitest (not full suite):
`npx vitest run src/commands/__tests__/import-exclude.test.ts src/commands/__tests__/import-dry-run.test.ts src/commands/__tests__/import-target.test.ts src/commands/__tests__/export-exclude.test.ts` — 11 passed.

Plasmate: https://savestate.dev and https://savestate.dev/docs/cli.html

Follow-on to export `--exclude` (#263) and selective restore. No unique unused READY-labeled issue was a 15-minute increment; this is the next small CLI change.