### PR TITLE
Print payload name on savestate import

### DIFF
--- a/src/commands/__tests__/import-payload-name-output.test.ts
+++ b/src/commands/__tests__/import-payload-name-output.test.ts
@@ -1,0 +1,115 @@
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { exportState, formatImportPayloadName, importState } from '../container.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate import payload name output', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-import-payload-name-output-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(fileName: string): Promise<string> {
+    const passphrase = 'synthetic-passphrase';
+    const plaintext = Buffer.from(JSON.stringify({
+      agentId: 'fixture-agent',
+      version: 1,
+      exportedAt: '2026-08-22T18:00:00.000Z',
+      memory: { facts: ['synthetic'] },
+      tools: { enabled: [] },
+    }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest: Record<string, unknown> = {
+      formatVersion: 1,
+      created: '2026-08-22T18:00:00.000Z',
+      agentId: 'fixture-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: createHash('sha256').update(plaintext).digest('hex'),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await fs.writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('formats the payload name on its own line', () => {
+    expect(formatImportPayloadName('agent_state')).toBe('  Payload: agent_state');
+    expect(formatImportPayloadName('agent_state')).not.toContain('Agent:');
+  });
+
+  it('returns and prints the payload name on a successful import', async () => {
+    const filePath = await writeContainer('with-payload-name.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: filePath,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    expect(result).toMatchObject({
+      restored: true,
+      agentId: 'fixture-agent',
+      payloadName: 'agent_state',
+    });
+    expect(log.mock.calls.flat()).toContain('  Payload: agent_state');
+    log.mockRestore();
+  });
+
+  it('prints the payload name on dry-run and after a real export', async () => {
+    const packed = await writeContainer('dry-run-payload-name.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const preview = await importState({
+      in: packed,
+      passphrase: 'synthetic-passphrase',
+      dryRun: true,
+    });
+    const exported = join(testDir, 'exported.savestate');
+    await exportState({
+      agent: 'fixture-agent',
+      out: exported,
+      passphrase: 'synthetic-passphrase',
+    });
+    const fromExport = await importState({
+      in: exported,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    expect(preview).toMatchObject({
+      dryRun: true,
+      restored: false,
+      payloadName: 'agent_state',
+    });
+    expect(fromExport).toMatchObject({ payloadName: 'agent_state' });
+    expect(log.mock.calls.flat()).toContain('  Payload: agent_state');
+    expect(log.mock.calls.filter((call) => call[0] === '  Payload: agent_state').length).toBeGreaterThan(1);
+    log.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -245,6 +245,18 @@ export function formatImportChecksum(checksum: string): string {
   return `  Checksum: ${checksum}`;
 }
 
+export function formatImportPayloadName(name: string): string {
+  return `  Payload: ${name}`;
+}
+
+function optionalImportPayloadName(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const name = value.trim();
+  return name.length > 0 ? name : undefined;
+}
+
 function optionalImportKeyDerivation(value: unknown): string | undefined {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return undefined;
@@ -665,6 +677,7 @@ export interface ImportResult {
   encryptionAlgorithm?: string;
   keyDerivation?: string;
   checksum?: string;
+  payloadName?: string;
   target?: string;
 }
 
@@ -899,6 +912,7 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
     const description = optionalImportDescription(manifest.description);
     const encryptionAlgorithm = optionalImportEncryption(manifest.encryption);
     const keyDerivation = optionalImportKeyDerivation(manifest.encryption);
+    const payloadName = optionalImportPayloadName(payload.name);
     const result: ImportResult = {
       dryRun: !!options.dryRun,
       restored: !options.dryRun,
@@ -911,6 +925,7 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
       ...(encryptionAlgorithm ? { encryptionAlgorithm } : {}),
       ...(keyDerivation ? { keyDerivation } : {}),
       checksum: calculatedHash,
+      ...(payloadName ? { payloadName } : {}),
     };
 
     if (options.dryRun) {
@@ -932,6 +947,9 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
         console.log(formatImportExcluded(excludedComponents));
       }
       console.log(formatImportChecksum(calculatedHash));
+      if (payloadName) {
+        console.log(formatImportPayloadName(payloadName));
+      }
       console.log(`  This was a dry run. No agent state was restored.`);
       return result;
     }
@@ -963,6 +981,9 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
       console.log(formatImportExcluded(excludedComponents));
     }
     console.log(formatImportChecksum(calculatedHash));
+    if (payloadName) {
+      console.log(formatImportPayloadName(payloadName));
+    }
     if (targetPath) {
       console.log(`  Target: ${targetPath}`);
     }


### PR DESCRIPTION
Closes #315

## Summary
Print a labeled `Payload:` line on `savestate import` (and dry-run) when the restored payload names itself. Return `ImportResult.payloadName` so callers see which packed payload was restored.

## Proof
Focused local test only (no full suite):

```
npx vitest run src/commands/__tests__/import-payload-name-output.test.ts
```

3 tests passed.

Plasmate: https://savestate.dev and https://savestate.dev/docs/cli/