### PR TITLE
Print key derivation on savestate import

### DIFF
--- a/src/commands/__tests__/import-kdf-output.test.ts
+++ b/src/commands/__tests__/import-kdf-output.test.ts
@@ -1,0 +1,130 @@
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { exportState, formatImportKeyDerivation, importState } from '../container.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate import key derivation output', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-import-kdf-output-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(fileName: string, encryption?: unknown): Promise<string> {
+    const passphrase = 'synthetic-passphrase';
+    const plaintext = Buffer.from(JSON.stringify({
+      agentId: 'fixture-agent',
+      version: 1,
+      exportedAt: '2026-08-22T15:00:00.000Z',
+      memory: { facts: ['synthetic'] },
+      tools: { enabled: [] },
+    }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest: Record<string, unknown> = {
+      formatVersion: 1,
+      created: '2026-08-22T15:00:00.000Z',
+      agentId: 'fixture-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: createHash('sha256').update(plaintext).digest('hex'),
+        },
+      ],
+    };
+    if (encryption !== undefined) {
+      manifest.encryption = encryption;
+    }
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await fs.writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('formats the key derivation on its own line', () => {
+    expect(formatImportKeyDerivation('Argon2id')).toBe('  Key derivation: Argon2id');
+    expect(formatImportKeyDerivation('Argon2id')).not.toContain('Agent:');
+  });
+
+  it('returns and prints the KDF when the manifest names it', async () => {
+    const filePath = await writeContainer('with-kdf.savestate', {
+      algorithm: 'AES-256-GCM',
+      keyDerivation: 'Argon2id',
+    });
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: filePath,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    expect(result).toMatchObject({
+      restored: true,
+      agentId: 'fixture-agent',
+      keyDerivation: 'Argon2id',
+    });
+    expect(log.mock.calls.flat()).toContain('  Key derivation: Argon2id');
+    log.mockRestore();
+  });
+
+  it('prints the KDF on dry-run and omits it when the archive has none', async () => {
+    const withKdf = await writeContainer('dry-run-kdf.savestate', {
+      algorithm: 'AES-256-GCM',
+      keyDerivation: 'Argon2id',
+    });
+    const withoutKdf = await writeContainer('no-kdf.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const preview = await importState({
+      in: withKdf,
+      passphrase: 'synthetic-passphrase',
+      dryRun: true,
+    });
+    const older = await importState({
+      in: withoutKdf,
+      passphrase: 'synthetic-passphrase',
+    });
+    const exported = join(testDir, 'exported.savestate');
+    await exportState({
+      agent: 'fixture-agent',
+      out: exported,
+      passphrase: 'synthetic-passphrase',
+    });
+    const fromExport = await importState({
+      in: exported,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    expect(preview).toMatchObject({
+      dryRun: true,
+      restored: false,
+      keyDerivation: 'Argon2id',
+    });
+    expect(older?.keyDerivation).toBeUndefined();
+    expect(fromExport).toMatchObject({ keyDerivation: 'Argon2id' });
+    expect(log.mock.calls.flat()).toContain('  Key derivation: Argon2id');
+    expect(log.mock.calls.filter((call) => call[0] === '  Key derivation: Argon2id').length).toBeGreaterThan(1);
+    log.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -205,6 +205,22 @@ export function formatImportExcluded(excluded: readonly string[]): string {
   return `  Excluded: ${excluded.join(', ')}`;
 }
 
+export function formatImportKeyDerivation(kdf: string): string {
+  return `  Key derivation: ${kdf}`;
+}
+
+function optionalImportKeyDerivation(value: unknown): string | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+  const named = (value as { keyDerivation?: unknown }).keyDerivation;
+  if (typeof named !== 'string') {
+    return undefined;
+  }
+  const kdf = named.trim();
+  return kdf.length > 0 ? kdf : undefined;
+}
+
 const IMPORT_METADATA_KEYS = new Set(['agentId', 'version', 'exportedAt']);
 
 export function applyImportInclude(
@@ -609,6 +625,7 @@ export interface ImportResult {
   created: string;
   components: string[];
   excluded?: string[];
+  keyDerivation?: string;
   target?: string;
 }
 
@@ -840,6 +857,7 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
       console.log(`Excluding paths: ${excludedPaths.join(', ')}`);
     }
     const components = selected.components;
+    const keyDerivation = optionalImportKeyDerivation(manifest.encryption);
     const result: ImportResult = {
       dryRun: !!options.dryRun,
       restored: !options.dryRun,
@@ -848,6 +866,7 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
       created: manifest.created,
       components,
       ...(excludedComponents ? { excluded: excludedComponents } : {}),
+      ...(keyDerivation ? { keyDerivation } : {}),
     };
 
     if (options.dryRun) {
@@ -856,6 +875,9 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
       console.log(`  Mode: ${mode}`);
       console.log(`  Original export: ${manifest.created}`);
       console.log(`  Components: ${components.join(', ') || 'none'}`);
+      if (keyDerivation) {
+        console.log(formatImportKeyDerivation(keyDerivation));
+      }
       if (excludedComponents && excludedComponents.length > 0) {
         console.log(formatImportExcluded(excludedComponents));
       }
@@ -876,6 +898,9 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
     console.log(`\n✓ Successfully restored agent '${manifest.agentId}' from ${inFile}`);
     console.log(`  Mode: ${mode}`);
     console.log(`  Original export: ${manifest.created}`);
+    if (keyDerivation) {
+      console.log(formatImportKeyDerivation(keyDerivation));
+    }
     if (excludedComponents && excludedComponents.length > 0) {
       console.log(formatImportExcluded(excludedComponents));
     }


### PR DESCRIPTION
## Summary
- Print a labeled `Key derivation:` line on `savestate import` (and dry-run) when the archive manifest names a KDF.
- Return that KDF on the import result so callers can see the same label export already records and verify already shows.

Closes #306

## Proof
- Focused: `npx vitest run src/commands/__tests__/import-kdf-output.test.ts src/commands/__tests__/import-excluded-output.test.ts src/commands/__tests__/import-dry-run.test.ts` (8 passed).
- Plasmate: https://savestate.dev and https://savestate.dev/docs/cli/