### PR TITLE
Print input path on savestate verify

### DIFF
--- a/src/commands/__tests__/verify-input-output.test.ts
+++ b/src/commands/__tests__/verify-input-output.test.ts
@@ -1,0 +1,76 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { formatVerifyInput, formatVerifyResult, verifyContainer } from '../verify.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate verify input path', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'savestate-verify-input-output-'));
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it('formats the input path on its own line', () => {
+    expect(formatVerifyInput('/tmp/agent.savestate')).toBe('   Input: /tmp/agent.savestate');
+    expect(formatVerifyInput('/tmp/agent.savestate')).not.toContain('Agent:');
+  });
+
+  it('returns and prints the input path after a valid checksum comparison', async () => {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'], tools: [] }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest = {
+      formatVersion: 1,
+      created: '2026-08-23T12:00:00.000Z',
+      agentId: 'demo-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: createHash('sha256').update(plaintext).digest('hex'),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, 'valid.savestate');
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(), manifestLength, manifestBuffer, encryptedState]),
+    );
+
+    const result = await verifyContainer(filePath, { passphrase });
+
+    expect(result.status).toBe('valid');
+    expect(result.input).toBe(filePath);
+    expect(formatVerifyInput(result.input!)).toBe(`   Input: ${filePath}`);
+    expect(formatVerifyResult(result, false)).toContain(`   Input: ${filePath}`);
+  });
+
+  it('omits an input line when the file is not a SaveState container', async () => {
+    const filePath = join(testDir, 'not-a-container.bin');
+    await writeFile(filePath, Buffer.from('not-a-savestate-file'));
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('invalid_format');
+    expect(result.input).toBeUndefined();
+    expect(formatVerifyResult(result, false)).not.toContain('Input:');
+  });
+});

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -20,6 +20,7 @@ export interface VerifyResult {
   payloadName?: string;
   encryptionAlgorithm?: string;
   keyDerivation?: string;
+  input?: string;
   manifest?: {
     agentId: string;
     created: string;
@@ -52,6 +53,10 @@ export function formatVerifyAgent(agentId: string): string {
 
 export function formatVerifyCreated(created: string): string {
   return `   Created: ${created}`;
+}
+
+export function formatVerifyInput(input: string): string {
+  return `   Input: ${input}`;
 }
 
 const DEFAULT_VERIFY_ENCRYPTION = 'AES-256-GCM';
@@ -761,6 +766,7 @@ export async function verifyContainer(
     },
     components,
     ...(excluded ? { excluded } : {}),
+    input: filePath,
   };
 }
 
@@ -813,6 +819,9 @@ export function formatVerifyResult(result: VerifyResult, json: boolean): string 
       }
       if (result.keyDerivation) {
         lines.push(formatVerifyKeyDerivation(result.keyDerivation));
+      }
+      if (result.input) {
+        lines.push(formatVerifyInput(result.input));
       }
       return lines.join('\n');
     }


### PR DESCRIPTION
## Summary
- Extract `formatVerifyInput` so `savestate verify` prints a labeled `Input:` line, matching import/export path fields.
- Successful verify prints `   Input: <path>`; invalid-format verify omits the line.

Closes #354.

## Proof
Focused: `npx vitest run src/commands/__tests__/verify-input-output.test.ts` — 3 passed.

Plasmate: https://savestate.dev and https://savestate.dev/docs/cli.html