### PR TITLE
Print format version on savestate import

### DIFF
--- a/src/commands/__tests__/import-format-version-output.test.ts
+++ b/src/commands/__tests__/import-format-version-output.test.ts
@@ -1,0 +1,118 @@
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { exportState, formatImportFormatVersion, importState } from '../container.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate import format version output', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-import-format-version-output-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(
+    fileName: string,
+    formatVersion = 1,
+  ): Promise<{ filePath: string; formatVersion: number }> {
+    const passphrase = 'synthetic-passphrase';
+    const plaintext = Buffer.from(JSON.stringify({
+      agentId: 'fixture-agent',
+      version: 1,
+      exportedAt: '2026-08-22T17:00:00.000Z',
+      memory: { facts: ['synthetic'] },
+      tools: { enabled: [] },
+    }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest: Record<string, unknown> = {
+      formatVersion,
+      created: '2026-08-22T17:00:00.000Z',
+      agentId: 'fixture-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: createHash('sha256').update(plaintext).digest('hex'),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await fs.writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return { filePath, formatVersion };
+  }
+
+  it('formats the format version on its own line', () => {
+    expect(formatImportFormatVersion(1)).toBe('  Format: v1');
+    expect(formatImportFormatVersion(1)).not.toContain('Agent:');
+  });
+
+  it('returns and prints the format version on a successful import', async () => {
+    const { filePath, formatVersion } = await writeContainer('with-format-version.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: filePath,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    expect(result).toMatchObject({
+      restored: true,
+      agentId: 'fixture-agent',
+      formatVersion,
+    });
+    expect(log.mock.calls.flat()).toContain(`  Format: v${formatVersion}`);
+    log.mockRestore();
+  });
+
+  it('prints the format version on dry-run and after a real export', async () => {
+    const packed = await writeContainer('dry-run-format-version.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const preview = await importState({
+      in: packed.filePath,
+      passphrase: 'synthetic-passphrase',
+      dryRun: true,
+    });
+    const exported = join(testDir, 'exported.savestate');
+    await exportState({
+      agent: 'fixture-agent',
+      out: exported,
+      passphrase: 'synthetic-passphrase',
+    });
+    const fromExport = await importState({
+      in: exported,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    expect(preview).toMatchObject({
+      dryRun: true,
+      restored: false,
+      formatVersion: packed.formatVersion,
+    });
+    expect(fromExport?.formatVersion).toBe(1);
+    expect(log.mock.calls.flat()).toContain(`  Format: v${packed.formatVersion}`);
+    expect(log.mock.calls.filter((call) => typeof call[0] === 'string' && call[0].startsWith('  Format: v')).length).toBeGreaterThan(1);
+    log.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -245,6 +245,10 @@ export function formatImportChecksum(checksum: string): string {
   return `  Checksum: ${checksum}`;
 }
 
+export function formatImportFormatVersion(formatVersion: number): string {
+  return `  Format: v${formatVersion}`;
+}
+
 function optionalImportKeyDerivation(value: unknown): string | undefined {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return undefined;
@@ -665,6 +669,7 @@ export interface ImportResult {
   encryptionAlgorithm?: string;
   keyDerivation?: string;
   checksum?: string;
+  formatVersion?: number;
   target?: string;
 }
 
@@ -899,6 +904,10 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
     const description = optionalImportDescription(manifest.description);
     const encryptionAlgorithm = optionalImportEncryption(manifest.encryption);
     const keyDerivation = optionalImportKeyDerivation(manifest.encryption);
+    const formatVersion =
+      typeof manifest.formatVersion === 'number' && Number.isFinite(manifest.formatVersion)
+        ? manifest.formatVersion
+        : undefined;
     const result: ImportResult = {
       dryRun: !!options.dryRun,
       restored: !options.dryRun,
@@ -911,6 +920,7 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
       ...(encryptionAlgorithm ? { encryptionAlgorithm } : {}),
       ...(keyDerivation ? { keyDerivation } : {}),
       checksum: calculatedHash,
+      ...(formatVersion !== undefined ? { formatVersion } : {}),
     };
 
     if (options.dryRun) {
@@ -918,6 +928,9 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
       console.log(`  Agent: ${manifest.agentId}`);
       console.log(`  Mode: ${mode}`);
       console.log(`  Original export: ${manifest.created}`);
+      if (formatVersion !== undefined) {
+        console.log(formatImportFormatVersion(formatVersion));
+      }
       if (description) {
         console.log(formatImportDescription(description));
       }
@@ -949,6 +962,9 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
     console.log(`\n✓ Successfully restored agent '${manifest.agentId}' from ${inFile}`);
     console.log(`  Mode: ${mode}`);
     console.log(`  Original export: ${manifest.created}`);
+    if (formatVersion !== undefined) {
+      console.log(formatImportFormatVersion(formatVersion));
+    }
     if (description) {
       console.log(formatImportDescription(description));
     }


### PR DESCRIPTION
Closes #313

## Summary
Print a labeled `Format:` line on `savestate import` (and dry-run) when the manifest names a numeric format version. Return `ImportResult.formatVersion` so callers see the same format version `savestate verify` already shows.

## Proof
Focused local test only (no full suite):

```
npx vitest run src/commands/__tests__/import-format-version-output.test.ts
```

3 tests passed.

Plasmate: https://savestate.dev and https://savestate.dev/docs/cli/