### PR TITLE
Print payload size when the verify container has no agent state

### DIFF
--- a/src/commands/__tests__/verify-size-no-agent-output.test.ts
+++ b/src/commands/__tests__/verify-size-no-agent-output.test.ts
@@ -1,0 +1,85 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { encrypt } from '../../container/crypto.js';
+import { formatVerifyResult, formatVerifySize, verifyContainer } from '../verify.js';
+
+function createMagicHeader(version = 1): Buffer {
+  const header = Buffer.alloc(16);
+  header.write('SAVESTAT', 0, 'ascii');
+  header.writeUInt8(version, 8);
+  return header;
+}
+
+describe('savestate verify size no-agent output', () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'savestate-verify-size-no-agent-'));
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeContainer(fileName: string): Promise<{ filePath: string; payloadBytes: number }> {
+    const passphrase = 'synthetic-verify-pass';
+    const plaintext = Buffer.from(JSON.stringify({
+      agentId: 'fixture-agent',
+      version: 1,
+      exportedAt: '2026-08-26T00:00:00.000Z',
+      memory: { facts: ['synthetic'] },
+      tools: { enabled: [] },
+    }));
+    const encryptedState = await encrypt(plaintext, { passphrase });
+    const manifest: Record<string, unknown> = {
+      formatVersion: 1,
+      created: '2026-08-26T00:00:00.000Z',
+      agentId: 'fixture-agent',
+      payloads: [
+        {
+          name: 'other_payload',
+          contentType: 'application/json',
+          byteLength: plaintext.length,
+          sha256: 'a'.repeat(64),
+        },
+      ],
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest));
+    const manifestLength = Buffer.alloc(4);
+    manifestLength.writeUInt32LE(manifestBuffer.length, 0);
+    const filePath = join(testDir, fileName);
+    await writeFile(
+      filePath,
+      Buffer.concat([createMagicHeader(1), manifestLength, manifestBuffer, encryptedState]),
+    );
+    return { filePath, payloadBytes: plaintext.length };
+  }
+
+  it('formats the size on its own line', () => {
+    expect(formatVerifySize(42)).toBe('   Size: 42 bytes');
+    expect(formatVerifySize(42)).not.toContain('Agent:');
+  });
+
+  it('prints the payload size when the container has no agent state', async () => {
+    const { filePath, payloadBytes } = await writeContainer('no-agent-size.savestate');
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('corrupted');
+    expect(result.message).toContain('missing agent_state');
+    expect(result.payloadBytes).toBe(payloadBytes);
+    expect(formatVerifyResult(result, false)).toContain(`   Size: ${payloadBytes} bytes`);
+  });
+
+  it('omits a size line when the file is not a SaveState container', async () => {
+    const filePath = join(testDir, 'not-a-container.bin');
+    await writeFile(filePath, Buffer.from('not-a-savestate-file'));
+
+    const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
+
+    expect(result.status).toBe('invalid_format');
+    expect(result.payloadBytes).toBeUndefined();
+    expect(formatVerifyResult(result, false)).not.toContain('Size:');
+  });
+});

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -676,10 +676,17 @@ export async function verifyContainer(
   if (!payload || !payload.sha256) {
     const agentId = typeof manifest.agentId === 'string' ? manifest.agentId.trim() : '';
     const formatVersion = typeof manifest.formatVersion === 'number' ? manifest.formatVersion : undefined;
+    const sizedPayload = Array.isArray(manifest.payloads)
+      ? manifest.payloads.find((p: any) => p && typeof p.byteLength === 'number')
+      : undefined;
+    const payloadBytes = sizedPayload && typeof sizedPayload.byteLength === 'number'
+      ? sizedPayload.byteLength
+      : undefined;
     return {
       status: 'corrupted',
       message: 'Invalid manifest: missing agent_state payload or checksum',
       input: filePath,
+      ...(payloadBytes !== undefined ? { payloadBytes } : {}),
       ...(excluded ? { excluded } : {}),
       ...((agentId || formatVersion !== undefined) ? {
         manifest: {


### PR DESCRIPTION
## Summary
- Print the payload size on `savestate verify` when the container decrypts but has no `agent_state` payload.
- Focused tests cover the size line, the no-agent case, and omitting size for non-containers.

## Proof
`npx vitest run src/commands/__tests__/verify-size-no-agent-output.test.ts` — 3 passed.

Plasmate: https://savestate.dev and https://savestate.dev/docs