### PR TITLE
Print key derivation on savestate export

### DIFF
--- a/src/commands/__tests__/export-kdf-output.test.ts
+++ b/src/commands/__tests__/export-kdf-output.test.ts
@@ -1,0 +1,66 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { exportState, formatExportKeyDerivation } from '../container.js';
+
+function readManifest(file: Buffer): {
+  encryption?: { keyDerivation?: string };
+} {
+  const manifestLength = file.readUInt32LE(16);
+  return JSON.parse(file.subarray(20, 20 + manifestLength).toString('utf-8'));
+}
+
+describe('savestate export key derivation output', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-export-kdf-output-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  it('formats the key derivation on its own line', () => {
+    expect(formatExportKeyDerivation('Argon2id')).toBe('  Key derivation: Argon2id');
+    expect(formatExportKeyDerivation('Argon2id')).not.toContain('Agent:');
+  });
+
+  it('prints the key derivation after a successful export', async () => {
+    const filePath = join(testDir, 'with-kdf.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await exportState({
+      agent: 'fixture-agent',
+      out: filePath,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    const written = await fs.readFile(filePath);
+    const manifest = readManifest(written);
+
+    expect(result).toEqual({ written: true, out: filePath, overwritten: false });
+    expect(manifest.encryption?.keyDerivation).toBe('Argon2id');
+    expect(log.mock.calls.flat()).toContain('  Key derivation: Argon2id');
+    log.mockRestore();
+  });
+
+  it('omits key derivation when export does not write', async () => {
+    const filePath = join(testDir, 'unwritten.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const result = await exportState({
+      agent: '',
+      out: filePath,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    expect(result).toEqual({ written: false, out: filePath, overwritten: false });
+    expect(log.mock.calls.flat()).not.toContain('  Key derivation: Argon2id');
+    error.mockRestore();
+    log.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -249,6 +249,10 @@ export function formatExportChecksum(checksum: string): string {
   return `  Checksum: ${checksum}`;
 }
 
+export function formatExportKeyDerivation(kdf: string): string {
+  return `  Key derivation: ${kdf}`;
+}
+
 export function formatImportSize(payloadBytes: number): string {
   return `  Size: ${payloadBytes} bytes`;
 }
@@ -623,6 +627,7 @@ export async function exportState(options: ExportOptions): Promise<ExportResult>
     const formatVersion = 1;
     const payloadName = 'agent_state';
     const payloadChecksum = createHash('sha256').update(plaintext).digest('hex');
+    const keyDerivation = 'Argon2id';
     const manifest = {
       formatVersion,
       created: new Date().toISOString(),
@@ -630,7 +635,7 @@ export async function exportState(options: ExportOptions): Promise<ExportResult>
       ...(trimmedDescription ? { description: trimmedDescription } : {}),
       encryption: {
         algorithm: 'AES-256-GCM',
-        keyDerivation: 'Argon2id',
+        keyDerivation,
       },
       components: validatedComponents.components,
       ...(options.exclude !== undefined
@@ -675,6 +680,7 @@ export async function exportState(options: ExportOptions): Promise<ExportResult>
     console.log(formatExportFormatVersion(formatVersion));
     console.log(formatExportChecksum(payloadChecksum));
     console.log(formatExportPayloadName(payloadName));
+    console.log(formatExportKeyDerivation(keyDerivation));
     return { written: true, out, overwritten: existed };
   } catch (error: any) {
     console.error('Export failed:', error.message);


### PR DESCRIPTION
Closes #327

## Summary
Print a labeled `Key derivation:` line on `savestate export` after the archive is written. Export already writes `keyDerivation` on the encryption metadata; users can now see that KDF without inspecting the archive. Matches import (#306).

## Proof
Focused local test only (no full suite):

```
npx vitest run src/commands/__tests__/export-kdf-output.test.ts
```

3 tests passed.

Plasmate: https://savestate.dev and https://savestate.dev/docs