### PR TITLE
Print agent id on savestate import

### DIFF
--- a/src/commands/__tests__/import-agent-output.test.ts
+++ b/src/commands/__tests__/import-agent-output.test.ts
@@ -1,0 +1,129 @@
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { exportState, formatImportAgent, importState } from '../container.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate import agent output', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-import-agent-output-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(fileName: string): Promise<string> {
+    const passphrase = 'synthetic-passphrase';
+    const plaintext = Buffer.from(JSON.stringify({
+      agentId: 'fixture-agent',
+      version: 1,
+      exportedAt: '2026-08-23T06:00:00.000Z',
+      memory: { facts: ['synthetic'] },
+      tools: { enabled: [] },
+    }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest: Record<string, unknown> = {
+      formatVersion: 1,
+      created: '2026-08-23T06:00:00.000Z',
+      agentId: 'fixture-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: createHash('sha256').update(plaintext).digest('hex'),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await fs.writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('formats the agent id on its own line', () => {
+    expect(formatImportAgent('fixture-agent')).toBe('  Agent: fixture-agent');
+    expect(formatImportAgent('fixture-agent')).not.toContain('Mode:');
+  });
+
+  it('returns and prints the agent id on a successful import', async () => {
+    const filePath = await writeContainer('with-agent.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: filePath,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    expect(result).toMatchObject({
+      restored: true,
+      agentId: 'fixture-agent',
+    });
+    expect(log.mock.calls.flat()).toContain('  Agent: fixture-agent');
+    log.mockRestore();
+  });
+
+  it('prints the agent id on dry-run and after a real export', async () => {
+    const packed = await writeContainer('dry-run-agent.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const preview = await importState({
+      in: packed,
+      passphrase: 'synthetic-passphrase',
+      dryRun: true,
+    });
+    const exported = join(testDir, 'exported.savestate');
+    await exportState({
+      agent: 'fixture-agent',
+      out: exported,
+      passphrase: 'synthetic-passphrase',
+    });
+    const fromExport = await importState({
+      in: exported,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    expect(preview).toMatchObject({
+      dryRun: true,
+      restored: false,
+      agentId: 'fixture-agent',
+    });
+    expect(fromExport).toMatchObject({ agentId: 'fixture-agent' });
+    expect(log.mock.calls.flat()).toContain('  Agent: fixture-agent');
+    expect(log.mock.calls.filter((call) => call[0] === '  Agent: fixture-agent').length).toBeGreaterThan(1);
+    log.mockRestore();
+  });
+
+  it('omits an agent id when import does not restore', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: '',
+      passphrase: 'synthetic-passphrase',
+    });
+
+    expect(result).toBeUndefined();
+    expect(log.mock.calls.flat().some((line) => typeof line === 'string' && line.startsWith('  Agent: '))).toBe(false);
+    error.mockRestore();
+    log.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -285,6 +285,10 @@ export function formatExportFormatVersion(formatVersion: number): string {
   return `  Format: v${formatVersion}`;
 }
 
+export function formatImportAgent(agentId: string): string {
+  return `  Agent: ${agentId}`;
+}
+
 export function formatImportPayloadName(name: string): string {
   return `  Payload: ${name}`;
 }
@@ -1010,7 +1014,7 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
 
     if (options.dryRun) {
       console.log(`\nDRY RUN — no changes will be made`);
-      console.log(`  Agent: ${manifest.agentId}`);
+      console.log(formatImportAgent(manifest.agentId));
       console.log(`  Mode: ${mode}`);
       console.log(`  Original export: ${manifest.created}`);
       if (formatVersion !== undefined) {
@@ -1052,6 +1056,7 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
     await restoreAgentState(manifest.agentId, stateText, mode);
 
     console.log(`\n✓ Successfully restored agent '${manifest.agentId}' from ${inFile}`);
+    console.log(formatImportAgent(manifest.agentId));
     console.log(`  Mode: ${mode}`);
     console.log(`  Original export: ${manifest.created}`);
     if (formatVersion !== undefined) {


### PR DESCRIPTION
Closes #340

## Summary
Print a labeled `Agent:` line on `savestate import` after a successful restore. Dry-run already showed the agent id; a real import only mentioned it in the status sentence. Users can now confirm which agent was written without parsing that line.

## Proof
Focused local test only (no full suite):

```
npx vitest run src/commands/__tests__/import-agent-output.test.ts
```

4 tests passed.

Plasmate: https://savestate.dev and https://savestate.dev/docs/cli/