### PR TITLE
Print payload content type when the import file is corrupted

### DIFF
--- a/src/commands/__tests__/import-content-type-corrupted-output.test.ts
+++ b/src/commands/__tests__/import-content-type-corrupted-output.test.ts
@@ -1,0 +1,137 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { formatImportContentType, importState } from '../container.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate import content type corrupted output', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-import-content-type-corrupted-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(fileName: string, contentType?: unknown): Promise<string> {
+    const passphrase = 'synthetic-passphrase';
+    const plaintext = Buffer.from(JSON.stringify({
+      agentId: 'fixture-agent',
+      version: 1,
+      exportedAt: '2026-08-24T22:00:00.000Z',
+      memory: { facts: ['synthetic'] },
+      tools: { enabled: [] },
+    }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const payload: Record<string, unknown> = {
+      name: 'agent_state',
+      byteLength: plaintext.length,
+      sha256: 'a'.repeat(64),
+    };
+    if (contentType !== undefined) {
+      payload.contentType = contentType;
+    }
+    const manifest: Record<string, unknown> = {
+      formatVersion: 1,
+      created: '2026-08-24T22:00:00.000Z',
+      agentId: 'fixture-agent',
+      encryption: {
+        algorithm: 'AES-256-GCM',
+        keyDerivation: 'Argon2id',
+      },
+      payloads: [payload],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await fs.writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('formats the content type on its own line', () => {
+    expect(formatImportContentType('application/json')).toBe('  Content-Type: application/json');
+    expect(formatImportContentType('application/json')).not.toContain('Agent:');
+  });
+
+  it('prints the content type when the file is corrupted', async () => {
+    const filePath = await writeContainer('corrupted-content-type.savestate', 'application/json');
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const exit = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit:${code ?? ''}`);
+    }) as typeof process.exit);
+
+    await expect(
+      importState({
+        in: filePath,
+        passphrase: 'synthetic-passphrase',
+      }),
+    ).rejects.toThrow(/process\.exit:1/);
+
+    expect(error.mock.calls.flat()).toContain('  Content-Type: application/json');
+    expect(log.mock.calls.flat().some((line) => typeof line === 'string' && line.startsWith('  Content-Type:'))).toBe(false);
+    error.mockRestore();
+    log.mockRestore();
+    exit.mockRestore();
+  });
+
+  it('omits the content type line when the file is corrupted and type is empty', async () => {
+    const filePath = await writeContainer('corrupted-empty-content-type.savestate', '   ');
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const exit = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit:${code ?? ''}`);
+    }) as typeof process.exit);
+
+    await expect(
+      importState({
+        in: filePath,
+        passphrase: 'synthetic-passphrase',
+      }),
+    ).rejects.toThrow(/process\.exit:1/);
+
+    expect(error.mock.calls.flat().some((line) => typeof line === 'string' && line.includes('Content-Type:'))).toBe(false);
+    expect(log.mock.calls.flat().some((line) => typeof line === 'string' && line.includes('Content-Type:'))).toBe(false);
+    error.mockRestore();
+    log.mockRestore();
+    exit.mockRestore();
+  });
+
+  it('omits a content type line when the file is not a SaveState container', async () => {
+    const filePath = join(testDir, 'not-a-container.bin');
+    await fs.writeFile(filePath, Buffer.from('not-a-savestate-file'));
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const exit = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit:${code ?? ''}`);
+    }) as typeof process.exit);
+
+    await expect(
+      importState({
+        in: filePath,
+        passphrase: 'synthetic-passphrase',
+      }),
+    ).rejects.toThrow(/process\.exit:1/);
+
+    expect(error.mock.calls.flat().some((line) => typeof line === 'string' && line.includes('Content-Type:'))).toBe(false);
+    expect(log.mock.calls.flat().some((line) => typeof line === 'string' && line.includes('Content-Type:'))).toBe(false);
+    error.mockRestore();
+    log.mockRestore();
+    exit.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -1031,6 +1031,9 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
       if (keyDerivation) {
         console.error(formatImportKeyDerivation(keyDerivation));
       }
+      if (contentType) {
+        console.error(formatImportContentType(contentType));
+      }
       process.exit(1);
     }
     


### PR DESCRIPTION
## Summary
- Print `  Content-Type: <type>` on stderr when `savestate import` fails integrity check and the manifest names a content type
- Omit the line when the content type is empty/missing or the file is not a SaveState container

Closes #426

## Proof
Focused: `npx vitest run src/commands/__tests__/import-content-type-corrupted-output.test.ts` — 4 passed

Plasmate: https://savestate.dev and https://savestate.dev/docs/cli/