### PR TITLE
Print payload content type on savestate import

### DIFF
--- a/src/commands/__tests__/import-content-type-output.test.ts
+++ b/src/commands/__tests__/import-content-type-output.test.ts
@@ -1,0 +1,118 @@
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { exportState, formatImportContentType, importState } from '../container.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate import content type output', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-import-content-type-output-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(
+    fileName: string,
+    contentType = 'application/json',
+  ): Promise<{ filePath: string; contentType: string }> {
+    const passphrase = 'synthetic-passphrase';
+    const plaintext = Buffer.from(JSON.stringify({
+      agentId: 'fixture-agent',
+      version: 1,
+      exportedAt: '2026-08-22T16:00:00.000Z',
+      memory: { facts: ['synthetic'] },
+      tools: { enabled: [] },
+    }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest: Record<string, unknown> = {
+      formatVersion: 1,
+      created: '2026-08-22T16:00:00.000Z',
+      agentId: 'fixture-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType,
+          byteLength: plaintext.length,
+          sha256: createHash('sha256').update(plaintext).digest('hex'),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await fs.writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return { filePath, contentType };
+  }
+
+  it('formats the content type on its own line', () => {
+    expect(formatImportContentType('application/json')).toBe('  Content-Type: application/json');
+    expect(formatImportContentType('application/json')).not.toContain('Agent:');
+  });
+
+  it('returns and prints the content type on a successful import', async () => {
+    const { filePath, contentType } = await writeContainer('with-content-type.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: filePath,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    expect(result).toMatchObject({
+      restored: true,
+      agentId: 'fixture-agent',
+      contentType,
+    });
+    expect(log.mock.calls.flat()).toContain(`  Content-Type: ${contentType}`);
+    log.mockRestore();
+  });
+
+  it('prints the content type on dry-run and after a real export', async () => {
+    const packed = await writeContainer('dry-run-content-type.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const preview = await importState({
+      in: packed.filePath,
+      passphrase: 'synthetic-passphrase',
+      dryRun: true,
+    });
+    const exported = join(testDir, 'exported.savestate');
+    await exportState({
+      agent: 'fixture-agent',
+      out: exported,
+      passphrase: 'synthetic-passphrase',
+    });
+    const fromExport = await importState({
+      in: exported,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    expect(preview).toMatchObject({
+      dryRun: true,
+      restored: false,
+      contentType: packed.contentType,
+    });
+    expect(fromExport?.contentType).toBe('application/json');
+    expect(log.mock.calls.flat()).toContain(`  Content-Type: ${packed.contentType}`);
+    expect(log.mock.calls.filter((call) => typeof call[0] === 'string' && call[0].startsWith('  Content-Type: ')).length).toBeGreaterThan(1);
+    log.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -245,6 +245,10 @@ export function formatImportChecksum(checksum: string): string {
   return `  Checksum: ${checksum}`;
 }
 
+export function formatImportContentType(contentType: string): string {
+  return `  Content-Type: ${contentType}`;
+}
+
 function optionalImportKeyDerivation(value: unknown): string | undefined {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return undefined;
@@ -665,6 +669,7 @@ export interface ImportResult {
   encryptionAlgorithm?: string;
   keyDerivation?: string;
   checksum?: string;
+  contentType?: string;
   target?: string;
 }
 
@@ -844,6 +849,10 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
       console.error('Error: Invalid container - no agent state found.');
       process.exit(1);
     }
+    const contentType =
+      typeof payload.contentType === 'string' && payload.contentType.trim() !== ''
+        ? payload.contentType.trim()
+        : undefined;
 
     reportContainerProgress('Verifying integrity', decryptedState.length);
     const calculatedHash = createHash('sha256').update(decryptedState).digest('hex');
@@ -911,6 +920,7 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
       ...(encryptionAlgorithm ? { encryptionAlgorithm } : {}),
       ...(keyDerivation ? { keyDerivation } : {}),
       checksum: calculatedHash,
+      ...(contentType ? { contentType } : {}),
     };
 
     if (options.dryRun) {
@@ -930,6 +940,9 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
       }
       if (excludedComponents && excludedComponents.length > 0) {
         console.log(formatImportExcluded(excludedComponents));
+      }
+      if (contentType) {
+        console.log(formatImportContentType(contentType));
       }
       console.log(formatImportChecksum(calculatedHash));
       console.log(`  This was a dry run. No agent state was restored.`);
@@ -961,6 +974,9 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
     }
     if (excludedComponents && excludedComponents.length > 0) {
       console.log(formatImportExcluded(excludedComponents));
+    }
+    if (contentType) {
+      console.log(formatImportContentType(contentType));
     }
     console.log(formatImportChecksum(calculatedHash));
     if (targetPath) {


### PR DESCRIPTION
Closes #311

## Summary
Print a labeled `Content-Type:` line on `savestate import` (and dry-run) when the payload names a type. Return `ImportResult.contentType` so callers see the same content type `savestate verify` already shows.

## Proof
Focused local test only (no full suite):

```
npx vitest run src/commands/__tests__/import-content-type-output.test.ts
```

3 tests passed.

Plasmate: https://savestate.dev and https://savestate.dev/docs/