### PR TITLE
Print agent id when the import passphrase is wrong

### DIFF
--- a/src/commands/__tests__/import-agent-wrong-pass-output.test.ts
+++ b/src/commands/__tests__/import-agent-wrong-pass-output.test.ts
@@ -1,0 +1,125 @@
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { formatImportAgent, importState } from '../container.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate import agent wrong-password output', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-import-agent-wrong-pass-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(fileName: string, agentId?: unknown): Promise<string> {
+    const passphrase = 'synthetic-passphrase';
+    const plaintext = Buffer.from(JSON.stringify({
+      agentId: 'fixture-agent',
+      version: 1,
+      exportedAt: '2026-08-24T11:00:00.000Z',
+      memory: { facts: ['synthetic'] },
+      tools: { enabled: [] },
+    }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest: Record<string, unknown> = {
+      formatVersion: 1,
+      created: '2026-08-24T11:00:00.000Z',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: createHash('sha256').update(plaintext).digest('hex'),
+        },
+      ],
+    };
+    if (agentId !== undefined) {
+      manifest.agentId = agentId;
+    }
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await fs.writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('formats the agent id on its own line', () => {
+    expect(formatImportAgent('fixture-agent')).toBe('  Agent: fixture-agent');
+    expect(formatImportAgent('fixture-agent')).not.toContain('Mode:');
+  });
+
+  it('prints the agent id when the passphrase is wrong', async () => {
+    const filePath = await writeContainer('wrong-pass-agent.savestate', 'fixture-agent');
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: filePath,
+      passphrase: 'wrong-pass',
+    });
+
+    expect(result).toBeUndefined();
+    expect(error.mock.calls.flat()).toContain('  Agent: fixture-agent');
+    expect(log.mock.calls.flat().some((line) => typeof line === 'string' && line.startsWith('  Agent: '))).toBe(false);
+    error.mockRestore();
+    log.mockRestore();
+  });
+
+  it('omits the agent line when the passphrase is wrong and agent id is empty', async () => {
+    const filePath = await writeContainer('wrong-pass-empty-agent.savestate', '   ');
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: filePath,
+      passphrase: 'wrong-pass',
+    });
+
+    expect(result).toBeUndefined();
+    expect(error.mock.calls.flat().some((line) => typeof line === 'string' && line.includes('Agent:'))).toBe(false);
+    expect(log.mock.calls.flat().some((line) => typeof line === 'string' && line.includes('Agent:'))).toBe(false);
+    error.mockRestore();
+    log.mockRestore();
+  });
+
+  it('omits an agent line when the file is not a SaveState container', async () => {
+    const filePath = join(testDir, 'not-a-container.bin');
+    await fs.writeFile(filePath, Buffer.from('not-a-savestate-file'));
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const exit = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit:${code ?? ''}`);
+    }) as typeof process.exit);
+
+    await expect(
+      importState({
+        in: filePath,
+        passphrase: 'synthetic-passphrase',
+      }),
+    ).rejects.toThrow(/process\.exit:1/);
+
+    expect(error.mock.calls.flat().some((line) => typeof line === 'string' && line.includes('Agent:'))).toBe(false);
+    expect(log.mock.calls.flat().some((line) => typeof line === 'string' && line.includes('Agent:'))).toBe(false);
+    error.mockRestore();
+    log.mockRestore();
+    exit.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -960,7 +960,11 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
       decryptedState = await decrypt(encryptedState, keySource);
     } catch {
       console.error('Error: Decryption failed. The passphrase or keyfile may be incorrect.');
-      process.exit(1);
+      const agentId = typeof manifest.agentId === 'string' ? manifest.agentId.trim() : '';
+      if (agentId) {
+        console.error(formatImportAgent(agentId));
+      }
+      return undefined;
     }
     
     const payload = manifest.payloads.find((p: any) => p.name === 'agent_state');


### PR DESCRIPTION
## Summary

`savestate import` now prints `  Agent: <id>` when decryption fails because the passphrase is wrong, using the unencrypted manifest. Empty or missing agent ids and invalid-format files still omit the line.

Closes #402

## Focused proof

```
npx vitest run src/commands/__tests__/import-agent-wrong-pass-output.test.ts src/commands/__tests__/import-agent-output.test.ts src/commands/__tests__/import-empty-passphrase.test.ts
```

13 passed.

Plasmate: https://savestate.dev and https://savestate.dev/docs/ and https://savestate.dev/docs/cli.html