### PR TITLE
Print agent id on savestate export

### DIFF
--- a/src/commands/__tests__/export-agent-output.test.ts
+++ b/src/commands/__tests__/export-agent-output.test.ts
@@ -1,0 +1,66 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { exportState, formatExportAgent } from '../container.js';
+
+function readManifest(file: Buffer): {
+  agentId?: string;
+} {
+  const manifestLength = file.readUInt32LE(16);
+  return JSON.parse(file.subarray(20, 20 + manifestLength).toString('utf-8'));
+}
+
+describe('savestate export agent output', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-export-agent-output-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  it('formats the agent id on its own line', () => {
+    expect(formatExportAgent('fixture-agent')).toBe('  Agent: fixture-agent');
+    expect(formatExportAgent('fixture-agent')).not.toContain('Source:');
+  });
+
+  it('prints the agent id after a successful export', async () => {
+    const filePath = join(testDir, 'with-agent.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await exportState({
+      agent: 'fixture-agent',
+      out: filePath,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    const written = await fs.readFile(filePath);
+    const manifest = readManifest(written);
+
+    expect(result).toEqual({ written: true, out: filePath, overwritten: false });
+    expect(manifest.agentId).toBe('fixture-agent');
+    expect(log.mock.calls.flat()).toContain('  Agent: fixture-agent');
+    log.mockRestore();
+  });
+
+  it('omits an agent id when export does not write', async () => {
+    const filePath = join(testDir, 'unwritten.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const result = await exportState({
+      agent: '',
+      out: filePath,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    expect(result).toEqual({ written: false, out: filePath, overwritten: false });
+    expect(log.mock.calls.flat().some((line) => typeof line === 'string' && line.startsWith('  Agent: '))).toBe(false);
+    error.mockRestore();
+    log.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -293,6 +293,10 @@ export function formatExportPayloadName(name: string): string {
   return `  Payload: ${name}`;
 }
 
+export function formatExportAgent(agentId: string): string {
+  return `  Agent: ${agentId}`;
+}
+
 export function formatExportComponents(components: readonly string[]): string {
   return `  Components: ${components.length > 0 ? components.join(', ') : 'none'}`;
 }
@@ -698,6 +702,7 @@ export async function exportState(options: ExportOptions): Promise<ExportResult>
     reportContainerProgress(`Writing ${out}`, finalBuffer.length);
     await fs.writeFile(out, finalBuffer);
     console.log(`Successfully exported agent '${agent}' to ${out}`);
+    console.log(formatExportAgent(agent));
     console.log(formatExportFormatVersion(formatVersion));
     console.log(formatExportChecksum(payloadChecksum));
     console.log(formatExportSize(plaintext.length));


### PR DESCRIPTION
Closes #338

## Summary
Print a labeled `Agent:` line on `savestate export` after the archive is written. Export already writes `agentId` on the manifest; users can now see that id without inspecting the archive.

## Proof
Focused local test only (no full suite):

```
npx vitest run src/commands/__tests__/export-agent-output.test.ts
```

3 tests passed.

Plasmate: https://savestate.dev and https://savestate.dev/docs and https://savestate.dev/docs/cli.html