### PR TITLE
Print encryption algorithm when the passphrase is wrong

### DIFF
--- a/src/commands/__tests__/verify-encryption.test.ts
+++ b/src/commands/__tests__/verify-encryption.test.ts
@@ -93,7 +93,7 @@ describe('savestate verify encryption algorithm', () => {
     expect(result.encryptionAlgorithm).toBe('AES-256-GCM');
   });
 
-  it('omits an encryption algorithm when the passphrase is wrong', async () => {
+  it('prints the encryption algorithm when the passphrase is wrong', async () => {
     const passphrase = 'synthetic-verify-pass';
     const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
     const encryptedState = await encrypt(plaintext, { passphrase });
@@ -126,7 +126,8 @@ describe('savestate verify encryption algorithm', () => {
     const result = await verifyContainer(filePath, { passphrase: 'wrong-pass' });
 
     expect(result.status).toBe('wrong_password');
-    expect(result.encryptionAlgorithm).toBeUndefined();
+    expect(result.encryptionAlgorithm).toBe('AES-256-GCM');
+    expect(formatVerifyResult(result, false)).toContain('   Encryption: AES-256-GCM');
   });
 
   it('prints the encryption algorithm when the file is corrupted', async () => {

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -698,6 +698,7 @@ export async function verifyContainer(
         ...(description ? { description } : {}),
       },
       input: filePath,
+      encryptionAlgorithm: resolveEncryptionAlgorithm(manifest),
     };
   }
 
@@ -866,6 +867,9 @@ export function formatVerifyResult(result: VerifyResult, json: boolean): string 
       }
       if (result.input) {
         lines.push(formatVerifyInput(result.input));
+      }
+      if (result.encryptionAlgorithm) {
+        lines.push(formatVerifyEncryption(result.encryptionAlgorithm));
       }
       return lines.join('\n');
     }


### PR DESCRIPTION
## Summary
- `savestate verify` now prints `   Encryption: AES-256-GCM` (or the manifest algorithm) when the passphrase is wrong.
- Invalid-format verify still omits the line. Corrupted and valid verify are unchanged.

Closes #384.

## Proof
Focused: `npx vitest run src/commands/__tests__/verify-encryption.test.ts src/commands/__tests__/verify-input-output.test.ts src/commands/__tests__/verify-kdf.test.ts` — 17 passed.

Plasmate: https://savestate.dev and https://savestate.dev/docs/