### PR TITLE
Print key derivation when the import container has no agent state

### DIFF
--- a/src/commands/__tests__/import-kdf-no-agent-output.test.ts
+++ b/src/commands/__tests__/import-kdf-no-agent-output.test.ts
@@ -1,0 +1,141 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { formatImportKeyDerivation, importState } from '../container.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate import key derivation no-agent output', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-import-kdf-no-agent-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(fileName: string, encryption?: unknown): Promise<string> {
+    const passphrase = 'synthetic-passphrase';
+    const plaintext = Buffer.from(JSON.stringify({
+      agentId: 'fixture-agent',
+      version: 1,
+      exportedAt: '2026-08-25T13:00:00.000Z',
+      memory: { facts: ['synthetic'] },
+      tools: { enabled: [] },
+    }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest: Record<string, unknown> = {
+      formatVersion: 1,
+      created: '2026-08-25T13:00:00.000Z',
+      agentId: 'fixture-agent',
+      payloads: [
+        {
+          name: 'other_payload',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: 'a'.repeat(64),
+        },
+      ],
+    };
+    if (encryption !== undefined) {
+      manifest.encryption = encryption;
+    }
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await fs.writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('formats the key derivation on its own line', () => {
+    expect(formatImportKeyDerivation('Argon2id')).toBe('  Key derivation: Argon2id');
+    expect(formatImportKeyDerivation('Argon2id')).not.toContain('Agent:');
+  });
+
+  it('prints the key derivation when the container has no agent state', async () => {
+    const filePath = await writeContainer('no-agent-kdf.savestate', {
+      algorithm: 'AES-256-GCM',
+      keyDerivation: 'Argon2id',
+    });
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const exit = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit:${code ?? ''}`);
+    }) as typeof process.exit);
+
+    await expect(
+      importState({
+        in: filePath,
+        passphrase: 'synthetic-passphrase',
+      }),
+    ).rejects.toThrow(/process\.exit:1/);
+
+    expect(error.mock.calls.flat()).toContain(formatImportKeyDerivation('Argon2id'));
+    expect(log.mock.calls.flat().some((line) => typeof line === 'string' && line.startsWith('  Key derivation:'))).toBe(false);
+    error.mockRestore();
+    log.mockRestore();
+    exit.mockRestore();
+  });
+
+  it('omits the key derivation line when the container has no agent state and KDF is empty', async () => {
+    const filePath = await writeContainer('no-agent-empty-kdf.savestate', {
+      algorithm: 'AES-256-GCM',
+      keyDerivation: '   ',
+    });
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const exit = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit:${code ?? ''}`);
+    }) as typeof process.exit);
+
+    await expect(
+      importState({
+        in: filePath,
+        passphrase: 'synthetic-passphrase',
+      }),
+    ).rejects.toThrow(/process\.exit:1/);
+
+    expect(error.mock.calls.flat().some((line) => typeof line === 'string' && line.includes('Key derivation:'))).toBe(false);
+    expect(log.mock.calls.flat().some((line) => typeof line === 'string' && line.includes('Key derivation:'))).toBe(false);
+    error.mockRestore();
+    log.mockRestore();
+    exit.mockRestore();
+  });
+
+  it('omits a key derivation line when the file is not a SaveState container', async () => {
+    const filePath = join(testDir, 'not-a-container.bin');
+    await fs.writeFile(filePath, Buffer.from('not-a-savestate-file'));
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const exit = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit:${code ?? ''}`);
+    }) as typeof process.exit);
+
+    await expect(
+      importState({
+        in: filePath,
+        passphrase: 'synthetic-passphrase',
+      }),
+    ).rejects.toThrow(/process\.exit:1/);
+
+    expect(error.mock.calls.flat().some((line) => typeof line === 'string' && line.includes('Key derivation:'))).toBe(false);
+    expect(log.mock.calls.flat().some((line) => typeof line === 'string' && line.includes('Key derivation:'))).toBe(false);
+    error.mockRestore();
+    log.mockRestore();
+    exit.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -1055,6 +1055,10 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
       if (formatVersion !== undefined) {
         console.error(formatImportFormatVersion(formatVersion));
       }
+      const keyDerivation = optionalImportKeyDerivation(manifest.encryption);
+      if (keyDerivation) {
+        console.error(formatImportKeyDerivation(keyDerivation));
+      }
       process.exit(1);
     }
     const contentType =


### PR DESCRIPTION
## Summary
- Print the manifest key derivation on `savestate import` when the container has no agent state.
- Omit the line when KDF is empty or the file is not a SaveState container.

## Proof
Focused vitest: import-kdf-no-agent / import-kdf / import-kdf-corrupted / import-kdf-wrong-pass / import-format-no-agent / import-mode-no-agent — 23 passed.

Plasmate: https://savestate.dev and https://savestate.dev/docs/