### PR TITLE
Print input path on savestate import

### DIFF
--- a/src/commands/__tests__/import-input-output.test.ts
+++ b/src/commands/__tests__/import-input-output.test.ts
@@ -1,0 +1,128 @@
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { exportState, formatImportInput, importState } from '../container.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate import input path', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-import-input-output-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(fileName: string): Promise<string> {
+    const passphrase = 'synthetic-passphrase';
+    const plaintext = Buffer.from(JSON.stringify({
+      agentId: 'fixture-agent',
+      version: 1,
+      exportedAt: '2026-08-23T07:00:00.000Z',
+      memory: { facts: ['synthetic'] },
+      tools: { enabled: [] },
+    }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest: Record<string, unknown> = {
+      formatVersion: 1,
+      created: '2026-08-23T07:00:00.000Z',
+      agentId: 'fixture-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: createHash('sha256').update(plaintext).digest('hex'),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await fs.writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('formats the input path on its own line', () => {
+    expect(formatImportInput('/tmp/agent.savestate')).toBe('  Input: /tmp/agent.savestate');
+    expect(formatImportInput('/tmp/agent.savestate')).not.toContain('Agent:');
+  });
+
+  it('prints the input path on a successful import', async () => {
+    const filePath = await writeContainer('with-input.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: filePath,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    expect(result).toMatchObject({
+      restored: true,
+      agentId: 'fixture-agent',
+    });
+    expect(log.mock.calls.flat()).toContain(formatImportInput(filePath));
+    log.mockRestore();
+  });
+
+  it('prints the input path on dry-run and after a real export', async () => {
+    const packed = await writeContainer('dry-run-input.savestate');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const preview = await importState({
+      in: packed,
+      passphrase: 'synthetic-passphrase',
+      dryRun: true,
+    });
+    const exported = join(testDir, 'exported.savestate');
+    await exportState({
+      agent: 'fixture-agent',
+      out: exported,
+      passphrase: 'synthetic-passphrase',
+    });
+    const fromExport = await importState({
+      in: exported,
+      passphrase: 'synthetic-passphrase',
+    });
+
+    expect(preview).toMatchObject({
+      dryRun: true,
+      restored: false,
+    });
+    expect(fromExport).toMatchObject({ restored: true });
+    expect(log.mock.calls.flat()).toContain(formatImportInput(packed));
+    expect(log.mock.calls.flat()).toContain(formatImportInput(exported));
+    log.mockRestore();
+  });
+
+  it('omits an input path when import does not restore', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: '',
+      passphrase: 'synthetic-passphrase',
+    });
+
+    expect(result).toBeUndefined();
+    expect(log.mock.calls.flat().some((line) => typeof line === 'string' && line.startsWith('  Input: '))).toBe(false);
+    error.mockRestore();
+    log.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -305,6 +305,10 @@ export function formatImportMode(mode: RestoreMode): string {
   return `  Mode: ${mode}`;
 }
 
+export function formatImportInput(inFile: string): string {
+  return `  Input: ${inFile}`;
+}
+
 export function formatImportPayloadName(name: string): string {
   return `  Payload: ${name}`;
 }
@@ -1066,6 +1070,7 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
       if (payloadName) {
         console.log(formatImportPayloadName(payloadName));
       }
+      console.log(formatImportInput(inFile));
       console.log(`  This was a dry run. No agent state was restored.`);
       return result;
     }
@@ -1108,6 +1113,7 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
     if (payloadName) {
       console.log(formatImportPayloadName(payloadName));
     }
+    console.log(formatImportInput(inFile));
     if (targetPath) {
       console.log(`  Target: ${targetPath}`);
     }


### PR DESCRIPTION
## Summary
Closes #349.

Print a labeled `Input:` line on `savestate import` via `formatImportInput`, matching the other labeled restore fields.

- Successful import prints `  Input: <path>`
- Dry-run prints the same line without writing
- Failed import (empty input) omits the line

## Proof
`npx vitest run src/commands/__tests__/import-input-output.test.ts`

Plasmate: https://savestate.dev and https://savestate.dev/docs/cli.html