### PR TITLE
Print payload name on savestate export

### DIFF
--- a/src/commands/__tests__/export-payload-name-output.test.ts
+++ b/src/commands/__tests__/export-payload-name-output.test.ts
@@ -1,0 +1,66 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { exportState, formatExportPayloadName } from '../container.js';
+
+function readManifest(file: Buffer): {
+  payloads?: Array<{ name?: string }>;
+} {
+  const manifestLength = file.readUInt32LE(16);
+  return JSON.parse(file.subarray(20, 20 + manifestLength).toString('utf-8'));
+}
+
+describe('savestate export payload name output', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-export-payload-name-output-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  it('formats the payload name on its own line', () => {
+    expect(formatExportPayloadName('agent_state')).toBe('  Payload: agent_state');
+    expect(formatExportPayloadName('agent_state')).not.toContain('Agent:');
+  });
+
+  it('prints the payload name after a successful export', async () => {
+    const filePath = join(testDir, 'with-payload-name.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await exportState({
+      agent: 'fixture-agent',
+      out: filePath,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    const written = await fs.readFile(filePath);
+    const manifest = readManifest(written);
+
+    expect(result).toEqual({ written: true, out: filePath, overwritten: false });
+    expect(manifest.payloads?.[0]?.name).toBe('agent_state');
+    expect(log.mock.calls.flat()).toContain('  Payload: agent_state');
+    log.mockRestore();
+  });
+
+  it('omits a payload name when export does not write', async () => {
+    const filePath = join(testDir, 'unwritten.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const result = await exportState({
+      agent: '',
+      out: filePath,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    expect(result).toEqual({ written: false, out: filePath, overwritten: false });
+    expect(log.mock.calls.flat()).not.toContain('  Payload: agent_state');
+    error.mockRestore();
+    log.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -261,6 +261,10 @@ export function formatImportPayloadName(name: string): string {
   return `  Payload: ${name}`;
 }
 
+export function formatExportPayloadName(name: string): string {
+  return `  Payload: ${name}`;
+}
+
 function optionalImportPayloadName(value: unknown): string | undefined {
   if (typeof value !== 'string') {
     return undefined;
@@ -608,6 +612,7 @@ export async function exportState(options: ExportOptions): Promise<ExportResult>
     const plaintext = Buffer.from(agentState);
 
     const trimmedDescription = description?.trim();
+    const payloadName = 'agent_state';
     const manifest = {
       formatVersion: 1,
       created: new Date().toISOString(),
@@ -628,7 +633,7 @@ export async function exportState(options: ExportOptions): Promise<ExportResult>
         : {}),
       payloads: [
         {
-          name: 'agent_state',
+          name: payloadName,
           contentType: 'application/json',
           byteLength: plaintext.length,
           sha256: createHash('sha256').update(plaintext).digest('hex'),
@@ -657,6 +662,7 @@ export async function exportState(options: ExportOptions): Promise<ExportResult>
     reportContainerProgress(`Writing ${out}`, finalBuffer.length);
     await fs.writeFile(out, finalBuffer);
     console.log(`Successfully exported agent '${agent}' to ${out}`);
+    console.log(formatExportPayloadName(payloadName));
     return { written: true, out, overwritten: existed };
   } catch (error: any) {
     console.error('Export failed:', error.message);


### PR DESCRIPTION
Closes #318

## Summary
Print a labeled `Payload:` line on `savestate export` after the archive is written. Export already packs `agent_state` by name; users can now see that payload name without inspecting the archive. Matches import (#315) and verify (#317).

## Proof
Focused local test only (no full suite):

```
npx vitest run src/commands/__tests__/export-payload-name-output.test.ts
```

3 tests passed.

Plasmate: https://savestate.dev and https://savestate.dev/docs