### PR TITLE
Print output path on savestate export

### DIFF
--- a/src/commands/__tests__/export-output-path-output.test.ts
+++ b/src/commands/__tests__/export-output-path-output.test.ts
@@ -1,0 +1,55 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { exportState, formatExportOutput } from '../container.js';
+
+describe('savestate export output path', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-export-output-path-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  it('formats the output path on its own line', () => {
+    expect(formatExportOutput('/tmp/agent.savestate')).toBe('  Output: /tmp/agent.savestate');
+    expect(formatExportOutput('/tmp/agent.savestate')).not.toContain('Agent:');
+  });
+
+  it('prints the output path after a successful export', async () => {
+    const filePath = join(testDir, 'with-output.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await exportState({
+      agent: 'fixture-agent',
+      out: filePath,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    expect(result).toEqual({ written: true, out: filePath, overwritten: false });
+    expect(log.mock.calls.flat()).toContain(formatExportOutput(filePath));
+    log.mockRestore();
+  });
+
+  it('omits an output path when export does not write', async () => {
+    const filePath = join(testDir, 'unwritten.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const result = await exportState({
+      agent: '',
+      out: filePath,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    expect(result).toEqual({ written: false, out: filePath, overwritten: false });
+    expect(log.mock.calls.flat().some((line) => typeof line === 'string' && line.startsWith('  Output: '))).toBe(false);
+    error.mockRestore();
+    log.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -317,6 +317,10 @@ export function formatExportAgent(agentId: string): string {
   return `  Agent: ${agentId}`;
 }
 
+export function formatExportOutput(out: string): string {
+  return `  Output: ${out}`;
+}
+
 export function formatExportComponents(components: readonly string[]): string {
   return `  Components: ${components.length > 0 ? components.join(', ') : 'none'}`;
 }
@@ -740,6 +744,7 @@ export async function exportState(options: ExportOptions): Promise<ExportResult>
     if (excludedPaths.length > 0) {
       console.log(formatExportExcluded(excludedPaths));
     }
+    console.log(formatExportOutput(out));
     return { written: true, out, overwritten: existed };
   } catch (error: any) {
     console.error('Export failed:', error.message);


### PR DESCRIPTION
## Summary
Closes #347.

Print a labeled `Output:` line on `savestate export` via `formatExportOutput`, matching the other labeled export fields.

- Successful export prints `  Output: <path>`
- Failed export (empty agent) omits the line

## Proof
`npx vitest run src/commands/__tests__/export-output-path-output.test.ts`

Plasmate: https://savestate.dev and https://savestate.dev/docs/cli.html