### PR TITLE
Print format version on savestate export

### DIFF
--- a/src/commands/__tests__/export-format-version-output.test.ts
+++ b/src/commands/__tests__/export-format-version-output.test.ts
@@ -1,0 +1,66 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { exportState, formatExportFormatVersion } from '../container.js';
+
+function readManifest(file: Buffer): {
+  formatVersion?: number;
+} {
+  const manifestLength = file.readUInt32LE(16);
+  return JSON.parse(file.subarray(20, 20 + manifestLength).toString('utf-8'));
+}
+
+describe('savestate export format version output', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-export-format-version-output-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  it('formats the format version on its own line', () => {
+    expect(formatExportFormatVersion(1)).toBe('  Format: v1');
+    expect(formatExportFormatVersion(1)).not.toContain('Agent:');
+  });
+
+  it('prints the format version after a successful export', async () => {
+    const filePath = join(testDir, 'with-format-version.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await exportState({
+      agent: 'fixture-agent',
+      out: filePath,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    const written = await fs.readFile(filePath);
+    const manifest = readManifest(written);
+
+    expect(result).toEqual({ written: true, out: filePath, overwritten: false });
+    expect(manifest.formatVersion).toBe(1);
+    expect(log.mock.calls.flat()).toContain('  Format: v1');
+    log.mockRestore();
+  });
+
+  it('omits a format version when export does not write', async () => {
+    const filePath = join(testDir, 'unwritten.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const result = await exportState({
+      agent: '',
+      out: filePath,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    expect(result).toEqual({ written: false, out: filePath, overwritten: false });
+    expect(log.mock.calls.flat()).not.toContain('  Format: v1');
+    error.mockRestore();
+    log.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -257,6 +257,10 @@ export function formatImportFormatVersion(formatVersion: number): string {
   return `  Format: v${formatVersion}`;
 }
 
+export function formatExportFormatVersion(formatVersion: number): string {
+  return `  Format: v${formatVersion}`;
+}
+
 export function formatImportPayloadName(name: string): string {
   return `  Payload: ${name}`;
 }
@@ -608,8 +612,9 @@ export async function exportState(options: ExportOptions): Promise<ExportResult>
     const plaintext = Buffer.from(agentState);
 
     const trimmedDescription = description?.trim();
+    const formatVersion = 1;
     const manifest = {
-      formatVersion: 1,
+      formatVersion,
       created: new Date().toISOString(),
       agentId: agent,
       ...(trimmedDescription ? { description: trimmedDescription } : {}),
@@ -657,6 +662,7 @@ export async function exportState(options: ExportOptions): Promise<ExportResult>
     reportContainerProgress(`Writing ${out}`, finalBuffer.length);
     await fs.writeFile(out, finalBuffer);
     console.log(`Successfully exported agent '${agent}' to ${out}`);
+    console.log(formatExportFormatVersion(formatVersion));
     return { written: true, out, overwritten: existed };
   } catch (error: any) {
     console.error('Export failed:', error.message);


### PR DESCRIPTION
Closes #320

## Summary
Print a labeled `Format:` line on `savestate export` after the archive is written. Export already writes `formatVersion` on the manifest; users can now see that version without inspecting the archive. Matches import (#313) and verify.

## Proof
Focused local test only (no full suite):

```
npx vitest run src/commands/__tests__/export-format-version-output.test.ts
```

3 tests passed.

Plasmate: https://savestate.dev and https://savestate.dev/docs