### PR TITLE
Print format version when the passphrase is wrong

### DIFF
--- a/src/commands/__tests__/verify-format-version-output.test.ts
+++ b/src/commands/__tests__/verify-format-version-output.test.ts
@@ -63,6 +63,39 @@ describe('savestate verify format version output', () => {
     expect(formatVerifyResult(result, false)).toContain('   Format: v1');
   });
 
+  it('prints the format version when the passphrase is wrong', async () => {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest = {
+      formatVersion: 1,
+      created: '2026-08-23T12:00:00.000Z',
+      agentId: 'demo-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: createHash('sha256').update(plaintext).digest('hex'),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, 'wrong-pass.savestate');
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(), manifestLength, manifestBuffer, encryptedState]),
+    );
+
+    const result = await verifyContainer(filePath, { passphrase: 'wrong-pass' });
+
+    expect(result.status).toBe('wrong_password');
+    expect(result.manifest?.formatVersion).toBe(1);
+    expect(formatVerifyResult(result, false)).toContain('   Format: v1');
+  });
+
   it('omits a format version line when the file is not a SaveState container', async () => {
     const filePath = join(testDir, 'not-a-container.bin');
     await writeFile(filePath, Buffer.from('not-a-savestate-file'));

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -838,6 +838,7 @@ export function formatVerifyResult(result: VerifyResult, json: boolean): string 
       if (result.manifest) {
         lines.push(formatVerifyAgent(result.manifest.agentId));
         lines.push(formatVerifyCreated(result.manifest.created));
+        lines.push(formatVerifyFormatVersion(result.manifest.formatVersion));
       }
       return lines.join('\n');
     }


### PR DESCRIPTION
## Summary
- Print `   Format: v<n>` on `savestate verify` when decryption fails, matching agent and created.
- Invalid-format verify still omits the line.

Closes #360.

## Proof
Focused: `npx vitest run src/commands/__tests__/verify-format-version-output.test.ts src/commands/__tests__/verify-created-output.test.ts src/commands/__tests__/verify-agent-output.test.ts` — 12 passed.

Plasmate: https://savestate.dev and https://savestate.dev/docs/cli.html