### PR TITLE
Print created timestamp when the import passphrase is wrong

### DIFF
--- a/src/commands/__tests__/import-created-wrong-pass-output.test.ts
+++ b/src/commands/__tests__/import-created-wrong-pass-output.test.ts
@@ -1,0 +1,125 @@
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { formatImportCreated, importState } from '../container.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate import created wrong-password output', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-import-created-wrong-pass-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(fileName: string, created?: unknown): Promise<string> {
+    const passphrase = 'synthetic-passphrase';
+    const plaintext = Buffer.from(JSON.stringify({
+      agentId: 'fixture-agent',
+      version: 1,
+      exportedAt: '2026-08-24T14:00:00.000Z',
+      memory: { facts: ['synthetic'] },
+      tools: { enabled: [] },
+    }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest: Record<string, unknown> = {
+      formatVersion: 1,
+      agentId: 'fixture-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: createHash('sha256').update(plaintext).digest('hex'),
+        },
+      ],
+    };
+    if (created !== undefined) {
+      manifest.created = created;
+    }
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await fs.writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('formats the created timestamp on its own line', () => {
+    expect(formatImportCreated('2026-08-24T14:00:00.000Z')).toBe('  Created: 2026-08-24T14:00:00.000Z');
+    expect(formatImportCreated('2026-08-24T14:00:00.000Z')).not.toContain('Agent:');
+  });
+
+  it('prints the created timestamp when the passphrase is wrong', async () => {
+    const filePath = await writeContainer('wrong-pass-created.savestate', '2026-08-24T14:00:00.000Z');
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: filePath,
+      passphrase: 'wrong-pass',
+    });
+
+    expect(result).toBeUndefined();
+    expect(error.mock.calls.flat()).toContain('  Created: 2026-08-24T14:00:00.000Z');
+    expect(log.mock.calls.flat().some((line) => typeof line === 'string' && line.startsWith('  Created: '))).toBe(false);
+    error.mockRestore();
+    log.mockRestore();
+  });
+
+  it('omits the created line when the passphrase is wrong and created is empty', async () => {
+    const filePath = await writeContainer('wrong-pass-empty-created.savestate', '   ');
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: filePath,
+      passphrase: 'wrong-pass',
+    });
+
+    expect(result).toBeUndefined();
+    expect(error.mock.calls.flat().some((line) => typeof line === 'string' && line.includes('Created:'))).toBe(false);
+    expect(log.mock.calls.flat().some((line) => typeof line === 'string' && line.includes('Created:'))).toBe(false);
+    error.mockRestore();
+    log.mockRestore();
+  });
+
+  it('omits a created line when the file is not a SaveState container', async () => {
+    const filePath = join(testDir, 'not-a-container.bin');
+    await fs.writeFile(filePath, Buffer.from('not-a-savestate-file'));
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const exit = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit:${code ?? ''}`);
+    }) as typeof process.exit);
+
+    await expect(
+      importState({
+        in: filePath,
+        passphrase: 'synthetic-passphrase',
+      }),
+    ).rejects.toThrow(/process\.exit:1/);
+
+    expect(error.mock.calls.flat().some((line) => typeof line === 'string' && line.includes('Created:'))).toBe(false);
+    expect(log.mock.calls.flat().some((line) => typeof line === 'string' && line.includes('Created:'))).toBe(false);
+    error.mockRestore();
+    log.mockRestore();
+    exit.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -971,6 +971,10 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
       if (formatVersion !== undefined) {
         console.error(formatImportFormatVersion(formatVersion));
       }
+      const created = typeof manifest.created === 'string' ? manifest.created.trim() : '';
+      if (created) {
+        console.error(formatImportCreated(created));
+      }
       return undefined;
     }
     


### PR DESCRIPTION
Closes #409

When `savestate import` cannot decrypt an archive, print the readable manifest `created` timestamp on stderr so the operator can still identify which snapshot they tried to restore.

- Prints `  Created: <timestamp>` after the decryption-failed message
- Omits the line when `created` is missing or empty
- Omits the line when the file is not a SaveState container

Focused proof: `npx vitest run src/commands/__tests__/import-created-wrong-pass-output.test.ts src/commands/__tests__/import-created-output.test.ts src/commands/__tests__/import-format-wrong-pass-output.test.ts src/commands/__tests__/import-agent-wrong-pass-output.test.ts` — 16 passed.

Plasmate: https://savestate.dev and https://savestate.dev/docs/