### PR TITLE
Print payload size when the import passphrase is wrong

### DIFF
--- a/src/commands/__tests__/import-size-wrong-pass-output.test.ts
+++ b/src/commands/__tests__/import-size-wrong-pass-output.test.ts
@@ -1,0 +1,126 @@
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { formatImportSize, importState } from '../container.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate import size wrong-password output', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-import-size-wrong-pass-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(fileName: string, byteLength?: unknown): Promise<{ filePath: string; payloadBytes: number }> {
+    const passphrase = 'synthetic-passphrase';
+    const plaintext = Buffer.from(JSON.stringify({
+      agentId: 'fixture-agent',
+      version: 1,
+      exportedAt: '2026-08-24T23:00:00.000Z',
+      memory: { facts: ['synthetic'] },
+      tools: { enabled: [] },
+    }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const payload: Record<string, unknown> = {
+      name: 'agent_state',
+      contentType: 'application/json',
+      sha256: createHash('sha256').update(plaintext).digest('hex'),
+    };
+    if (byteLength !== undefined) {
+      payload.byteLength = byteLength;
+    } else {
+      payload.byteLength = plaintext.length;
+    }
+    const manifest: Record<string, unknown> = {
+      formatVersion: 1,
+      created: '2026-08-24T23:00:00.000Z',
+      agentId: 'fixture-agent',
+      payloads: [payload],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await fs.writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return { filePath, payloadBytes: plaintext.length };
+  }
+
+  it('formats the size on its own line', () => {
+    expect(formatImportSize(42)).toBe('  Size: 42 bytes');
+    expect(formatImportSize(42)).not.toContain('Agent:');
+  });
+
+  it('prints the payload size when the passphrase is wrong', async () => {
+    const { filePath, payloadBytes } = await writeContainer('wrong-pass-size.savestate');
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: filePath,
+      passphrase: 'wrong-pass',
+    });
+
+    expect(result).toBeUndefined();
+    expect(error.mock.calls.flat()).toContain(`  Size: ${payloadBytes} bytes`);
+    expect(log.mock.calls.flat().some((line) => typeof line === 'string' && line.startsWith('  Size:'))).toBe(false);
+    error.mockRestore();
+    log.mockRestore();
+  });
+
+  it('omits the size line when the passphrase is wrong and byteLength is missing', async () => {
+    const { filePath } = await writeContainer('wrong-pass-missing-size.savestate', null);
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: filePath,
+      passphrase: 'wrong-pass',
+    });
+
+    expect(result).toBeUndefined();
+    expect(error.mock.calls.flat().some((line) => typeof line === 'string' && line.includes('Size:'))).toBe(false);
+    expect(log.mock.calls.flat().some((line) => typeof line === 'string' && line.includes('Size:'))).toBe(false);
+    error.mockRestore();
+    log.mockRestore();
+  });
+
+  it('omits a size line when the file is not a SaveState container', async () => {
+    const filePath = join(testDir, 'not-a-container.bin');
+    await fs.writeFile(filePath, Buffer.from('not-a-savestate-file'));
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const exit = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit:${code ?? ''}`);
+    }) as typeof process.exit);
+
+    await expect(
+      importState({
+        in: filePath,
+        passphrase: 'synthetic-passphrase',
+      }),
+    ).rejects.toThrow(/process\.exit:1/);
+
+    expect(error.mock.calls.flat().some((line) => typeof line === 'string' && line.includes('Size:'))).toBe(false);
+    expect(log.mock.calls.flat().some((line) => typeof line === 'string' && line.includes('Size:'))).toBe(false);
+    error.mockRestore();
+    log.mockRestore();
+    exit.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -999,6 +999,18 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
       if (contentType) {
         console.error(formatImportContentType(contentType));
       }
+      const sizedPayload = Array.isArray(manifest.payloads)
+        ? manifest.payloads.find((p: { byteLength?: unknown }) =>
+            typeof p?.byteLength === 'number' && Number.isInteger(p.byteLength) && p.byteLength >= 0,
+          )
+        : undefined;
+      const payloadBytes =
+        sizedPayload && typeof sizedPayload.byteLength === 'number'
+          ? sizedPayload.byteLength
+          : undefined;
+      if (payloadBytes !== undefined) {
+        console.error(formatImportSize(payloadBytes));
+      }
       const namedPayload = Array.isArray(manifest.payloads)
         ? manifest.payloads.find((p: { name?: unknown }) => optionalImportPayloadName(p?.name))
         : undefined;


### PR DESCRIPTION
## Summary
- Print `  Size: <n> bytes` on stderr when `savestate import` fails decryption and the manifest names a payload byte length
- Omit the line when byteLength is missing/invalid or the file is not a SaveState container

## Proof
Focused: `npx vitest run src/commands/__tests__/import-size-wrong-pass-output.test.ts` — 4 passed

Plasmate: https://savestate.dev and https://savestate.dev/docs