### PR TITLE
Print the optional manifest description when the file is corrupted

### DIFF
--- a/src/commands/__tests__/verify-description-output.test.ts
+++ b/src/commands/__tests__/verify-description-output.test.ts
@@ -79,6 +79,73 @@ describe('savestate verify description output', () => {
     expect(formatVerifyResult(result, false)).toContain('   Description: Labeled verify fixture');
   });
 
+  it('prints the description when the file is corrupted', async () => {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest = {
+      formatVersion: 1,
+      created: '2026-08-23T14:00:00.000Z',
+      agentId: 'demo-agent',
+      description: 'Labeled verify fixture',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: 'a'.repeat(64),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, 'checksum-mismatch.savestate');
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(), manifestLength, manifestBuffer, encryptedState]),
+    );
+
+    const result = await verifyContainer(filePath, { passphrase });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.manifest?.description).toBe('Labeled verify fixture');
+    expect(formatVerifyResult(result, false)).toContain('   Description: Labeled verify fixture');
+  });
+
+  it('omits a description line when the file is corrupted and the manifest has none', async () => {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest = {
+      formatVersion: 1,
+      created: '2026-08-23T14:00:00.000Z',
+      agentId: 'demo-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: 'a'.repeat(64),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, 'checksum-mismatch-unlabeled.savestate');
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(), manifestLength, manifestBuffer, encryptedState]),
+    );
+
+    const result = await verifyContainer(filePath, { passphrase });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.manifest?.description).toBeUndefined();
+    expect(formatVerifyResult(result, false)).not.toContain('Description:');
+  });
+
   it('omits a description line when the passphrase is wrong and the manifest has none', async () => {
     const filePath = await writeContainer('wrong-pass-unlabeled.savestate');
     const result = await verifyContainer(filePath, { passphrase: 'wrong-pass' });

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -704,6 +704,7 @@ export async function verifyContainer(
   // 5. Verify checksum
   const calculatedHash = createHash('sha256').update(decryptedState).digest('hex');
   if (calculatedHash !== payload.sha256) {
+    const description = optionalDescription(manifest.description);
     return {
       status: 'corrupted',
       message: 'Integrity check failed: checksum mismatch (file may be corrupted or tampered)',
@@ -711,6 +712,7 @@ export async function verifyContainer(
         agentId: manifest.agentId,
         created: manifest.created,
         formatVersion: manifest.formatVersion,
+        ...(description ? { description } : {}),
       },
     };
   }
@@ -720,6 +722,7 @@ export async function verifyContainer(
   try {
     components = listStateComponents(JSON.parse(decryptedState.toString()));
   } catch {
+    const description = optionalDescription(manifest.description);
     return {
       status: 'corrupted',
       message: 'Decrypted payload is not valid JSON',
@@ -727,6 +730,7 @@ export async function verifyContainer(
         agentId: manifest.agentId,
         created: manifest.created,
         formatVersion: manifest.formatVersion,
+        ...(description ? { description } : {}),
       },
     };
   }
@@ -859,6 +863,9 @@ export function formatVerifyResult(result: VerifyResult, json: boolean): string 
         lines.push(formatVerifyAgent(result.manifest.agentId));
         lines.push(formatVerifyCreated(result.manifest.created));
         lines.push(formatVerifyFormatVersion(result.manifest.formatVersion));
+        if (result.manifest.description) {
+          lines.push(formatVerifyDescription(result.manifest.description));
+        }
       }
       return lines.join('\n');
     }


### PR DESCRIPTION
## Summary
- `savestate verify` now prints the optional manifest description when checksum mismatch or invalid JSON marks the file corrupted.
- Matches the existing valid and wrong-passphrase description lines so users can still identify the snapshot.

## Proof
- Focused: `npx vitest run src/commands/__tests__/verify-description-output.test.ts src/commands/__tests__/verify-created-output.test.ts src/commands/__tests__/verify-format-version-output.test.ts`
- 17 passed.

Plasmate: https://savestate.dev and https://savestate.dev/docs/cli.html