### PR TITLE
Print encryption algorithm on savestate export

### DIFF
--- a/src/commands/__tests__/export-encryption-output.test.ts
+++ b/src/commands/__tests__/export-encryption-output.test.ts
@@ -1,0 +1,66 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { exportState, formatExportEncryption } from '../container.js';
+
+function readManifest(file: Buffer): {
+  encryption?: { algorithm?: string };
+} {
+  const manifestLength = file.readUInt32LE(16);
+  return JSON.parse(file.subarray(20, 20 + manifestLength).toString('utf-8'));
+}
+
+describe('savestate export encryption output', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-export-encryption-output-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  it('formats the encryption algorithm on its own line', () => {
+    expect(formatExportEncryption('AES-256-GCM')).toBe('  Encryption: AES-256-GCM');
+    expect(formatExportEncryption('AES-256-GCM')).not.toContain('Agent:');
+  });
+
+  it('prints the encryption algorithm after a successful export', async () => {
+    const filePath = join(testDir, 'with-encryption.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await exportState({
+      agent: 'fixture-agent',
+      out: filePath,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    const written = await fs.readFile(filePath);
+    const manifest = readManifest(written);
+
+    expect(result).toEqual({ written: true, out: filePath, overwritten: false });
+    expect(manifest.encryption?.algorithm).toBe('AES-256-GCM');
+    expect(log.mock.calls.flat()).toContain('  Encryption: AES-256-GCM');
+    log.mockRestore();
+  });
+
+  it('omits encryption when export does not write', async () => {
+    const filePath = join(testDir, 'unwritten.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const result = await exportState({
+      agent: '',
+      out: filePath,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    expect(result).toEqual({ written: false, out: filePath, overwritten: false });
+    expect(log.mock.calls.flat()).not.toContain('  Encryption: AES-256-GCM');
+    error.mockRestore();
+    log.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -249,6 +249,10 @@ export function formatExportChecksum(checksum: string): string {
   return `  Checksum: ${checksum}`;
 }
 
+export function formatExportEncryption(algorithm: string): string {
+  return `  Encryption: ${algorithm}`;
+}
+
 export function formatImportSize(payloadBytes: number): string {
   return `  Size: ${payloadBytes} bytes`;
 }
@@ -623,13 +627,14 @@ export async function exportState(options: ExportOptions): Promise<ExportResult>
     const formatVersion = 1;
     const payloadName = 'agent_state';
     const payloadChecksum = createHash('sha256').update(plaintext).digest('hex');
+    const encryptionAlgorithm = 'AES-256-GCM';
     const manifest = {
       formatVersion,
       created: new Date().toISOString(),
       agentId: agent,
       ...(trimmedDescription ? { description: trimmedDescription } : {}),
       encryption: {
-        algorithm: 'AES-256-GCM',
+        algorithm: encryptionAlgorithm,
         keyDerivation: 'Argon2id',
       },
       components: validatedComponents.components,
@@ -675,6 +680,7 @@ export async function exportState(options: ExportOptions): Promise<ExportResult>
     console.log(formatExportFormatVersion(formatVersion));
     console.log(formatExportChecksum(payloadChecksum));
     console.log(formatExportPayloadName(payloadName));
+    console.log(formatExportEncryption(encryptionAlgorithm));
     return { written: true, out, overwritten: existed };
   } catch (error: any) {
     console.error('Export failed:', error.message);


### PR DESCRIPTION
Closes #329

## Summary
Print a labeled `Encryption:` line on `savestate export` after the archive is written. Export already writes `encryption.algorithm` on the manifest; users can now see that algorithm without inspecting the archive. Matches import (#304) and verify (#202).

## Proof
Focused local test only (no full suite):

```
npx vitest run src/commands/__tests__/export-encryption-output.test.ts src/commands/__tests__/export-encryption-metadata.test.ts src/commands/__tests__/export-checksum-output.test.ts
```

7 tests passed.

Plasmate: https://savestate.dev and https://savestate.dev/docs