### PR TITLE
Print encryption algorithm when the import file is corrupted

### DIFF
--- a/src/commands/__tests__/import-encryption-corrupted-output.test.ts
+++ b/src/commands/__tests__/import-encryption-corrupted-output.test.ts
@@ -1,0 +1,141 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { formatImportEncryption, importState } from '../container.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate import encryption corrupted output', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-import-encryption-corrupted-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(fileName: string, encryption?: unknown): Promise<string> {
+    const passphrase = 'synthetic-passphrase';
+    const plaintext = Buffer.from(JSON.stringify({
+      agentId: 'fixture-agent',
+      version: 1,
+      exportedAt: '2026-08-24T18:00:00.000Z',
+      memory: { facts: ['synthetic'] },
+      tools: { enabled: [] },
+    }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest: Record<string, unknown> = {
+      formatVersion: 1,
+      created: '2026-08-24T18:00:00.000Z',
+      agentId: 'fixture-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: 'a'.repeat(64),
+        },
+      ],
+    };
+    if (encryption !== undefined) {
+      manifest.encryption = encryption;
+    }
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await fs.writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('formats the encryption algorithm on its own line', () => {
+    expect(formatImportEncryption('AES-256-GCM')).toBe('  Encryption: AES-256-GCM');
+    expect(formatImportEncryption('AES-256-GCM')).not.toContain('Agent:');
+  });
+
+  it('prints the encryption algorithm when the file is corrupted', async () => {
+    const filePath = await writeContainer('corrupted-encryption.savestate', {
+      algorithm: 'AES-256-GCM',
+      keyDerivation: 'Argon2id',
+    });
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const exit = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit:${code ?? ''}`);
+    }) as typeof process.exit);
+
+    await expect(
+      importState({
+        in: filePath,
+        passphrase: 'synthetic-passphrase',
+      }),
+    ).rejects.toThrow(/process\.exit:1/);
+
+    expect(error.mock.calls.flat()).toContain('  Encryption: AES-256-GCM');
+    expect(log.mock.calls.flat().some((line) => typeof line === 'string' && line.startsWith('  Encryption:'))).toBe(false);
+    error.mockRestore();
+    log.mockRestore();
+    exit.mockRestore();
+  });
+
+  it('omits the encryption line when the file is corrupted and algorithm is empty', async () => {
+    const filePath = await writeContainer('corrupted-empty-encryption.savestate', {
+      algorithm: '   ',
+      keyDerivation: 'Argon2id',
+    });
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const exit = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit:${code ?? ''}`);
+    }) as typeof process.exit);
+
+    await expect(
+      importState({
+        in: filePath,
+        passphrase: 'synthetic-passphrase',
+      }),
+    ).rejects.toThrow(/process\.exit:1/);
+
+    expect(error.mock.calls.flat().some((line) => typeof line === 'string' && line.includes('Encryption:'))).toBe(false);
+    expect(log.mock.calls.flat().some((line) => typeof line === 'string' && line.includes('Encryption:'))).toBe(false);
+    error.mockRestore();
+    log.mockRestore();
+    exit.mockRestore();
+  });
+
+  it('omits an encryption line when the file is not a SaveState container', async () => {
+    const filePath = join(testDir, 'not-a-container.bin');
+    await fs.writeFile(filePath, Buffer.from('not-a-savestate-file'));
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const exit = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit:${code ?? ''}`);
+    }) as typeof process.exit);
+
+    await expect(
+      importState({
+        in: filePath,
+        passphrase: 'synthetic-passphrase',
+      }),
+    ).rejects.toThrow(/process\.exit:1/);
+
+    expect(error.mock.calls.flat().some((line) => typeof line === 'string' && line.includes('Encryption:'))).toBe(false);
+    expect(log.mock.calls.flat().some((line) => typeof line === 'string' && line.includes('Encryption:'))).toBe(false);
+    error.mockRestore();
+    log.mockRestore();
+    exit.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -1011,6 +1011,10 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
       if (description) {
         console.error(formatImportDescription(description));
       }
+      const encryptionAlgorithm = optionalImportEncryption(manifest.encryption);
+      if (encryptionAlgorithm) {
+        console.error(formatImportEncryption(encryptionAlgorithm));
+      }
       process.exit(1);
     }
     


### PR DESCRIPTION
## Summary

`savestate import` already prints `  Encryption: <algorithm>` on a successful restore when the unencrypted manifest names one. Integrity-check failure now prints the same line from the unencrypted manifest so operators can identify the algorithm after a failed import.

Empty, missing, or whitespace-only algorithms omit the line. Non-container files also omit it.

Closes #417

## Proof

Focused: `npx vitest run src/commands/__tests__/import-encryption-corrupted-output.test.ts` — 4 passed.

Plasmate: https://savestate.dev and https://savestate.dev/docs/cli.html