### PR TITLE
Print created timestamp when the file is corrupted

### DIFF
--- a/src/commands/__tests__/verify-created-output.test.ts
+++ b/src/commands/__tests__/verify-created-output.test.ts
@@ -98,6 +98,40 @@ describe('savestate verify created output', () => {
     expect(formatVerifyResult(result, false)).toContain(`   Created: ${created}`);
   });
 
+  it('prints the created timestamp when the file is corrupted', async () => {
+    const passphrase = 'synthetic-verify-pass';
+    const created = '2026-08-23T11:00:00.000Z';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest = {
+      formatVersion: 1,
+      created,
+      agentId: 'demo-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: 'a'.repeat(64),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, 'checksum-mismatch.savestate');
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(), manifestLength, manifestBuffer, encryptedState]),
+    );
+
+    const result = await verifyContainer(filePath, { passphrase });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.manifest?.created).toBe(created);
+    expect(formatVerifyResult(result, false)).toContain(`   Created: ${created}`);
+  });
+
   it('omits a created line when the file is not a SaveState container', async () => {
     const filePath = join(testDir, 'not-a-container.bin');
     await writeFile(filePath, Buffer.from('not-a-savestate-file'));

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -847,6 +847,7 @@ export function formatVerifyResult(result: VerifyResult, json: boolean): string 
       const lines = [`❌ File corrupted: ${result.message}`];
       if (result.manifest) {
         lines.push(formatVerifyAgent(result.manifest.agentId));
+        lines.push(formatVerifyCreated(result.manifest.created));
       }
       return lines.join('\n');
     }


### PR DESCRIPTION
## Summary
- Print `   Created: <timestamp>` on `savestate verify` when the file is corrupted, matching agent.
- Invalid-format verify still omits the line.

Closes #366.

## Proof
Focused: `npx vitest run src/commands/__tests__/verify-created-output.test.ts src/commands/__tests__/verify-agent-output.test.ts src/commands/__tests__/verify-input-output.test.ts` — 12 passed.

Plasmate: https://savestate.dev and https://savestate.dev/docs/cli.html