### PR TITLE
Print payload content type when the passphrase is wrong

### DIFF
--- a/src/commands/__tests__/verify-content-type.test.ts
+++ b/src/commands/__tests__/verify-content-type.test.ts
@@ -57,7 +57,7 @@ describe('savestate verify content type', () => {
     expect(formatVerifyContentType(result.contentType!)).toBe('   Content-Type: application/json');
   });
 
-  it('omits a content type when the passphrase is wrong', async () => {
+  it('prints the payload content type when the passphrase is wrong', async () => {
     const passphrase = 'synthetic-verify-pass';
     const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
     const encryptedState = await encrypt(plaintext, { passphrase });
@@ -86,8 +86,8 @@ describe('savestate verify content type', () => {
     const result = await verifyContainer(filePath, { passphrase: 'wrong-pass' });
 
     expect(result.status).toBe('wrong_password');
-    expect(result.contentType).toBeUndefined();
-    expect(formatVerifyResult(result, false)).not.toContain('Content-Type:');
+    expect(result.contentType).toBe('application/json');
+    expect(formatVerifyResult(result, false)).toContain('   Content-Type: application/json');
   });
 
   it('prints the payload content type when the file is corrupted', async () => {

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -700,6 +700,7 @@ export async function verifyContainer(
       input: filePath,
       encryptionAlgorithm: resolveEncryptionAlgorithm(manifest),
       keyDerivation: resolveKeyDerivation(manifest),
+      contentType: typeof payload.contentType === 'string' ? payload.contentType : undefined,
     };
   }
 
@@ -874,6 +875,9 @@ export function formatVerifyResult(result: VerifyResult, json: boolean): string 
       }
       if (result.keyDerivation) {
         lines.push(formatVerifyKeyDerivation(result.keyDerivation));
+      }
+      if (result.contentType) {
+        lines.push(formatVerifyContentType(result.contentType));
       }
       return lines.join('\n');
     }


### PR DESCRIPTION
## Summary
- `savestate verify` now prints `   Content-Type: application/json` (or the manifest content type) when the passphrase is wrong.
- Invalid-format verify still omits the line. Corrupted and valid verify are unchanged.

Closes #389.

## Proof
Focused: `npx vitest run src/commands/__tests__/verify-content-type.test.ts src/commands/__tests__/verify-encryption.test.ts src/commands/__tests__/verify-kdf.test.ts` — 17 passed.

Plasmate: https://savestate.dev and https://savestate.dev/docs/