### PR TITLE
Reject an excluded path that is still packed on savestate verify

### DIFF
--- a/src/commands/__tests__/verify-excluded-packed.test.ts
+++ b/src/commands/__tests__/verify-excluded-packed.test.ts
@@ -1,0 +1,90 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { packedExcludedPath, verifyContainer } from '../verify.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate verify packed excluded membership', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'savestate-verify-excluded-packed-'));
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(fileName: string, excluded?: unknown): Promise<string> {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({
+      agentId: 'demo-agent',
+      version: 1,
+      exportedAt: '2026-08-22T03:00:00.000Z',
+      memory: { facts: ['synthetic'] },
+    }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest: Record<string, unknown> = {
+      formatVersion: 1,
+      created: '2026-08-22T03:00:00.000Z',
+      agentId: 'demo-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: createHash('sha256').update(plaintext).digest('hex'),
+        },
+      ],
+    };
+    if (excluded !== undefined) {
+      manifest.excluded = excluded;
+    }
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('reports an excluded path that is still present in packed state', () => {
+    expect(packedExcludedPath(['memory', 'personality'], ['memory'])).toBe('memory');
+    expect(packedExcludedPath(['personality'], ['memory'])).toBeUndefined();
+  });
+
+  it('rejects a container whose excluded list includes a packed path', async () => {
+    const filePath = await writeContainer('excluded-packed.savestate', ['memory']);
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.message).toBe('Invalid manifest: excluded path is packed: memory');
+    expect(result.manifest).toBeUndefined();
+  });
+
+  it('accepts a matching excluded list and still verifies older files without them', async () => {
+    const matching = await writeContainer('matching-excluded.savestate', ['personality']);
+    const legacy = await writeContainer('no-excluded.savestate');
+
+    const valid = await verifyContainer(matching, { passphrase: 'synthetic-verify-pass' });
+    const older = await verifyContainer(legacy, { passphrase: 'synthetic-verify-pass' });
+
+    expect(valid.status).toBe('valid');
+    expect(valid.components).toEqual(['memory']);
+    expect(older.status).toBe('valid');
+    expect(older.components).toEqual(['memory']);
+  });
+});

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -96,6 +96,13 @@ export function missingPackedComponent(
   return listed.find((path) => !packed.includes(path));
 }
 
+export function packedExcludedPath(
+  excluded: readonly string[],
+  packed: readonly string[],
+): string | undefined {
+  return excluded.find((path) => packed.includes(path));
+}
+
 /**
  * Verify a .savestate file's integrity and optionally its decryptability.
  *
@@ -670,6 +677,16 @@ export async function verifyContainer(
       return {
         status: 'corrupted',
         message: `Invalid manifest: component not packed: ${missing}`,
+      };
+    }
+  }
+
+  if (Array.isArray(manifest.excluded)) {
+    const packedExclusion = packedExcludedPath(manifest.excluded, components);
+    if (packedExclusion) {
+      return {
+        status: 'corrupted',
+        message: `Invalid manifest: excluded path is packed: ${packedExclusion}`,
       };
     }
   }


### PR DESCRIPTION
## Summary

`savestate verify` now rejects a container whose unencrypted `excluded` list names a path that is still in the decrypted payload.

Follow-on to #278 (record excluded on export manifest) and #282 (excluded schema). Distinct from packed-component membership (#280).

Closes #283

## Proof

- `npx vitest run src/commands/__tests__/verify-excluded-packed.test.ts src/commands/__tests__/verify-excluded-schema.test.ts src/commands/__tests__/verify-components-mismatch.test.ts src/commands/__tests__/verify.test.ts` — 20 passed
- `packedExcludedPath(['memory', 'personality'], ['memory'])` returns `memory`
- A memory-only payload listed as `excluded: ['memory']` returns `Invalid manifest: excluded path is packed: memory`
- A matching `['personality']` list still verifies
- Legacy archives without `excluded` still verify

## Scope

Packed-excluded membership on verify only. No export, import, adapter, or publish changes.

Plasmate: https://savestate.dev and https://savestate.dev/docs/cli.html