### PR TITLE
Reject an excluded path that is still packed on savestate import

### DIFF
--- a/src/commands/__tests__/import-excluded-packed.test.ts
+++ b/src/commands/__tests__/import-excluded-packed.test.ts
@@ -1,0 +1,131 @@
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { exportState, importState } from '../container.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate import excluded packed membership', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-import-excluded-packed-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(
+    fileName: string,
+    state: Record<string, unknown>,
+    excluded?: unknown,
+  ): Promise<string> {
+    const passphrase = 'synthetic-passphrase';
+    const plaintext = Buffer.from(JSON.stringify(state));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest: Record<string, unknown> = {
+      formatVersion: 1,
+      created: '2026-08-22T07:20:00.000Z',
+      agentId: 'fixture-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: createHash('sha256').update(plaintext).digest('hex'),
+        },
+      ],
+    };
+    if (excluded !== undefined) {
+      manifest.excluded = excluded;
+    }
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await fs.writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('rejects a container whose excluded list includes a packed path', async () => {
+    const filePath = await writeContainer(
+      'excluded-packed.savestate',
+      {
+        agentId: 'fixture-agent',
+        version: 1,
+        memory: { facts: ['synthetic'] },
+      },
+      ['memory'],
+    );
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: filePath,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    expect(result).toBeUndefined();
+    expect(error.mock.calls.flat().join('\n')).toMatch(/excluded path is packed: memory/i);
+    expect(log.mock.calls.flat().join('\n')).not.toContain('Successfully restored');
+    error.mockRestore();
+    log.mockRestore();
+  });
+
+  it('imports a matching omit list and still accepts older files without one', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const matching = await writeContainer(
+      'matching-excluded.savestate',
+      {
+        agentId: 'fixture-agent',
+        version: 1,
+        memory: { facts: ['synthetic'] },
+      },
+      ['personality'],
+    );
+    const legacy = await writeContainer('legacy.savestate', {
+      agentId: 'fixture-agent',
+      version: 1,
+      memory: { facts: ['synthetic'] },
+    });
+    const exported = join(testDir, 'exported.savestate');
+
+    const valid = await importState({
+      in: matching,
+      passphrase: 'synthetic-passphrase',
+    });
+    const older = await importState({
+      in: legacy,
+      passphrase: 'synthetic-passphrase',
+    });
+    const written = await exportState({
+      agent: 'fixture-agent',
+      out: exported,
+      passphrase: 'synthetic-passphrase',
+      exclude: 'personality',
+    });
+    const fromExport = await importState({
+      in: exported,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    expect(valid).toMatchObject({ restored: true, agentId: 'fixture-agent' });
+    expect(older).toMatchObject({ restored: true, agentId: 'fixture-agent' });
+    expect(written.written).toBe(true);
+    expect(fromExport).toMatchObject({ restored: true, agentId: 'fixture-agent' });
+    log.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -740,12 +740,14 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
       }
     }
 
+    let excludedComponents: IncludePath[] | undefined;
     if (manifest && typeof manifest === 'object' && 'excluded' in manifest) {
       const validatedExcluded = validateExcludedComponents(manifest.excluded);
       if ('error' in validatedExcluded) {
         console.error(validatedExcluded.error);
         return undefined;
       }
+      excludedComponents = validatedExcluded.excluded;
     }
 
     // 2. Decrypt and verify
@@ -774,6 +776,15 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
     
     let stateText = decryptedState.toString();
     let parsedState = JSON.parse(stateText) as Record<string, unknown>;
+    if (excludedComponents) {
+      const packedExclusion = excludedComponents.find((path) =>
+        Object.prototype.hasOwnProperty.call(parsedState, path),
+      );
+      if (packedExclusion) {
+        console.error(`Error: excluded path is packed: ${packedExclusion}`);
+        return undefined;
+      }
+    }
     const imported = applyImportInclude(parsedState, options.include);
     if ('error' in imported) {
       console.error(imported.error);


### PR DESCRIPTION
## Summary

`savestate import` now rejects a container whose unencrypted `excluded` list names a path that is still present in the decrypted payload.

Follow-on to #291 (import excluded schema) and #283 (verify excluded-packed). Distinct from import excluded-vs-listed (#292) and verify-only membership checks (#283, #285, #289). Payload membership: excluded paths must be absent from packed state.

Closes #294

## Proof

- `npx vitest run src/commands/__tests__/import-excluded-packed.test.ts src/commands/__tests__/import-excluded-schema.test.ts` — 5 passed
- A `excluded: ['memory']` archive with packed `memory` fails import with `excluded path is packed: memory`
- A matching `excluded: ['personality']` omit (path absent from packed state) still imports
- Legacy archives without `excluded` still import
- A real export with `--exclude personality` still imports

## Scope

Import excluded-vs-packed membership only. No export, verify, adapter, or publish changes.

Plasmate: https://savestate.dev and https://savestate.dev/docs/cli.html