### PR TITLE
Print payload size when the file is corrupted

### DIFF
--- a/src/commands/__tests__/verify-size.test.ts
+++ b/src/commands/__tests__/verify-size.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { encrypt } from '../../container/crypto.js';
-import { formatVerifySize, verifyContainer } from '../verify.js';
+import { formatVerifySize, formatVerifyResult, verifyContainer } from '../verify.js';
 
 function createMagicHeader(version = 1): Buffer {
   const header = Buffer.alloc(16);
@@ -87,6 +87,51 @@ describe('savestate verify size', () => {
 
     expect(result.status).toBe('wrong_password');
     expect(result.payloadBytes).toBeUndefined();
+    expect(formatVerifyResult(result, false)).not.toContain('Size:');
+  });
+
+  it('prints the payload size when the file is corrupted', async () => {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest = {
+      formatVersion: 1,
+      created: '2026-08-24T00:00:00.000Z',
+      agentId: 'demo-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: 'a'.repeat(64),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, 'checksum-mismatch.savestate');
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(), manifestLength, manifestBuffer, encryptedState]),
+    );
+
+    const result = await verifyContainer(filePath, { passphrase });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.payloadBytes).toBe(plaintext.length);
+    expect(formatVerifyResult(result, false)).toContain(`   Size: ${plaintext.length} bytes`);
+  });
+
+  it('omits a size line when the file is not a SaveState container', async () => {
+    const filePath = join(testDir, 'not-a-container.bin');
+    await writeFile(filePath, Buffer.from('not-a-savestate-file'));
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('invalid_format');
+    expect(result.payloadBytes).toBeUndefined();
+    expect(formatVerifyResult(result, false)).not.toContain('Size:');
   });
 
   it('prints a Size line for a known byte count', () => {

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -719,6 +719,7 @@ export async function verifyContainer(
       keyDerivation: resolveKeyDerivation(manifest),
       payloadName: typeof payload.name === 'string' && payload.name.trim() !== '' ? payload.name.trim() : undefined,
       contentType: typeof payload.contentType === 'string' ? payload.contentType : undefined,
+      payloadBytes: decryptedState.length,
     };
   }
 
@@ -742,6 +743,7 @@ export async function verifyContainer(
       keyDerivation: resolveKeyDerivation(manifest),
       payloadName: typeof payload.name === 'string' && payload.name.trim() !== '' ? payload.name.trim() : undefined,
       contentType: typeof payload.contentType === 'string' ? payload.contentType : undefined,
+      payloadBytes: decryptedState.length,
     };
   }
 
@@ -891,6 +893,9 @@ export function formatVerifyResult(result: VerifyResult, json: boolean): string 
       }
       if (result.contentType) {
         lines.push(formatVerifyContentType(result.contentType));
+      }
+      if (result.payloadBytes !== undefined) {
+        lines.push(formatVerifySize(result.payloadBytes));
       }
       return lines.join('\n');
     }


### PR DESCRIPTION
## Summary
- `savestate verify` now prints `   Size: <n> bytes` when checksum mismatch or invalid JSON marks the file corrupted.
- Invalid-format verify still omits the line. Wrong-password verify is unchanged.

Closes #380.

## Proof
Focused: `npx vitest run src/commands/__tests__/verify-size.test.ts` — 5 passed.

Plasmate: https://savestate.dev and https://savestate.dev/docs/