### PR TITLE
Print created timestamp when the verify container has no agent state

### DIFF
--- a/src/commands/__tests__/verify-created-no-agent-output.test.ts
+++ b/src/commands/__tests__/verify-created-no-agent-output.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { encrypt } from '../../container/crypto.js';
-import { formatVerifyAgent, formatVerifyResult, verifyContainer } from '../verify.js';
+import { formatVerifyCreated, formatVerifyResult, verifyContainer } from '../verify.js';
 
 function createMagicHeader(version = 1): Buffer {
   const header = Buffer.alloc(16);
@@ -12,11 +12,11 @@ function createMagicHeader(version = 1): Buffer {
   return header;
 }
 
-describe('savestate verify agent no-agent output', () => {
+describe('savestate verify created no-agent output', () => {
   let testDir: string;
 
   beforeAll(async () => {
-    testDir = await mkdtemp(join(tmpdir(), 'savestate-verify-agent-no-agent-'));
+    testDir = await mkdtemp(join(tmpdir(), 'savestate-verify-created-no-agent-'));
   });
 
   afterAll(async () => {
@@ -57,22 +57,22 @@ describe('savestate verify agent no-agent output', () => {
     return filePath;
   }
 
-  it('formats the agent id on its own line', () => {
-    expect(formatVerifyAgent('fixture-agent')).toBe('   Agent: fixture-agent');
-    expect(formatVerifyAgent('fixture-agent')).not.toContain('Created:');
+  it('formats the created timestamp on its own line', () => {
+    expect(formatVerifyCreated('2026-08-26T00:00:00.000Z')).toBe('   Created: 2026-08-26T00:00:00.000Z');
+    expect(formatVerifyCreated('2026-08-26T00:00:00.000Z')).not.toContain('Agent:');
   });
 
-  it('prints the agent id when the container has no agent state', async () => {
-    const filePath = await writeContainer('no-agent-agent.savestate');
+  it('prints the created timestamp when the container has no agent state', async () => {
+    const filePath = await writeContainer('no-agent-created.savestate');
     const result = await verifyContainer(filePath, { passphrase: 'synthetic-verify-pass' });
 
     expect(result.status).toBe('corrupted');
     expect(result.message).toContain('missing agent_state');
-    expect(result.manifest?.agentId).toBe('fixture-agent');
-    expect(formatVerifyResult(result, false)).toContain('   Agent: fixture-agent');
+    expect(result.manifest?.created).toBe('2026-08-26T00:00:00.000Z');
+    expect(formatVerifyResult(result, false)).toContain('   Created: 2026-08-26T00:00:00.000Z');
   });
 
-  it('omits an agent line when the file is not a SaveState container', async () => {
+  it('omits a created line when the file is not a SaveState container', async () => {
     const filePath = join(testDir, 'not-a-container.bin');
     await writeFile(filePath, Buffer.from('not-a-savestate-file'));
 
@@ -80,6 +80,6 @@ describe('savestate verify agent no-agent output', () => {
 
     expect(result.status).toBe('invalid_format');
     expect(result.manifest).toBeUndefined();
-    expect(formatVerifyResult(result, false)).not.toContain('Agent:');
+    expect(formatVerifyResult(result, false)).not.toContain('Created:');
   });
 });

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -675,6 +675,7 @@ export async function verifyContainer(
     const payload = manifest.payloads.find((p: any) => p.name === 'agent_state');
   if (!payload || !payload.sha256) {
     const agentId = typeof manifest.agentId === 'string' ? manifest.agentId.trim() : '';
+    const created = typeof manifest.created === 'string' ? manifest.created.trim() : '';
     const formatVersion = typeof manifest.formatVersion === 'number' ? manifest.formatVersion : undefined;
     const sizedPayload = Array.isArray(manifest.payloads)
       ? manifest.payloads.find((p: any) => p && typeof p.byteLength === 'number')
@@ -690,9 +691,10 @@ export async function verifyContainer(
       keyDerivation: resolveKeyDerivation(manifest),
       ...(payloadBytes !== undefined ? { payloadBytes } : {}),
       ...(excluded ? { excluded } : {}),
-      ...((agentId || formatVersion !== undefined) ? {
+      ...((agentId || created || formatVersion !== undefined) ? {
         manifest: {
           ...(agentId ? { agentId } : {}),
+          ...(created ? { created } : {}),
           ...(formatVersion !== undefined ? { formatVersion } : {}),
         },
       } : {}),


### PR DESCRIPTION
## Summary
- Print the manifest created timestamp when `savestate verify` finds a container with no `agent_state` payload.
- Keep existing agent/format no-agent output; add a focused created-no-agent test.

## Focused proof
`npx vitest run` on created/agent/format no-agent plus created-output tests: 14 passed.

Plasmate: https://savestate.dev and https://savestate.dev/docs/