### PR TITLE
Print payload name when the passphrase is wrong

### DIFF
--- a/src/commands/__tests__/verify-payload-name-output.test.ts
+++ b/src/commands/__tests__/verify-payload-name-output.test.ts
@@ -58,7 +58,7 @@ describe('savestate verify payload name output', () => {
     expect(formatVerifyResult(result, false)).toContain('   Payload: agent_state');
   });
 
-  it('omits a payload name when the passphrase is wrong', async () => {
+  it('prints the payload name when the passphrase is wrong', async () => {
     const passphrase = 'synthetic-verify-pass';
     const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
     const encryptedState = await encrypt(plaintext, { passphrase });
@@ -87,8 +87,8 @@ describe('savestate verify payload name output', () => {
     const result = await verifyContainer(filePath, { passphrase: 'wrong-pass' });
 
     expect(result.status).toBe('wrong_password');
-    expect(result.payloadName).toBeUndefined();
-    expect(formatVerifyResult(result, false)).not.toContain('Payload:');
+    expect(result.payloadName).toBe('agent_state');
+    expect(formatVerifyResult(result, false)).toContain('   Payload: agent_state');
   });
 
   it('prints the payload name when the file is corrupted', async () => {

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -700,6 +700,7 @@ export async function verifyContainer(
       input: filePath,
       encryptionAlgorithm: resolveEncryptionAlgorithm(manifest),
       keyDerivation: resolveKeyDerivation(manifest),
+      payloadName: typeof payload.name === 'string' && payload.name.trim() !== '' ? payload.name.trim() : undefined,
     };
   }
 
@@ -874,6 +875,9 @@ export function formatVerifyResult(result: VerifyResult, json: boolean): string 
       }
       if (result.keyDerivation) {
         lines.push(formatVerifyKeyDerivation(result.keyDerivation));
+      }
+      if (result.payloadName) {
+        lines.push(formatVerifyPayloadName(result.payloadName));
       }
       return lines.join('\n');
     }


### PR DESCRIPTION
## Summary

`savestate verify` already prints `Payload:` on valid and corrupted files. A wrong passphrase omitted the name even though it lives in the unencrypted manifest.

This returns `payloadName` on `wrong_password` and prints `   Payload: <name>` next to the other readable header fields.

Closes #387.

## Proof

Focused local vitest (15 passed):

- `src/commands/__tests__/verify-payload-name-output.test.ts`
- `src/commands/__tests__/verify-kdf.test.ts`
- `src/commands/__tests__/verify-agent-output.test.ts`

Plasmate: https://savestate.dev and https://savestate.dev/docs/cli.html