### PR TITLE
Print encryption algorithm when the file is corrupted

### DIFF
--- a/src/commands/__tests__/verify-encryption.test.ts
+++ b/src/commands/__tests__/verify-encryption.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { encrypt } from '../../container/crypto.js';
-import { formatVerifyEncryption, verifyContainer } from '../verify.js';
+import { formatVerifyEncryption, formatVerifyResult, verifyContainer } from '../verify.js';
 
 function createMagicHeader(version = 1): Buffer {
   const header = Buffer.alloc(16);
@@ -127,6 +127,54 @@ describe('savestate verify encryption algorithm', () => {
 
     expect(result.status).toBe('wrong_password');
     expect(result.encryptionAlgorithm).toBeUndefined();
+  });
+
+  it('prints the encryption algorithm when the file is corrupted', async () => {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest = {
+      formatVersion: 1,
+      created: '2026-08-18T09:00:00.000Z',
+      agentId: 'demo-agent',
+      encryption: {
+        algorithm: 'AES-256-GCM',
+        keyDerivation: 'Argon2id',
+      },
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: 'a'.repeat(64),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, 'checksum-mismatch.savestate');
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(), manifestLength, manifestBuffer, encryptedState]),
+    );
+
+    const result = await verifyContainer(filePath, { passphrase });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.encryptionAlgorithm).toBe('AES-256-GCM');
+    expect(formatVerifyResult(result, false)).toContain('   Encryption: AES-256-GCM');
+  });
+
+  it('omits an encryption line when the file is not a SaveState container', async () => {
+    const filePath = join(testDir, 'not-a-container.bin');
+    await writeFile(filePath, Buffer.from('not-a-savestate-file'));
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('invalid_format');
+    expect(result.encryptionAlgorithm).toBeUndefined();
+    expect(formatVerifyResult(result, false)).not.toContain('Encryption:');
   });
 
   it('prints an Encryption line for a known algorithm', () => {

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -712,6 +712,7 @@ export async function verifyContainer(
         created: manifest.created,
         formatVersion: manifest.formatVersion,
       },
+      encryptionAlgorithm: resolveEncryptionAlgorithm(manifest),
     };
   }
 
@@ -728,6 +729,7 @@ export async function verifyContainer(
         created: manifest.created,
         formatVersion: manifest.formatVersion,
       },
+      encryptionAlgorithm: resolveEncryptionAlgorithm(manifest),
     };
   }
 
@@ -859,6 +861,9 @@ export function formatVerifyResult(result: VerifyResult, json: boolean): string 
         lines.push(formatVerifyAgent(result.manifest.agentId));
         lines.push(formatVerifyCreated(result.manifest.created));
         lines.push(formatVerifyFormatVersion(result.manifest.formatVersion));
+      }
+      if (result.encryptionAlgorithm) {
+        lines.push(formatVerifyEncryption(result.encryptionAlgorithm));
       }
       return lines.join('\n');
     }


### PR DESCRIPTION
## Summary
- `savestate verify` now prints `   Encryption: AES-256-GCM` when checksum mismatch or invalid JSON marks the file corrupted.
- Invalid-format verify still omits the line. Wrong-password verify is unchanged.

Closes #373.

## Proof
Focused: `npx vitest run src/commands/__tests__/verify-encryption.test.ts src/commands/__tests__/verify-created-output.test.ts src/commands/__tests__/verify-format-version-output.test.ts src/commands/__tests__/verify-agent-output.test.ts` — 20 passed.

Plasmate: https://savestate.dev and https://savestate.dev/docs/cli.html