### PR TITLE
Print payload checksum when the passphrase is wrong

### DIFF
--- a/src/commands/__tests__/verify-checksum.test.ts
+++ b/src/commands/__tests__/verify-checksum.test.ts
@@ -58,9 +58,10 @@ describe('savestate verify checksum', () => {
     expect(formatVerifyChecksum(result.checksum!)).toBe(`   Checksum: ${expected}`);
   });
 
-  it('omits a checksum when the passphrase is wrong', async () => {
+  it('prints the payload checksum when the passphrase is wrong', async () => {
     const passphrase = 'synthetic-verify-pass';
     const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'] }));
+    const expected = createHash('sha256').update(plaintext).digest('hex');
     const encryptedState = await encrypt(plaintext, { passphrase });
     const manifest = {
       formatVersion: 1,
@@ -71,7 +72,7 @@ describe('savestate verify checksum', () => {
           name: 'agent_state',
           contentType: 'application/json',
           byteLength: plaintext.length,
-          sha256: createHash('sha256').update(plaintext).digest('hex'),
+          sha256: expected,
         },
       ],
     };
@@ -87,8 +88,8 @@ describe('savestate verify checksum', () => {
     const result = await verifyContainer(filePath, { passphrase: 'wrong-pass' });
 
     expect(result.status).toBe('wrong_password');
-    expect(result.checksum).toBeUndefined();
-    expect(formatVerifyResult(result, false)).not.toContain('Checksum:');
+    expect(result.checksum).toBe(expected);
+    expect(formatVerifyResult(result, false)).toContain(`   Checksum: ${expected}`);
   });
 
   it('prints the payload checksum when the file is corrupted', async () => {

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -700,6 +700,7 @@ export async function verifyContainer(
       input: filePath,
       encryptionAlgorithm: resolveEncryptionAlgorithm(manifest),
       keyDerivation: resolveKeyDerivation(manifest),
+      checksum: typeof payload.sha256 === 'string' && payload.sha256.trim() !== '' ? payload.sha256 : undefined,
     };
   }
 
@@ -874,6 +875,9 @@ export function formatVerifyResult(result: VerifyResult, json: boolean): string 
       }
       if (result.keyDerivation) {
         lines.push(formatVerifyKeyDerivation(result.keyDerivation));
+      }
+      if (result.checksum) {
+        lines.push(formatVerifyChecksum(result.checksum));
       }
       return lines.join('\n');
     }


### PR DESCRIPTION
## Summary
- `savestate verify` now prints `   Checksum: <sha256>` (or the manifest checksum) when the passphrase is wrong.
- Invalid-format verify still omits the line. Corrupted and valid verify are unchanged.

Closes #393.

## Proof
Focused: `npx vitest run src/commands/__tests__/verify-checksum.test.ts src/commands/__tests__/verify-input-output.test.ts src/commands/__tests__/verify-kdf.test.ts` — 16 passed.

Plasmate: https://savestate.dev and https://savestate.dev/docs/