### PR TITLE
Print payload size on savestate import

### DIFF
--- a/src/commands/__tests__/import-dry-run.test.ts
+++ b/src/commands/__tests__/import-dry-run.test.ts
@@ -88,6 +88,7 @@ describe('savestate import --dry-run', () => {
       created: '2026-08-17T21:08:00.000Z',
       components: ['personality', 'memory'],
       checksum: expect.stringMatching(/^[a-f0-9]{64}$/),
+      payloadBytes: expect.any(Number),
     });
     expect(log.mock.calls.flat().join('\n')).toContain('DRY RUN');
     expect(log.mock.calls.flat().join('\n')).not.toContain('Replacing state');

--- a/src/commands/__tests__/import-exclude.test.ts
+++ b/src/commands/__tests__/import-exclude.test.ts
@@ -119,6 +119,7 @@ describe('savestate import --exclude', () => {
       created: '2026-08-21T16:00:00.000Z',
       components: ['memory', 'tools'],
       checksum: expect.stringMatching(/^[a-f0-9]{64}$/),
+      payloadBytes: expect.any(Number),
       target: writtenPath,
     });
     expect(log.mock.calls.flat()).toContain('Including paths: memory, tools');

--- a/src/commands/__tests__/import-include.test.ts
+++ b/src/commands/__tests__/import-include.test.ts
@@ -119,6 +119,7 @@ describe('savestate import --include', () => {
       created: '2026-08-21T15:00:00.000Z',
       components: ['memory'],
       checksum: expect.stringMatching(/^[a-f0-9]{64}$/),
+      payloadBytes: expect.any(Number),
       target: writtenPath,
     });
     expect(log.mock.calls.flat()).toContain('Including paths: memory');

--- a/src/commands/__tests__/import-size-output.test.ts
+++ b/src/commands/__tests__/import-size-output.test.ts
@@ -1,0 +1,116 @@
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { exportState, formatImportSize, importState } from '../container.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate import size output', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-import-size-output-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(fileName: string): Promise<{ filePath: string; payloadBytes: number }> {
+    const passphrase = 'synthetic-passphrase';
+    const plaintext = Buffer.from(JSON.stringify({
+      agentId: 'fixture-agent',
+      version: 1,
+      exportedAt: '2026-08-22T16:00:00.000Z',
+      memory: { facts: ['synthetic'] },
+      tools: { enabled: [] },
+    }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest: Record<string, unknown> = {
+      formatVersion: 1,
+      created: '2026-08-22T16:00:00.000Z',
+      agentId: 'fixture-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: createHash('sha256').update(plaintext).digest('hex'),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await fs.writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return { filePath, payloadBytes: plaintext.length };
+  }
+
+  it('formats the size on its own line', () => {
+    expect(formatImportSize(42)).toBe('  Size: 42 bytes');
+    expect(formatImportSize(42)).not.toContain('Agent:');
+  });
+
+  it('returns and prints the decrypted payload length on a successful import', async () => {
+    const { filePath, payloadBytes } = await writeContainer('with-size.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: filePath,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    expect(result).toMatchObject({
+      restored: true,
+      agentId: 'fixture-agent',
+      payloadBytes,
+    });
+    expect(log.mock.calls.flat()).toContain(`  Size: ${payloadBytes} bytes`);
+    log.mockRestore();
+  });
+
+  it('prints the size on dry-run and after a real export', async () => {
+    const packed = await writeContainer('dry-run-size.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const preview = await importState({
+      in: packed.filePath,
+      passphrase: 'synthetic-passphrase',
+      dryRun: true,
+    });
+    const exported = join(testDir, 'exported.savestate');
+    await exportState({
+      agent: 'fixture-agent',
+      out: exported,
+      passphrase: 'synthetic-passphrase',
+    });
+    const fromExport = await importState({
+      in: exported,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    expect(preview).toMatchObject({
+      dryRun: true,
+      restored: false,
+      payloadBytes: packed.payloadBytes,
+    });
+    expect(fromExport?.payloadBytes).toEqual(expect.any(Number));
+    expect(fromExport!.payloadBytes).toBeGreaterThan(0);
+    expect(log.mock.calls.flat()).toContain(`  Size: ${packed.payloadBytes} bytes`);
+    expect(log.mock.calls.filter((call) => typeof call[0] === 'string' && call[0].startsWith('  Size: ')).length).toBeGreaterThan(1);
+    log.mockRestore();
+  });
+});

--- a/src/commands/__tests__/import-target.test.ts
+++ b/src/commands/__tests__/import-target.test.ts
@@ -91,6 +91,7 @@ describe('savestate import --target', () => {
       created: '2026-08-17T23:03:00.000Z',
       components: ['personality', 'memory'],
       checksum: expect.stringMatching(/^[a-f0-9]{64}$/),
+      payloadBytes: expect.any(Number),
       target: writtenPath,
     });
     expect(await fs.readFile(writtenPath, 'utf-8')).toBe(plaintext);
@@ -117,6 +118,7 @@ describe('savestate import --target', () => {
       created: '2026-08-17T23:03:00.000Z',
       components: ['personality', 'memory'],
       checksum: expect.stringMatching(/^[a-f0-9]{64}$/),
+      payloadBytes: expect.any(Number),
     });
     await expect(fs.stat(strayDir)).rejects.toMatchObject({ code: 'ENOENT' });
     expect(log.mock.calls.flat().join('\n')).toContain('Successfully restored');

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -245,6 +245,10 @@ export function formatImportChecksum(checksum: string): string {
   return `  Checksum: ${checksum}`;
 }
 
+export function formatImportSize(payloadBytes: number): string {
+  return `  Size: ${payloadBytes} bytes`;
+}
+
 function optionalImportKeyDerivation(value: unknown): string | undefined {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return undefined;
@@ -665,6 +669,7 @@ export interface ImportResult {
   encryptionAlgorithm?: string;
   keyDerivation?: string;
   checksum?: string;
+  payloadBytes?: number;
   target?: string;
 }
 
@@ -911,6 +916,7 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
       ...(encryptionAlgorithm ? { encryptionAlgorithm } : {}),
       ...(keyDerivation ? { keyDerivation } : {}),
       checksum: calculatedHash,
+      payloadBytes: decryptedState.length,
     };
 
     if (options.dryRun) {
@@ -932,6 +938,7 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
         console.log(formatImportExcluded(excludedComponents));
       }
       console.log(formatImportChecksum(calculatedHash));
+      console.log(formatImportSize(decryptedState.length));
       console.log(`  This was a dry run. No agent state was restored.`);
       return result;
     }
@@ -963,6 +970,7 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
       console.log(formatImportExcluded(excludedComponents));
     }
     console.log(formatImportChecksum(calculatedHash));
+    console.log(formatImportSize(decryptedState.length));
     if (targetPath) {
       console.log(`  Target: ${targetPath}`);
     }


### PR DESCRIPTION
## Summary
- Print a labeled `Size:` line on `savestate import` (and dry-run) after the payload is decrypted and verified.
- Return that byte length on the import result so callers can see the same size `savestate verify` already shows.

Closes #309

## Proof
- Focused: `npx vitest run src/commands/__tests__/import-size-output.test.ts src/commands/__tests__/import-dry-run.test.ts src/commands/__tests__/import-target.test.ts src/commands/__tests__/import-include.test.ts src/commands/__tests__/import-exclude.test.ts src/commands/__tests__/import-checksum-output.test.ts` (17 passed).
- Plasmate: https://savestate.dev and https://savestate.dev/docs/cli/