### PR TITLE
Print excluded paths on savestate --exclude

### DIFF
--- a/src/commands/__tests__/exclude-paths-output.test.ts
+++ b/src/commands/__tests__/exclude-paths-output.test.ts
@@ -1,0 +1,142 @@
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { exportState, importState, listExcludedPaths } from '../container.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate --exclude path output', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-exclude-paths-output-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  async function createValidContainer(filePath: string, passphrase: string): Promise<void> {
+    const agentState = {
+      agentId: 'fixture-agent',
+      version: 1,
+      exportedAt: '2026-08-21T23:30:00.000Z',
+      personality: { name: 'fixture-agent' },
+      memory: { facts: ['synthetic'] },
+      tools: { enabled: [] },
+    };
+    const plaintext = Buffer.from(JSON.stringify(agentState));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest = {
+      formatVersion: 1,
+      created: '2026-08-21T23:30:00.000Z',
+      agentId: 'fixture-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: createHash('sha256').update(plaintext).digest('hex'),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    await fs.writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+  }
+
+  it('normalizes excluded path tokens', () => {
+    expect(listExcludedPaths(undefined)).toEqual([]);
+    expect(listExcludedPaths('personality')).toEqual(['personality']);
+    expect(listExcludedPaths('personality, Memory')).toEqual(['personality', 'memory']);
+  });
+
+  it('prints excluded paths on export', async () => {
+    const filePath = join(testDir, 'export-exclude.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await exportState({
+      agent: 'fixture-agent',
+      out: filePath,
+      passphrase: 'synthetic-passphrase',
+      exclude: 'personality',
+    });
+
+    expect(result).toEqual({ written: true, out: filePath, overwritten: false });
+    expect(log.mock.calls.flat()).toContain('Excluding paths: personality');
+    expect(log.mock.calls.flat()).toContain('Including paths: memory, tools, preferences, conversation_history');
+    log.mockRestore();
+  });
+
+  it('prints excluded paths on import', async () => {
+    const filePath = join(testDir, 'import-exclude.savestate');
+    const targetDir = join(testDir, 'restored');
+    await createValidContainer(filePath, 'synthetic-passphrase');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: filePath,
+      passphrase: 'synthetic-passphrase',
+      exclude: 'personality',
+      target: targetDir,
+    });
+
+    expect(result).toMatchObject({
+      restored: true,
+      agentId: 'fixture-agent',
+      components: ['memory', 'tools'],
+    });
+    expect(log.mock.calls.flat()).toContain('Excluding paths: personality');
+    expect(log.mock.calls.flat()).toContain('Including paths: memory, tools');
+    log.mockRestore();
+  });
+
+  it('does not print excluded paths when --exclude is rejected', async () => {
+    const filePath = join(testDir, 'rejected-exclude.savestate');
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await exportState({
+      agent: 'fixture-agent',
+      out: filePath,
+      passphrase: 'synthetic-passphrase',
+      exclude: 'secrets',
+    });
+
+    expect(result).toEqual({ written: false, out: filePath, overwritten: false });
+    expect(error.mock.calls.flat().join('\n')).toMatch(/unknown exclude path/i);
+    expect(log.mock.calls.flat().join('\n')).not.toContain('Excluding paths:');
+    error.mockRestore();
+    log.mockRestore();
+  });
+
+  it('does not print excluded paths for include-only selection', async () => {
+    const filePath = join(testDir, 'include-only.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await exportState({
+      agent: 'fixture-agent',
+      out: filePath,
+      passphrase: 'synthetic-passphrase',
+      include: 'memory,tools',
+    });
+
+    expect(result).toEqual({ written: true, out: filePath, overwritten: false });
+    expect(log.mock.calls.flat()).toContain('Including paths: memory, tools');
+    expect(log.mock.calls.flat().join('\n')).not.toContain('Excluding paths:');
+    log.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -155,6 +155,17 @@ export function applyExcludePaths(
   return { components: next };
 }
 
+export function listExcludedPaths(raw?: string): string[] {
+  if (raw === undefined) {
+    return [];
+  }
+
+  return raw
+    .split(',')
+    .map((part) => part.trim().toLowerCase())
+    .filter((part) => part.length > 0);
+}
+
 const IMPORT_METADATA_KEYS = new Set(['agentId', 'version', 'exportedAt']);
 
 export function applyImportInclude(
@@ -469,6 +480,10 @@ export async function exportState(options: ExportOptions): Promise<ExportResult>
     if (options.include !== undefined || options.exclude !== undefined) {
       console.log(`Including paths: ${validatedComponents.components.join(', ')}`);
     }
+    const excludedPaths = listExcludedPaths(options.exclude);
+    if (excludedPaths.length > 0) {
+      console.log(`Excluding paths: ${excludedPaths.join(', ')}`);
+    }
 
     reportContainerProgress(`Loading state for agent ${agent}`);
     const agentState = await getAgentState(agent, components);
@@ -716,6 +731,10 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
       parsedState = selected.state;
       stateText = JSON.stringify(parsedState, null, 2);
       console.log(`Including paths: ${selected.components.join(', ')}`);
+    }
+    const excludedPaths = listExcludedPaths(options.exclude);
+    if (excludedPaths.length > 0) {
+      console.log(`Excluding paths: ${excludedPaths.join(', ')}`);
     }
     const components = selected.components;
     const result: ImportResult = {


### PR DESCRIPTION
## Summary

`--exclude personality` now prints the skipped paths on export and import, next to the remaining `Including paths:` line.

Follow-on to #269–#273. Closes #276.

## Proof

- `npx vitest run src/commands/__tests__/exclude-paths-output.test.ts src/commands/__tests__/export-exclude.test.ts src/commands/__tests__/import-exclude.test.ts src/commands/__tests__/exclude-unselected.test.ts src/commands/__tests__/empty-path-token.test.ts src/commands/__tests__/exclude-duplicate.test.ts` — 24 passed
- `listExcludedPaths('personality, Memory')` returns `['personality', 'memory']`
- Export and import with `--exclude personality` print `Excluding paths: personality`
- A rejected `--exclude secrets` does not print `Excluding paths:`
- `--include memory,tools` without `--exclude` still does not print `Excluding paths:`

## Scope

Excluded-path output only. No include-set, duplicate-path, empty-token, archive-membership, verify, adapter, or publish changes.

Plasmate: https://savestate.dev and https://savestate.dev/docs/cli.html