### PR TITLE
Print input path when the verify container has no agent state

### DIFF
--- a/src/commands/__tests__/verify-input-no-agent-output.test.ts
+++ b/src/commands/__tests__/verify-input-no-agent-output.test.ts
@@ -1,0 +1,85 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { formatVerifyInput, formatVerifyResult, verifyContainer } from '../verify.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate verify input no-agent output', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'savestate-verify-input-no-agent-'));
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(fileName: string): Promise<string> {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({
+      agentId: 'fixture-agent',
+      version: 1,
+      exportedAt: '2026-08-26T00:00:00.000Z',
+      memory: { facts: ['synthetic'] },
+      tools: { enabled: [] },
+    }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest: Record<string, unknown> = {
+      formatVersion: 1,
+      created: '2026-08-26T00:00:00.000Z',
+      agentId: 'fixture-agent',
+      payloads: [
+        {
+          name: 'other_payload',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: 'a'.repeat(64),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('formats the input path on its own line', () => {
+    expect(formatVerifyInput('/tmp/agent.savestate')).toBe('   Input: /tmp/agent.savestate');
+    expect(formatVerifyInput('/tmp/agent.savestate')).not.toContain('Agent:');
+  });
+
+  it('prints the input path when the container has no agent state', async () => {
+    const filePath = await writeContainer('no-agent-input.savestate');
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.message).toContain('missing agent_state');
+    expect(result.input).toBe(filePath);
+    expect(formatVerifyResult(result, false)).toContain(`   Input: ${filePath}`);
+  });
+
+  it('omits an input line when the file is not a SaveState container', async () => {
+    const filePath = join(testDir, 'not-a-container.bin');
+    await writeFile(filePath, Buffer.from('not-a-savestate-file'));
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('invalid_format');
+    expect(result.input).toBeUndefined();
+    expect(formatVerifyResult(result, false)).not.toContain('Input:');
+  });
+});

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -677,6 +677,7 @@ export async function verifyContainer(
     return {
       status: 'corrupted',
       message: 'Invalid manifest: missing agent_state payload or checksum',
+      input: filePath,
     };
   }
 


### PR DESCRIPTION
## Summary
- Print `Input:` when `savestate verify` finds a SaveState container with no `agent_state` payload.
- Omit the line when the file is not a SaveState container.

Closes #463

## Proof
Focused vitest: verify-input-no-agent, verify-input — 8 passed.

Plasmate: https://savestate.dev and https://savestate.dev/docs/cli.html