### PR TITLE
Print included components when the passphrase is wrong

### DIFF
--- a/src/commands/__tests__/verify-components-wrong-pass-output.test.ts
+++ b/src/commands/__tests__/verify-components-wrong-pass-output.test.ts
@@ -1,0 +1,92 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { formatVerifyComponents, formatVerifyResult, verifyContainer } from '../verify.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate verify components wrong-password output', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'savestate-verify-components-wrong-pass-'));
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(fileName: string, components?: unknown): Promise<string> {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({ memory: ['demo'], tools: { enabled: [] } }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest: Record<string, unknown> = {
+      formatVersion: 1,
+      created: '2026-08-24T10:00:00.000Z',
+      agentId: 'demo-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: createHash('sha256').update(plaintext).digest('hex'),
+        },
+      ],
+    };
+    if (components !== undefined) {
+      manifest.components = components;
+    }
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('formats packed components on their own line', () => {
+    expect(formatVerifyComponents(['memory'])).toBe('   Components: memory');
+    expect(formatVerifyComponents(['memory', 'tools'])).toBe('   Components: memory, tools');
+    expect(formatVerifyComponents(['memory'])).not.toContain('Agent:');
+  });
+
+  it('prints included components when the passphrase is wrong', async () => {
+    const filePath = await writeContainer('wrong-pass-components.savestate', ['memory', 'tools']);
+    const result = await verifyContainer(filePath, { passphrase: 'wrong-pass' });
+
+    expect(result.status).toBe('wrong_password');
+    expect(result.components).toEqual(['memory', 'tools']);
+    expect(formatVerifyResult(result, false)).toContain('   Components: memory, tools');
+  });
+
+  it('omits components when the passphrase is wrong and the archive has none', async () => {
+    const filePath = await writeContainer('wrong-pass-no-components.savestate');
+    const result = await verifyContainer(filePath, { passphrase: 'wrong-pass' });
+
+    expect(result.status).toBe('wrong_password');
+    expect(result.components).toBeUndefined();
+    expect(formatVerifyResult(result, false)).not.toContain('Components:');
+  });
+
+  it('omits a components line when the file is not a SaveState container', async () => {
+    const filePath = join(testDir, 'not-a-container.bin');
+    await writeFile(filePath, Buffer.from('not-a-savestate-file'));
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('invalid_format');
+    expect(result.components).toBeUndefined();
+    expect(formatVerifyResult(result, false)).not.toContain('Components:');
+  });
+});

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -91,6 +91,10 @@ export function formatVerifyExcluded(excluded: readonly string[]): string {
   return `   Excluded: ${excluded.join(', ')}`;
 }
 
+export function formatVerifyComponents(components: readonly string[]): string {
+  return `   Components: ${components.join(', ')}`;
+}
+
 function resolveKeyDerivation(manifest: { encryption?: { keyDerivation?: unknown } }): string {
   const named = manifest.encryption?.keyDerivation;
   if (typeof named === 'string' && named.trim().length > 0) {
@@ -397,6 +401,7 @@ export async function verifyContainer(
     };
   }
 
+  let listedComponents: string[] | undefined;
   if ('components' in manifest) {
     const validated = validateIncludedComponents(manifest.components);
     if ('error' in validated) {
@@ -405,6 +410,7 @@ export async function verifyContainer(
         message: `Invalid manifest: ${validated.error.replace(/^Error: /, '')}`,
       };
     }
+    listedComponents = validated.components;
   }
 
   let excluded: string[] | undefined;
@@ -704,6 +710,7 @@ export async function verifyContainer(
       contentType: typeof payload.contentType === 'string' ? payload.contentType : undefined,
       payloadBytes: typeof payload.byteLength === 'number' ? payload.byteLength : undefined,
       checksum: typeof payload.sha256 === 'string' && payload.sha256.trim() !== '' ? payload.sha256 : undefined,
+      ...(listedComponents ? { components: listedComponents } : {}),
       ...(excluded ? { excluded } : {}),
     };
   }
@@ -870,6 +877,9 @@ export function formatVerifyResult(result: VerifyResult, json: boolean): string 
         if (result.manifest.description) {
           lines.push(formatVerifyDescription(result.manifest.description));
         }
+      }
+      if (result.components && result.components.length > 0) {
+        lines.push(formatVerifyComponents(result.components));
       }
       if (result.excluded && result.excluded.length > 0) {
         lines.push(formatVerifyExcluded(result.excluded));


### PR DESCRIPTION
## Summary

`savestate verify` now prints `   Components: <paths>` on `wrong_password` when the unencrypted manifest lists them. Invalid-format verify still omits the line.

Closes #400

## Focused proof

```
npx vitest run src/commands/__tests__/verify-components-wrong-pass-output.test.ts src/commands/__tests__/verify-excluded-output.test.ts src/commands/__tests__/verify-components-schema.test.ts
```

12 passed.

Plasmate: https://savestate.dev and https://savestate.dev/docs/