### PR TITLE
Print format version when the verify container has no agent state

### DIFF
--- a/src/commands/__tests__/verify-format-no-agent-output.test.ts
+++ b/src/commands/__tests__/verify-format-no-agent-output.test.ts
@@ -1,0 +1,86 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { formatVerifyFormatVersion, formatVerifyResult, verifyContainer } from '../verify.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate verify format version no-agent output', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'savestate-verify-format-no-agent-'));
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(fileName: string): Promise<string> {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({
+      agentId: 'fixture-agent',
+      version: 1,
+      exportedAt: '2026-08-26T00:00:00.000Z',
+      memory: { facts: ['synthetic'] },
+      tools: { enabled: [] },
+    }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest: Record<string, unknown> = {
+      formatVersion: 1,
+      created: '2026-08-26T00:00:00.000Z',
+      agentId: 'fixture-agent',
+      payloads: [
+        {
+          name: 'other_payload',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: 'a'.repeat(64),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('formats the format version on its own line', () => {
+    expect(formatVerifyFormatVersion(1)).toBe('   Format: v1');
+    expect(formatVerifyFormatVersion(1)).not.toContain('Agent:');
+  });
+
+  it('prints the format version when the container has no agent state', async () => {
+    const filePath = await writeContainer('no-agent-format.savestate');
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.message).toContain('missing agent_state');
+    expect(result.manifest?.formatVersion).toBe(1);
+    expect(formatVerifyResult(result, false)).toContain('   Format: v1');
+    expect(formatVerifyResult(result, false)).not.toContain('Agent:');
+  });
+
+  it('omits a format line when the file is not a SaveState container', async () => {
+    const filePath = join(testDir, 'not-a-container.bin');
+    await writeFile(filePath, Buffer.from('not-a-savestate-file'));
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('invalid_format');
+    expect(result.manifest).toBeUndefined();
+    expect(formatVerifyResult(result, false)).not.toContain('Format:');
+  });
+});

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -22,9 +22,9 @@ export interface VerifyResult {
   keyDerivation?: string;
   input?: string;
   manifest?: {
-    agentId: string;
-    created: string;
-    formatVersion: number;
+    agentId?: string;
+    created?: string;
+    formatVersion?: number;
     description?: string;
   };
   components?: string[];
@@ -674,9 +674,11 @@ export async function verifyContainer(
 
   const payload = manifest.payloads.find((p: any) => p.name === 'agent_state');
   if (!payload || !payload.sha256) {
+    const formatVersion = typeof manifest.formatVersion === 'number' ? manifest.formatVersion : undefined;
     return {
       status: 'corrupted',
       message: 'Invalid manifest: missing agent_state payload or checksum',
+      ...(formatVersion !== undefined ? { manifest: { formatVersion } } : {}),
     };
   }
 
@@ -841,9 +843,15 @@ export function formatVerifyResult(result: VerifyResult, json: boolean): string 
     case 'valid': {
       const lines = ['✅ State file is valid'];
       if (result.manifest) {
-        lines.push(formatVerifyAgent(result.manifest.agentId));
-        lines.push(formatVerifyCreated(result.manifest.created));
-        lines.push(formatVerifyFormatVersion(result.manifest.formatVersion));
+        if (result.manifest.agentId) {
+          lines.push(formatVerifyAgent(result.manifest.agentId));
+        }
+        if (result.manifest.created) {
+          lines.push(formatVerifyCreated(result.manifest.created));
+        }
+        if (result.manifest.formatVersion !== undefined) {
+          lines.push(formatVerifyFormatVersion(result.manifest.formatVersion));
+        }
         if (result.manifest.description) {
           lines.push(formatVerifyDescription(result.manifest.description));
         }
@@ -880,9 +888,15 @@ export function formatVerifyResult(result: VerifyResult, json: boolean): string 
     case 'wrong_password': {
       const lines = ['⚠️  Wrong password (cannot decrypt)'];
       if (result.manifest) {
-        lines.push(formatVerifyAgent(result.manifest.agentId));
-        lines.push(formatVerifyCreated(result.manifest.created));
-        lines.push(formatVerifyFormatVersion(result.manifest.formatVersion));
+        if (result.manifest.agentId) {
+          lines.push(formatVerifyAgent(result.manifest.agentId));
+        }
+        if (result.manifest.created) {
+          lines.push(formatVerifyCreated(result.manifest.created));
+        }
+        if (result.manifest.formatVersion !== undefined) {
+          lines.push(formatVerifyFormatVersion(result.manifest.formatVersion));
+        }
         if (result.manifest.description) {
           lines.push(formatVerifyDescription(result.manifest.description));
         }
@@ -921,9 +935,15 @@ export function formatVerifyResult(result: VerifyResult, json: boolean): string 
     case 'corrupted': {
       const lines = [`❌ File corrupted: ${result.message}`];
       if (result.manifest) {
-        lines.push(formatVerifyAgent(result.manifest.agentId));
-        lines.push(formatVerifyCreated(result.manifest.created));
-        lines.push(formatVerifyFormatVersion(result.manifest.formatVersion));
+        if (result.manifest.agentId) {
+          lines.push(formatVerifyAgent(result.manifest.agentId));
+        }
+        if (result.manifest.created) {
+          lines.push(formatVerifyCreated(result.manifest.created));
+        }
+        if (result.manifest.formatVersion !== undefined) {
+          lines.push(formatVerifyFormatVersion(result.manifest.formatVersion));
+        }
         if (result.manifest.description) {
           lines.push(formatVerifyDescription(result.manifest.description));
         }


### PR DESCRIPTION
## Summary
- Print `Format:` when `savestate verify` finds a SaveState container with no `agent_state` payload and the archive lists a format version.
- Omit the line when the file is not a SaveState container.

Closes #469

## Proof
Focused vitest: verify-format-no-agent, verify-format-version, verify-agent, verify-input — 21 passed.

Plasmate: https://savestate.dev and https://savestate.dev/docs/cli.html