### PR TITLE
Print payload checksum when the import container has no agent state

### DIFF
--- a/src/commands/__tests__/import-checksum-no-agent-output.test.ts
+++ b/src/commands/__tests__/import-checksum-no-agent-output.test.ts
@@ -1,0 +1,139 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { formatImportChecksum, importState } from '../container.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate import checksum no-agent output', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `savestate-import-checksum-no-agent-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(fileName: string, sha256?: unknown): Promise<{ filePath: string; checksum?: string }> {
+    const passphrase = 'synthetic-passphrase';
+    const plaintext = Buffer.from(JSON.stringify({
+      agentId: 'fixture-agent',
+      version: 1,
+      exportedAt: '2026-08-25T17:00:00.000Z',
+      memory: { facts: ['synthetic'] },
+      tools: { enabled: [] },
+    }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const payload: Record<string, unknown> = {
+      name: 'other_payload',
+      contentType: 'application/json',
+      byteLength: plaintext.length,
+    };
+    if (sha256 !== undefined) {
+      payload.sha256 = sha256;
+    } else {
+      payload.sha256 = 'a'.repeat(64);
+    }
+    const manifest: Record<string, unknown> = {
+      formatVersion: 1,
+      created: '2026-08-25T17:00:00.000Z',
+      agentId: 'fixture-agent',
+      payloads: [payload],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await fs.writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return {
+      filePath,
+      checksum: typeof payload.sha256 === 'string' ? payload.sha256 : undefined,
+    };
+  }
+
+  it('formats the checksum on its own line', () => {
+    const hash = 'a'.repeat(64);
+    expect(formatImportChecksum(hash)).toBe(`  Checksum: ${hash}`);
+    expect(formatImportChecksum(hash)).not.toContain('Agent:');
+  });
+
+  it('prints the payload checksum when the container has no agent state', async () => {
+    const { filePath, checksum } = await writeContainer('no-agent-checksum.savestate');
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const exit = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit:${code ?? ''}`);
+    }) as typeof process.exit);
+
+    await expect(
+      importState({
+        in: filePath,
+        passphrase: 'synthetic-passphrase',
+      }),
+    ).rejects.toThrow(/process\.exit:1/);
+
+    expect(error.mock.calls.flat()).toContain(formatImportChecksum(checksum!));
+    expect(log.mock.calls.flat().some((line) => typeof line === 'string' && line.startsWith('  Checksum:'))).toBe(false);
+    error.mockRestore();
+    log.mockRestore();
+    exit.mockRestore();
+  });
+
+  it('omits the checksum line when the container has no agent state and sha256 is empty', async () => {
+    const { filePath } = await writeContainer('no-agent-empty-checksum.savestate', '   ');
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const exit = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit:${code ?? ''}`);
+    }) as typeof process.exit);
+
+    await expect(
+      importState({
+        in: filePath,
+        passphrase: 'synthetic-passphrase',
+      }),
+    ).rejects.toThrow(/process\.exit:1/);
+
+    expect(error.mock.calls.flat().some((line) => typeof line === 'string' && line.includes('Checksum:'))).toBe(false);
+    expect(log.mock.calls.flat().some((line) => typeof line === 'string' && line.includes('Checksum:'))).toBe(false);
+    error.mockRestore();
+    log.mockRestore();
+    exit.mockRestore();
+  });
+
+  it('omits a checksum line when the file is not a SaveState container', async () => {
+    const filePath = join(testDir, 'not-a-container.bin');
+    await fs.writeFile(filePath, Buffer.from('not-a-savestate-file'));
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const exit = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit:${code ?? ''}`);
+    }) as typeof process.exit);
+
+    await expect(
+      importState({
+        in: filePath,
+        passphrase: 'synthetic-passphrase',
+      }),
+    ).rejects.toThrow(/process\.exit:1/);
+
+    expect(error.mock.calls.flat().some((line) => typeof line === 'string' && line.includes('Checksum:'))).toBe(false);
+    expect(log.mock.calls.flat().some((line) => typeof line === 'string' && line.includes('Checksum:'))).toBe(false);
+    error.mockRestore();
+    log.mockRestore();
+    exit.mockRestore();
+  });
+});

--- a/src/commands/container.ts
+++ b/src/commands/container.ts
@@ -1083,6 +1083,18 @@ export async function importState(options: RestoreOptions): Promise<ImportResult
       if (typedContentType) {
         console.error(formatImportContentType(typedContentType));
       }
+      const hashedPayload = Array.isArray(manifest.payloads)
+        ? manifest.payloads.find((p: { sha256?: unknown }) =>
+            typeof p?.sha256 === 'string' && p.sha256.trim() !== '',
+          )
+        : undefined;
+      const checksum =
+        hashedPayload && typeof hashedPayload.sha256 === 'string'
+          ? hashedPayload.sha256.trim()
+          : undefined;
+      if (checksum) {
+        console.error(formatImportChecksum(checksum));
+      }
       process.exit(1);
     }
     const contentType =


### PR DESCRIPTION
## Summary
- Print the manifest payload checksum on stderr when `savestate import` rejects a container that has no `agent_state` payload.
- Matches the existing wrong-pass and corrupted import output, and follows the no-agent content-type increment.

## Proof
Focused vitest (19 passed):
- `import-checksum-no-agent-output.test.ts`
- `import-checksum-corrupted-output.test.ts`
- `import-checksum-wrong-pass-output.test.ts`
- `import-content-type-no-agent-output.test.ts`
- `import-checksum-output.test.ts`

Plasmate: https://savestate.dev and https://savestate.dev/docs/cli.html