### PR TITLE
Print payload checksum when the file is corrupted

### DIFF
--- a/src/commands/__tests__/verify-checksum.test.ts
+++ b/src/commands/__tests__/verify-checksum.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { encrypt } from '../../container/crypto.js';
-import { formatVerifyChecksum, verifyContainer } from '../verify.js';
+import { formatVerifyChecksum, formatVerifyResult, verifyContainer } from '../verify.js';
 
 function createMagicHeader(version = 1): Buffer {
   const header = Buffer.alloc(16);
@@ -88,6 +88,52 @@ describe('savestate verify checksum', () => {
 
     expect(result.status).toBe('wrong_password');
     expect(result.checksum).toBeUndefined();
+    expect(formatVerifyResult(result, false)).not.toContain('Checksum:');
+  });
+
+  it('prints the payload checksum when the file is corrupted', async () => {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
+    const expected = createHash('sha256').update(plaintext).digest('hex');
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest = {
+      formatVersion: 1,
+      created: '2026-08-24T01:00:00.000Z',
+      agentId: 'demo-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: 'a'.repeat(64),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, 'checksum-mismatch.savestate');
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(), manifestLength, manifestBuffer, encryptedState]),
+    );
+
+    const result = await verifyContainer(filePath, { passphrase });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.checksum).toBe(expected);
+    expect(formatVerifyResult(result, false)).toContain(`   Checksum: ${expected}`);
+  });
+
+  it('omits a checksum line when the file is not a SaveState container', async () => {
+    const filePath = join(testDir, 'not-a-container.bin');
+    await writeFile(filePath, Buffer.from('not-a-savestate-file'));
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('invalid_format');
+    expect(result.checksum).toBeUndefined();
+    expect(formatVerifyResult(result, false)).not.toContain('Checksum:');
   });
 
   it('prints a Checksum line for a known hash', () => {

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -720,6 +720,7 @@ export async function verifyContainer(
       payloadName: typeof payload.name === 'string' && payload.name.trim() !== '' ? payload.name.trim() : undefined,
       contentType: typeof payload.contentType === 'string' ? payload.contentType : undefined,
       payloadBytes: decryptedState.length,
+      checksum: calculatedHash,
     };
   }
 
@@ -744,6 +745,7 @@ export async function verifyContainer(
       payloadName: typeof payload.name === 'string' && payload.name.trim() !== '' ? payload.name.trim() : undefined,
       contentType: typeof payload.contentType === 'string' ? payload.contentType : undefined,
       payloadBytes: decryptedState.length,
+      checksum: calculatedHash,
     };
   }
 
@@ -896,6 +898,9 @@ export function formatVerifyResult(result: VerifyResult, json: boolean): string 
       }
       if (result.payloadBytes !== undefined) {
         lines.push(formatVerifySize(result.payloadBytes));
+      }
+      if (result.checksum) {
+        lines.push(formatVerifyChecksum(result.checksum));
       }
       return lines.join('\n');
     }


### PR DESCRIPTION
## Summary
- `savestate verify` now prints `   Checksum: <sha256>` when checksum mismatch or invalid JSON marks the file corrupted.
- Invalid-format verify still omits the line. Wrong-password verify is unchanged.

Closes #382.

## Proof
Focused: `npx vitest run src/commands/__tests__/verify-checksum.test.ts` — 5 passed.

Plasmate: https://savestate.dev and https://savestate.dev/docs/