### PR TITLE
Reject an excluded path that is also listed in components on savestate import

### DIFF
--- a/src/commands/__tests__/import-excluded-listed.test.ts
+++ b/src/commands/__tests__/import-excluded-listed.test.ts
@@ -1,0 +1,140 @@
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { exportState, importState } from '../container.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate import excluded listed membership', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-import-excluded-listed-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(
+    fileName: string,
+    fields?: { components?: unknown; excluded?: unknown },
+  ): Promise<string> {
+    const passphrase = 'synthetic-passphrase';
+    const plaintext = Buffer.from(JSON.stringify({
+      agentId: 'fixture-agent',
+      version: 1,
+      memory: { facts: ['synthetic'] },
+      tools: { enabled: [] },
+    }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest: Record<string, unknown> = {
+      formatVersion: 1,
+      created: '2026-08-22T07:10:00.000Z',
+      agentId: 'fixture-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: createHash('sha256').update(plaintext).digest('hex'),
+        },
+      ],
+    };
+    if (fields?.components !== undefined) {
+      manifest.components = fields.components;
+    }
+    if (fields?.excluded !== undefined) {
+      manifest.excluded = fields.excluded;
+    }
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await fs.writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('rejects a container whose excluded list includes a listed component', async () => {
+    const filePath = await writeContainer('overlap.savestate', {
+      components: ['memory', 'tools'],
+      excluded: ['memory'],
+    });
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: filePath,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    expect(result).toBeUndefined();
+    expect(error.mock.calls.flat().join('\n')).toMatch(/excluded path is listed: memory/i);
+    expect(log.mock.calls.flat().join('\n')).not.toContain('Successfully restored');
+    error.mockRestore();
+    log.mockRestore();
+  });
+
+  it('imports a disjoint pair and still accepts older files missing either field', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const disjoint = await writeContainer('disjoint.savestate', {
+      components: ['memory', 'tools'],
+      excluded: ['personality'],
+    });
+    const componentsOnly = await writeContainer('components-only.savestate', {
+      components: ['memory', 'tools'],
+    });
+    const excludedOnly = await writeContainer('excluded-only.savestate', {
+      excluded: ['personality'],
+    });
+    const legacy = await writeContainer('legacy.savestate');
+    const exported = join(testDir, 'exported.savestate');
+
+    const valid = await importState({
+      in: disjoint,
+      passphrase: 'synthetic-passphrase',
+    });
+    const listed = await importState({
+      in: componentsOnly,
+      passphrase: 'synthetic-passphrase',
+    });
+    const omitted = await importState({
+      in: excludedOnly,
+      passphrase: 'synthetic-passphrase',
+    });
+    const older = await importState({
+      in: legacy,
+      passphrase: 'synthetic-passphrase',
+    });
+    const written = await exportState({
+      agent: 'fixture-agent',
+      out: exported,
+      passphrase: 'synthetic-passphrase',
+      exclude: 'personality',
+    });
+    const fromExport = await importState({
+      in: exported,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    expect(valid).toMatchObject({ restored: true, agentId: 'fixture-agent' });
+    expect(listed).toMatchObject({ restored: true, agentId: 'fixture-agent' });
+    expect(omitted).toMatchObject({ restored: true, agentId: 'fixture-agent' });
+    expect(older).toMatchObject({ restored: true, agentId: 'fixture-agent' });
+    expect(written.written).toBe(true);
+    expect(fromExport).toMatchObject({ restored: true, agentId: 'fixture-agent' });
+    log.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -716,12 +716,14 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
     const manifestBuffer = fileBuffer.subarray(20, manifestEnd);
     const manifest = JSON.parse(manifestBuffer.toString());
 
+    let listedComponents: IncludePath[] | undefined;
     if (manifest && typeof manifest === 'object' && 'components' in manifest) {
       const validated = validateIncludedComponents(manifest.components);
       if ('error' in validated) {
         console.error(validated.error);
         return undefined;
       }
+      listedComponents = validated.components;
       if (options.include !== undefined) {
         for (const path of INCLUDE_PATHS) {
           if (included.components[path] && !validated.components.includes(path)) {
@@ -745,6 +747,14 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
       if ('error' in validatedExcluded) {
         console.error(validatedExcluded.error);
         return undefined;
+      }
+      if (listedComponents) {
+        const listed = listedComponents;
+        const overlap = validatedExcluded.excluded.find((path) => listed.includes(path));
+        if (overlap) {
+          console.error(`Error: excluded path is listed: ${overlap}`);
+          return undefined;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

`savestate import` now rejects a container whose unencrypted `excluded` list names a path that is also in `components`.

Follow-on to #291 (import excluded schema) and #289 (verify excluded-vs-listed). Distinct from verify-only membership checks (#283, #285) and print-excluded (#287). Manifest-only membership: the two lists must be disjoint.

Closes #292

## Proof

- `npx vitest run src/commands/__tests__/import-excluded-listed.test.ts src/commands/__tests__/import-excluded-schema.test.ts src/commands/__tests__/import-components-schema.test.ts` — 8 passed
- A `components: ['memory', 'tools']` + `excluded: ['memory']` archive fails import with `excluded path is listed: memory`
- A disjoint `['memory', 'tools']` + `['personality']` pair still imports
- Legacy archives missing either field still import
- A real export with `--exclude personality` still imports

## Scope

Excluded-vs-listed membership on import only. No export, verify, adapter, or publish changes.

Plasmate: https://savestate.dev and https://savestate.dev/docs/cli.html