### PR TITLE
Print payload size when the passphrase is wrong

### DIFF
--- a/src/commands/__tests__/verify-size.test.ts
+++ b/src/commands/__tests__/verify-size.test.ts
@@ -57,7 +57,7 @@ describe('savestate verify size', () => {
     expect(formatVerifySize(result.payloadBytes!)).toBe(`   Size: ${plaintext.length} bytes`);
   });
 
-  it('omits a size when the passphrase is wrong', async () => {
+  it('prints the payload size when the passphrase is wrong', async () => {
     const passphrase = 'synthetic-verify-pass';
     const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
     const encryptedState = await encrypt(plaintext, { passphrase });
@@ -86,8 +86,8 @@ describe('savestate verify size', () => {
     const result = await verifyContainer(filePath, { passphrase: 'wrong-pass' });
 
     expect(result.status).toBe('wrong_password');
-    expect(result.payloadBytes).toBeUndefined();
-    expect(formatVerifyResult(result, false)).not.toContain('Size:');
+    expect(result.payloadBytes).toBe(plaintext.length);
+    expect(formatVerifyResult(result, false)).toContain(`   Size: ${plaintext.length} bytes`);
   });
 
   it('prints the payload size when the file is corrupted', async () => {

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -700,6 +700,7 @@ export async function verifyContainer(
       input: filePath,
       encryptionAlgorithm: resolveEncryptionAlgorithm(manifest),
       keyDerivation: resolveKeyDerivation(manifest),
+      payloadBytes: typeof payload.byteLength === 'number' ? payload.byteLength : undefined,
     };
   }
 
@@ -874,6 +875,9 @@ export function formatVerifyResult(result: VerifyResult, json: boolean): string 
       }
       if (result.keyDerivation) {
         lines.push(formatVerifyKeyDerivation(result.keyDerivation));
+      }
+      if (result.payloadBytes !== undefined) {
+        lines.push(formatVerifySize(result.payloadBytes));
       }
       return lines.join('\n');
     }


### PR DESCRIPTION
## Summary
- `savestate verify` now prints `   Size: <n> bytes` (or the manifest byteLength) when the passphrase is wrong.
- Invalid-format verify still omits the line. Corrupted and valid verify are unchanged.

Closes #391.

## Proof
Focused: `npx vitest run src/commands/__tests__/verify-size.test.ts src/commands/__tests__/verify-encryption.test.ts src/commands/__tests__/verify-kdf.test.ts` — 17 passed.

Plasmate: https://savestate.dev and https://savestate.dev/docs/