### PR TITLE
Print restore mode when the import passphrase is wrong

### DIFF
--- a/src/commands/__tests__/import-mode-wrong-pass-output.test.ts
+++ b/src/commands/__tests__/import-mode-wrong-pass-output.test.ts
@@ -1,0 +1,125 @@
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { formatImportMode, importState } from '../container.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate import mode wrong-password output', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-import-mode-wrong-pass-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(fileName: string): Promise<string> {
+    const passphrase = 'synthetic-passphrase';
+    const plaintext = Buffer.from(JSON.stringify({
+      agentId: 'fixture-agent',
+      version: 1,
+      exportedAt: '2026-08-25T10:00:00.000Z',
+      memory: { facts: ['synthetic'] },
+      tools: { enabled: [] },
+    }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest: Record<string, unknown> = {
+      formatVersion: 1,
+      created: '2026-08-25T10:00:00.000Z',
+      agentId: 'fixture-agent',
+      payloads: [
+        {
+          name: 'agent_state',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: createHash('sha256').update(plaintext).digest('hex'),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await fs.writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('formats the restore mode on its own line', () => {
+    expect(formatImportMode('replace')).toBe('  Mode: replace');
+    expect(formatImportMode('merge')).toBe('  Mode: merge');
+    expect(formatImportMode('replace')).not.toContain('Agent:');
+  });
+
+  it('prints replace mode when the passphrase is wrong', async () => {
+    const filePath = await writeContainer('wrong-pass-mode.savestate');
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: filePath,
+      passphrase: 'wrong-pass',
+    });
+
+    expect(result).toBeUndefined();
+    expect(error.mock.calls.flat()).toContain(formatImportMode('replace'));
+    expect(log.mock.calls.flat().some((line) => typeof line === 'string' && line.startsWith('  Mode:'))).toBe(false);
+    error.mockRestore();
+    log.mockRestore();
+  });
+
+  it('prints merge mode when the passphrase is wrong and merge is requested', async () => {
+    const filePath = await writeContainer('wrong-pass-merge-mode.savestate');
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await importState({
+      in: filePath,
+      passphrase: 'wrong-pass',
+      merge: true,
+    });
+
+    expect(result).toBeUndefined();
+    expect(error.mock.calls.flat()).toContain(formatImportMode('merge'));
+    expect(log.mock.calls.flat().some((line) => typeof line === 'string' && line.startsWith('  Mode:'))).toBe(false);
+    error.mockRestore();
+    log.mockRestore();
+  });
+
+  it('omits a restore mode when the file is not a SaveState container', async () => {
+    const filePath = join(testDir, 'not-a-container.bin');
+    await fs.writeFile(filePath, Buffer.from('not-a-savestate-file'));
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const exit = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit:${code ?? ''}`);
+    }) as typeof process.exit);
+
+    await expect(
+      importState({
+        in: filePath,
+        passphrase: 'synthetic-passphrase',
+      }),
+    ).rejects.toThrow(/process\.exit:1/);
+
+    expect(error.mock.calls.flat().some((line) => typeof line === 'string' && line.includes('Mode:'))).toBe(false);
+    expect(log.mock.calls.flat().some((line) => typeof line === 'string' && line.includes('Mode:'))).toBe(false);
+    error.mockRestore();
+    log.mockRestore();
+    exit.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -964,6 +964,7 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
       if (agentId) {
         console.error(formatImportAgent(agentId));
       }
+      console.error(formatImportMode(mode));
       const formatVersion =
         typeof manifest.formatVersion === 'number' && Number.isFinite(manifest.formatVersion)
           ? manifest.formatVersion


### PR DESCRIPTION
## Summary
- Print `Mode:` on `savestate import` when decryption fails because the passphrase is wrong, matching successful import output.
- Add focused tests for replace, merge, and non-container cases.

## Proof
- `npx vitest run src/commands/__tests__/import-mode-wrong-pass-output.test.ts` — 4 passed
- Plasmate: https://savestate.dev and https://savestate.dev/docs/