### PR TITLE
Print payload name when the verify container has no agent state

### DIFF
--- a/src/commands/__tests__/verify-payload-name-no-agent-output.test.ts
+++ b/src/commands/__tests__/verify-payload-name-no-agent-output.test.ts
@@ -1,0 +1,85 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { formatVerifyPayloadName, formatVerifyResult, verifyContainer } from '../verify.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate verify payload name no-agent output', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'savestate-verify-payload-name-no-agent-'));
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(fileName: string): Promise<string> {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({
+      agentId: 'fixture-agent',
+      version: 1,
+      exportedAt: '2026-08-26T00:00:00.000Z',
+      memory: { facts: ['synthetic'] },
+      tools: { enabled: [] },
+    }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest: Record<string, unknown> = {
+      formatVersion: 1,
+      created: '2026-08-26T00:00:00.000Z',
+      agentId: 'fixture-agent',
+      payloads: [
+        {
+          name: 'other_payload',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: 'a'.repeat(64),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return filePath;
+  }
+
+  it('formats the payload name on its own line', () => {
+    expect(formatVerifyPayloadName('other_payload')).toBe('   Payload: other_payload');
+    expect(formatVerifyPayloadName('other_payload')).not.toContain('Agent:');
+  });
+
+  it('prints the payload name when the container has no agent state', async () => {
+    const filePath = await writeContainer('no-agent-payload-name.savestate');
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.message).toContain('missing agent_state');
+    expect(result.payloadName).toBe('other_payload');
+    expect(formatVerifyResult(result, false)).toContain('   Payload: other_payload');
+  });
+
+  it('omits a payload name line when the file is not a SaveState container', async () => {
+    const filePath = join(testDir, 'not-a-container.bin');
+    await writeFile(filePath, Buffer.from('not-a-savestate-file'));
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('invalid_format');
+    expect(result.payloadName).toBeUndefined();
+    expect(formatVerifyResult(result, false)).not.toContain('Payload:');
+  });
+});

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -676,10 +676,17 @@ export async function verifyContainer(
   if (!payload || !payload.sha256) {
     const agentId = typeof manifest.agentId === 'string' ? manifest.agentId.trim() : '';
     const formatVersion = typeof manifest.formatVersion === 'number' ? manifest.formatVersion : undefined;
+    const namedPayload = Array.isArray(manifest.payloads)
+      ? manifest.payloads.find((p: any) => p && typeof p.name === 'string' && p.name.trim() !== '')
+      : undefined;
+    const payloadName = namedPayload && typeof namedPayload.name === 'string'
+      ? namedPayload.name.trim()
+      : undefined;
     return {
       status: 'corrupted',
       message: 'Invalid manifest: missing agent_state payload or checksum',
       input: filePath,
+      ...(payloadName ? { payloadName } : {}),
       ...(excluded ? { excluded } : {}),
       ...((agentId || formatVersion !== undefined) ? {
         manifest: {


### PR DESCRIPTION
## Summary
- Print `Payload:` when `savestate verify` finds a SaveState container with no `agent_state` payload and the archive lists a payload name.
- Omit the line when the file is not a SaveState container.

## Proof
Focused vitest: verify-payload-name-no-agent, verify-payload-name, verify-excluded-no-agent, verify-agent-no-agent — 15 passed.

Plasmate: https://savestate.dev and https://savestate.dev/docs/