### PR TITLE
Print the optional manifest description when the passphrase is wrong

### DIFF
--- a/src/commands/__tests__/verify-description-output.test.ts
+++ b/src/commands/__tests__/verify-description-output.test.ts
@@ -70,6 +70,24 @@ describe('savestate verify description output', () => {
     expect(formatVerifyResult(result, false)).toContain('   Description: Labeled verify fixture');
   });
 
+  it('prints the description when the passphrase is wrong', async () => {
+    const filePath = await writeContainer('wrong-pass.savestate', 'Labeled verify fixture');
+    const result = await verifyContainer(filePath, { passphrase: 'wrong-pass' });
+
+    expect(result.status).toBe('wrong_password');
+    expect(result.manifest?.description).toBe('Labeled verify fixture');
+    expect(formatVerifyResult(result, false)).toContain('   Description: Labeled verify fixture');
+  });
+
+  it('omits a description line when the passphrase is wrong and the manifest has none', async () => {
+    const filePath = await writeContainer('wrong-pass-unlabeled.savestate');
+    const result = await verifyContainer(filePath, { passphrase: 'wrong-pass' });
+
+    expect(result.status).toBe('wrong_password');
+    expect(result.manifest?.description).toBeUndefined();
+    expect(formatVerifyResult(result, false)).not.toContain('Description:');
+  });
+
   it('omits a description line when the manifest has none or the file is invalid', async () => {
     const unlabeledPath = await writeContainer('unlabeled.savestate');
     const unlabeled = await verifyContainer(unlabeledPath, { passphrase: 'synthetic-verify-pass' });

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -687,6 +687,7 @@ export async function verifyContainer(
   try {
     decryptedState = await decrypt(encryptedState, keySource);
   } catch {
+    const description = optionalDescription(manifest.description);
     return {
       status: 'wrong_password',
       message: 'Decryption failed: incorrect passphrase or keyfile',
@@ -694,6 +695,7 @@ export async function verifyContainer(
         agentId: manifest.agentId,
         created: manifest.created,
         formatVersion: manifest.formatVersion,
+        ...(description ? { description } : {}),
       },
     };
   }
@@ -838,6 +840,9 @@ export function formatVerifyResult(result: VerifyResult, json: boolean): string 
       if (result.manifest) {
         lines.push(formatVerifyAgent(result.manifest.agentId));
         lines.push(formatVerifyCreated(result.manifest.created));
+        if (result.manifest.description) {
+          lines.push(formatVerifyDescription(result.manifest.description));
+        }
       }
       return lines.join('\n');
     }


### PR DESCRIPTION
## Summary
- Print `   Description: <text>` on `savestate verify` when decryption fails, matching agent and created.
- Omit the line when the wrong-password manifest has no description.
- Invalid-format verify still omits the line.

Closes #362.

## Proof
Focused: `npx vitest run src/commands/__tests__/verify-description-output.test.ts src/commands/__tests__/verify-created-output.test.ts src/commands/__tests__/verify-agent-output.test.ts` — 13 passed.

Plasmate: https://savestate.dev and https://savestate.dev/docs/cli.html