### PR TITLE
Print format version on savestate verify

### DIFF
--- a/src/commands/__tests__/verify-format-version-output.test.ts
+++ b/src/commands/__tests__/verify-format-version-output.test.ts
@@ -1,0 +1,76 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { formatVerifyFormatVersion, formatVerifyResult, verifyContainer } from '../verify.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate verify format version output', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'savestate-verify-format-version-output-'));
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it('formats the format version on its own line', () => {
+    expect(formatVerifyFormatVersion(1)).toBe('   Format: v1');
+    expect(formatVerifyFormatVersion(1)).not.toContain('Agent:');
+  });
+
+  it('returns and prints the format version after a valid checksum comparison', async () => {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'], tools: [] }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest = {
+      formatVersion: 1,
+      created: '2026-08-23T12:00:00.000Z',
+      agentId: 'demo-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: createHash('sha256').update(plaintext).digest('hex'),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, 'valid.savestate');
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(), manifestLength, manifestBuffer, encryptedState]),
+    );
+
+    const result = await verifyContainer(filePath, { passphrase });
+
+    expect(result.status).toBe('valid');
+    expect(result.manifest?.formatVersion).toBe(1);
+    expect(formatVerifyFormatVersion(result.manifest!.formatVersion)).toBe('   Format: v1');
+    expect(formatVerifyResult(result, false)).toContain('   Format: v1');
+  });
+
+  it('omits a format version line when the file is not a SaveState container', async () => {
+    const filePath = join(testDir, 'not-a-container.bin');
+    await writeFile(filePath, Buffer.from('not-a-savestate-file'));
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('invalid_format');
+    expect(result.manifest).toBeUndefined();
+    expect(formatVerifyResult(result, false)).not.toContain('Format:');
+  });
+});

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -54,6 +54,10 @@ export function formatVerifyCreated(created: string): string {
   return `   Created: ${created}`;
 }
 
+export function formatVerifyFormatVersion(formatVersion: number): string {
+  return `   Format: v${formatVersion}`;
+}
+
 const DEFAULT_VERIFY_ENCRYPTION = 'AES-256-GCM';
 
 export function formatVerifyEncryption(algorithm: string): string {
@@ -785,7 +789,7 @@ export function formatVerifyResult(result: VerifyResult, json: boolean): string 
       if (result.manifest) {
         lines.push(formatVerifyAgent(result.manifest.agentId));
         lines.push(formatVerifyCreated(result.manifest.created));
-        lines.push(`   Format: v${result.manifest.formatVersion}`);
+        lines.push(formatVerifyFormatVersion(result.manifest.formatVersion));
         if (result.manifest.description) {
           lines.push(`   Description: ${result.manifest.description}`);
         }


### PR DESCRIPTION
## Summary
- Extract `formatVerifyFormatVersion` so `savestate verify` prints a labeled `Format:` line, matching import/export format fields.
- Successful verify prints `   Format: v<n>`; invalid-format verify omits the line.

Closes #356.

## Proof
Focused: `npx vitest run src/commands/__tests__/verify-format-version-output.test.ts` — 3 passed.

Plasmate: https://savestate.dev and https://savestate.dev/docs/cli.html