### PR TITLE
Print excluded paths on savestate import

### DIFF
--- a/src/commands/__tests__/import-excluded-output.test.ts
+++ b/src/commands/__tests__/import-excluded-output.test.ts
@@ -1,0 +1,126 @@
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { exportState, formatImportExcluded, importState } from '../container.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate import excluded output', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-import-excluded-output-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(fileName: string, excluded?: unknown): Promise<string> {
+    const passphrase = 'synthetic-passphrase';
+    const plaintext = Buffer.from(JSON.stringify({
+      agentId: 'fixture-agent',
+      version: 1,
+      exportedAt: '2026-08-22T11:00:00.000Z',
+      memory: { facts: ['synthetic'] },
+      tools: { enabled: [] },
+    }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest: Record<string, unknown> = {
+      formatVersion: 1,
+      created: '2026-08-22T11:00:00.000Z',
+      agentId: 'fixture-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: createHash('sha256').update(plaintext).digest('hex'),
+        },
+      ],
+    };
+    if (excluded !== undefined) {
+      manifest.excluded = excluded;
+    }
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await fs.writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('formats excluded paths on their own line', () => {
+    expect(formatImportExcluded(['personality'])).toBe('  Excluded: personality');
+    expect(formatImportExcluded(['personality', 'tools'])).toBe('  Excluded: personality, tools');
+    expect(formatImportExcluded(['personality'])).not.toContain('Agent:');
+  });
+
+  it('returns and prints excluded paths when the manifest lists them', async () => {
+    const filePath = await writeContainer('with-excluded.savestate', ['personality']);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: filePath,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    expect(result).toMatchObject({
+      restored: true,
+      agentId: 'fixture-agent',
+      excluded: ['personality'],
+    });
+    expect(log.mock.calls.flat()).toContain('  Excluded: personality');
+    log.mockRestore();
+  });
+
+  it('prints excluded paths on dry-run and omits them when the archive has none', async () => {
+    const withExcluded = await writeContainer('dry-run-excluded.savestate', ['personality']);
+    const withoutExcluded = await writeContainer('no-excluded.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const preview = await importState({
+      in: withExcluded,
+      passphrase: 'synthetic-passphrase',
+      dryRun: true,
+    });
+    const older = await importState({
+      in: withoutExcluded,
+      passphrase: 'synthetic-passphrase',
+    });
+    const exported = join(testDir, 'exported.savestate');
+    await exportState({
+      agent: 'fixture-agent',
+      out: exported,
+      passphrase: 'synthetic-passphrase',
+      exclude: 'personality',
+    });
+    const fromExport = await importState({
+      in: exported,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    expect(preview).toMatchObject({
+      dryRun: true,
+      restored: false,
+      excluded: ['personality'],
+    });
+    expect(older?.excluded).toBeUndefined();
+    expect(fromExport).toMatchObject({ excluded: ['personality'] });
+    expect(log.mock.calls.flat()).toContain('  Excluded: personality');
+    expect(log.mock.calls.filter((call) => call[0] === '  Excluded: personality').length).toBeGreaterThan(1);
+    log.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -201,6 +201,10 @@ export function listExcludedPaths(raw?: string): string[] {
     .filter((part) => part.length > 0);
 }
 
+export function formatImportExcluded(excluded: readonly string[]): string {
+  return `  Excluded: ${excluded.join(', ')}`;
+}
+
 const IMPORT_METADATA_KEYS = new Set(['agentId', 'version', 'exportedAt']);
 
 export function applyImportInclude(
@@ -604,6 +608,7 @@ export interface ImportResult {
   mode: RestoreMode;
   created: string;
   components: string[];
+  excluded?: string[];
   target?: string;
 }
 
@@ -842,6 +847,7 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
       mode,
       created: manifest.created,
       components,
+      ...(excludedComponents ? { excluded: excludedComponents } : {}),
     };
 
     if (options.dryRun) {
@@ -850,6 +856,9 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
       console.log(`  Mode: ${mode}`);
       console.log(`  Original export: ${manifest.created}`);
       console.log(`  Components: ${components.join(', ') || 'none'}`);
+      if (excludedComponents && excludedComponents.length > 0) {
+        console.log(formatImportExcluded(excludedComponents));
+      }
       console.log(`  This was a dry run. No agent state was restored.`);
       return result;
     }
@@ -867,6 +876,9 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
     console.log(`\n✓ Successfully restored agent '${manifest.agentId}' from ${inFile}`);
     console.log(`  Mode: ${mode}`);
     console.log(`  Original export: ${manifest.created}`);
+    if (excludedComponents && excludedComponents.length > 0) {
+      console.log(formatImportExcluded(excludedComponents));
+    }
     if (targetPath) {
       console.log(`  Target: ${targetPath}`);
     }


### PR DESCRIPTION
## Summary
- Return and print the archive manifest `excluded` list on `savestate import` (including `--dry-run`).
- Mirrors verify output so a selective export is visible at restore time.

## Proof
- Plasmate: https://savestate.dev and https://savestate.dev/docs/cli/
- `npx vitest run src/commands/__tests__/import-excluded-output.test.ts` (3 passed)