### PR TITLE
Print included components when the file is corrupted

### DIFF
--- a/src/commands/__tests__/verify-components-output.test.ts
+++ b/src/commands/__tests__/verify-components-output.test.ts
@@ -1,0 +1,109 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { formatVerifyComponents, formatVerifyResult, verifyContainer } from '../verify.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate verify components output', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'savestate-verify-components-output-'));
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it('formats packed components on their own line', () => {
+    expect(formatVerifyComponents(['memory'])).toBe('   Components: memory');
+    expect(formatVerifyComponents(['memory', 'tools'])).toBe('   Components: memory, tools');
+    expect(formatVerifyComponents(['memory'])).not.toContain('Agent:');
+  });
+
+  it('prints included components when the file is corrupted', async () => {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'], tools: { enabled: [] } }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest = {
+      formatVersion: 1,
+      created: '2026-08-24T08:00:00.000Z',
+      agentId: 'demo-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: 'a'.repeat(64),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, 'corrupted-components.savestate');
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(), manifestLength, manifestBuffer, encryptedState]),
+    );
+
+    const result = await verifyContainer(filePath, { passphrase });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.components).toEqual(['memory', 'tools']);
+    expect(formatVerifyResult(result, false)).toContain('   Components: memory, tools');
+  });
+
+  it('omits components when the file is corrupted and the payload is not JSON', async () => {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from('not-json');
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest = {
+      formatVersion: 1,
+      created: '2026-08-24T08:00:00.000Z',
+      agentId: 'demo-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: 'a'.repeat(64),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, 'corrupted-invalid-json.savestate');
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(), manifestLength, manifestBuffer, encryptedState]),
+    );
+
+    const result = await verifyContainer(filePath, { passphrase });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.components).toBeUndefined();
+    expect(formatVerifyResult(result, false)).not.toContain('Components:');
+  });
+
+  it('omits a components line when the file is not a SaveState container', async () => {
+    const filePath = join(testDir, 'not-a-container.bin');
+    await writeFile(filePath, Buffer.from('not-a-savestate-file'));
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('invalid_format');
+    expect(result.components).toBeUndefined();
+    expect(formatVerifyResult(result, false)).not.toContain('Components:');
+  });
+});

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -91,6 +91,10 @@ export function formatVerifyExcluded(excluded: readonly string[]): string {
   return `   Excluded: ${excluded.join(', ')}`;
 }
 
+export function formatVerifyComponents(components: readonly string[]): string {
+  return `   Components: ${components.join(', ')}`;
+}
+
 function resolveKeyDerivation(manifest: { encryption?: { keyDerivation?: unknown } }): string {
   const named = manifest.encryption?.keyDerivation;
   if (typeof named === 'string' && named.trim().length > 0) {
@@ -712,6 +716,12 @@ export async function verifyContainer(
   const calculatedHash = createHash('sha256').update(decryptedState).digest('hex');
   if (calculatedHash !== payload.sha256) {
     const description = optionalDescription(manifest.description);
+    let components: string[] | undefined;
+    try {
+      components = listStateComponents(JSON.parse(decryptedState.toString()));
+    } catch {
+      components = undefined;
+    }
     return {
       status: 'corrupted',
       message: 'Integrity check failed: checksum mismatch (file may be corrupted or tampered)',
@@ -728,6 +738,7 @@ export async function verifyContainer(
       contentType: typeof payload.contentType === 'string' ? payload.contentType : undefined,
       payloadBytes: decryptedState.length,
       checksum: calculatedHash,
+      ...(components && components.length > 0 ? { components } : {}),
     };
   }
 
@@ -908,6 +919,9 @@ export function formatVerifyResult(result: VerifyResult, json: boolean): string 
         if (result.manifest.description) {
           lines.push(formatVerifyDescription(result.manifest.description));
         }
+      }
+      if (result.components && result.components.length > 0) {
+        lines.push(formatVerifyComponents(result.components));
       }
       if (result.input) {
         lines.push(formatVerifyInput(result.input));


### PR DESCRIPTION
## Summary
- `savestate verify` now prints `   Components: <paths>` when checksum mismatch marks the file corrupted and the decrypted payload is valid JSON.
- Invalid-JSON corruption and invalid-format verify still omit the line. Valid and wrong-password verify are unchanged.

Closes #398.

## Proof
Focused: `npx vitest run src/commands/__tests__/verify-components-output.test.ts src/commands/__tests__/verify-checksum.test.ts src/commands/__tests__/verify.test.ts` — 20 passed.

Plasmate: https://savestate.dev and https://savestate.dev/docs/